### PR TITLE
Convert search result items on editor wiki search from buttons to links

### DIFF
--- a/app/assets/stylesheets/editor/_editor-wiki.scss
+++ b/app/assets/stylesheets/editor/_editor-wiki.scss
@@ -28,7 +28,7 @@
   color: $text-color;
   font-family: $font-stack;
   text-align: left;
-  cursor: pointer;
+  text-decoration: none;
 
   &:hover,
   &:focus {

--- a/app/javascript/src/components/editor/EditorWikiSearch.svelte
+++ b/app/javascript/src/components/editor/EditorWikiSearch.svelte
@@ -67,10 +67,7 @@
           class="editor-wiki-results__item"
           href={`/wiki/articles/${result.slug}`}
           target="_blank"
-          on:click={(event) => {
-            event.preventDefault();
-            selectResult(result);
-          }}
+          on:click|preventDefault={() => selectResult(result)}
         >
           {result.title}
           <small>{result.category.title}</small>

--- a/app/javascript/src/components/editor/EditorWikiSearch.svelte
+++ b/app/javascript/src/components/editor/EditorWikiSearch.svelte
@@ -63,10 +63,18 @@
   {#if loading || results.length}
     <div class="editor-wiki-results">
       {#each results as result}
-        <button class="editor-wiki-results__item" on:click={() => selectResult(result)}>
+        <a
+          class="editor-wiki-results__item"
+          href={`/wiki/articles/${result.slug}`}
+          target="_blank"
+          on:click={(event) => {
+            event.preventDefault();
+            selectResult(result);
+          }}
+        >
           {result.title}
           <small>{result.category.title}</small>
-        </button>
+        </a>
       {/each}
 
       {#if loading}

--- a/app/javascript/src/components/editor/EditorWikiSearch.svelte
+++ b/app/javascript/src/components/editor/EditorWikiSearch.svelte
@@ -65,7 +65,7 @@
       {#each results as result}
         <a
           class="editor-wiki-results__item"
-          href={`/wiki/articles/${result.slug}`}
+          href={`/wiki/articles/${ result.slug }`}
           target="_blank"
           on:click|preventDefault={() => selectResult(result)}
         >


### PR DESCRIPTION
While the inline wiki is pretty useful, sometimes you want to open multiple browser tabs and have different wikis open, and the search can help with that.

With this change, search result items now behave like normal `<a>`s, meaning you can middle click to open the article on a new tab, or use the browser's context menu for links.