### PR TITLE
Add links to markdown-generated headers

### DIFF
--- a/app/assets/stylesheets/general/_titles.scss
+++ b/app/assets/stylesheets/general/_titles.scss
@@ -47,7 +47,12 @@ h6 {
   font-size: $font-size-base;
 }
 
-:is(h1, h2, h3, h4, h5, h6) .header_anchor {
+h1 .header_anchor,
+h2 .header_anchor,
+h3 .header_anchor,
+h4 .header_anchor,
+h5 .header_anchor,
+h6 .header_anchor {
   text-decoration: none;
 }
 

--- a/app/assets/stylesheets/general/_titles.scss
+++ b/app/assets/stylesheets/general/_titles.scss
@@ -47,15 +47,11 @@ h6 {
   font-size: $font-size-base;
 }
 
-h1 .header_anchor,
-h2 .header_anchor,
-h3 .header_anchor,
-h4 .header_anchor,
-h5 .header_anchor,
-h6 .header_anchor {
-  text-decoration: none;
+h1, h2, h3, h4, h5, h6 {
+  .header_anchor {
+    text-decoration: none;
+  }
 }
-
 .title-icon {
   display: inline-block;
   height: .75em;

--- a/app/assets/stylesheets/general/_titles.scss
+++ b/app/assets/stylesheets/general/_titles.scss
@@ -47,6 +47,10 @@ h6 {
   font-size: $font-size-base;
 }
 
+:is(h1, h2, h3, h4, h5, h6) .header_anchor {
+  text-decoration: none;
+}
+
 .title-icon {
   display: inline-block;
   height: .75em;

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -44,18 +44,23 @@ module ContentHelper
       tag = "h#{ level }"
       hash = header_anchor_hash(title)
 
-      "<#{ tag } id=\"#{ hash }\"><a class=\"header_anchor\" href=\"\##{ hash }\">#{ title }</a></#{ tag }>"
+      if @options[:header_anchors]
+        "<#{ tag } id=\"#{ hash }\"><a class=\"header_anchor\" href=\"\##{ hash }\">#{ title }</a></#{ tag }>"
+      else
+        "<#{ tag }>#{ title }</#{ tag }>"
+      end
     end
   end
 
-  def markdown(text)
-    options = {
+  def markdown(text, rendererOptions: {})
+    finalRendererOptions = {
       space_after_headers: true,
+      header_anchors: false,
       hard_wrap: true,
       link_attributes: { rel: "noreferrer noopener", target: "_blank" }
-    }
+    }.merge(rendererOptions)
 
-    renderer = HTML.new(options)
+    renderer = HTML.new(finalRendererOptions)
     markdown = Redcarpet::Markdown.new(renderer,
       disable_indented_code_blocks: true,
       highlight: true,
@@ -134,8 +139,12 @@ module ContentHelper
     "heroes/50/#{ hero.downcase.gsub(":", "").gsub(" ", "").gsub(".", "").gsub("ú", "u").gsub("ö", "o") }.png"
   end
 
-  def sanitized_markdown(text)
-    ActionController::Base.helpers.sanitize(markdown(text), tags: %w(div span hr style mark dl dd dt img details summary a b iframe audio source blockquote pre code br p table td tr th thead tbody ul ol li h1 h2 h3 h4 h5 h6 em i strong), attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls))
+  def sanitized_markdown(text, rendererOptions: {})
+    ActionController::Base.helpers.sanitize(
+      markdown(text, rendererOptions: rendererOptions),
+      tags: %w(div span hr style mark dl dd dt img details summary a b iframe audio source blockquote pre code br p table td tr th thead tbody ul ol li h1 h2 h3 h4 h5 h6 em i strong),
+      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls)
+    )
   end
 
   def youtube_to_video_id(url)

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -9,6 +9,43 @@ module ContentHelper
     def image(link, title, alt_text)
       image_tag(link, title: title, alt: alt_text, loading: "lazy")
     end
+
+    # losely based on https://github.com/vmg/redcarpet/blob/3e3f0b522fbe9283ba450334b5cec7a439dc0955/ext/redcarpet/html.c#L297
+    def header_anchor_hash(title)
+      result = ""
+      i = 0
+      while i < title.length do
+        # skip html tags
+        if title[i] == "<"
+          while title[i] != ">" && i < title.length
+            i += 1
+          end
+        end
+
+        # skip html entities
+        if title[i] == "&"
+          while title[i] != ";" && i < title.length
+            i += 1
+          end
+        end
+
+        result += title[i]
+        i += 1
+      end
+
+      result
+        .downcase
+        .gsub(/[^a-z0-9\- ]/i, "")
+        .strip
+        .gsub(/ +/, "-")
+    end
+
+    def header(title, level)
+      tag = "h#{ level }"
+      hash = header_anchor_hash(title)
+
+      "<#{ tag } id=\"#{ hash }\"><a class=\"header_anchor\" href=\"\##{ hash }\">#{ title }</#{ tag }>"
+    end
   end
 
   def markdown(text)

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -44,7 +44,7 @@ module ContentHelper
       tag = "h#{ level }"
       hash = header_anchor_hash(title)
 
-      "<#{ tag } id=\"#{ hash }\"><a class=\"header_anchor\" href=\"\##{ hash }\">#{ title }</#{ tag }>"
+      "<#{ tag } id=\"#{ hash }\"><a class=\"header_anchor\" href=\"\##{ hash }\">#{ title }</a></#{ tag }>"
     end
   end
 

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -10,7 +10,7 @@ module ContentHelper
       image_tag(link, title: title, alt: alt_text, loading: "lazy")
     end
 
-    # losely based on https://github.com/vmg/redcarpet/blob/3e3f0b522fbe9283ba450334b5cec7a439dc0955/ext/redcarpet/html.c#L297
+    # loosely based on https://github.com/vmg/redcarpet/blob/3e3f0b522fbe9283ba450334b5cec7a439dc0955/ext/redcarpet/html.c#L297
     def header_anchor_hash(title)
       result = ""
       i = 0

--- a/app/views/wiki/articles/show.html.erb
+++ b/app/views/wiki/articles/show.html.erb
@@ -16,7 +16,7 @@
 
 
     <div class="article__content">
-      <%= sanitized_markdown(@article.content || "_This article does not yet have a description_") %>
+      <%= sanitized_markdown(@article.content || "_This article does not yet have a description_", rendererOptions: { header_anchors: true }) %>
     </div>
   </main>
 


### PR DESCRIPTION
Headers rendered with `ContentHelper:markdown` now get an id derived from the content of the header, and a nested link to change the hash of the page to that id, so users can quickly jump to sections of a markdown document.

I checked on the default renderer from Redcarpet. While it does have a similar option, it is only active when using Table of Contents, which we don't always want.

As part of this change, I had add a style rule and used :is() for simplicity. :is() seems to have [good browser support](https://caniuse.com/?search=%3Ais), though I'm not sure which browser we want to support here.