### PR TITLE
feat: Atomically update post and derivatives

### DIFF
--- a/app/assets/stylesheets/general/_form.scss
+++ b/app/assets/stylesheets/general/_form.scss
@@ -268,8 +268,13 @@ input[type="file"] {
   display: inline;
 
   input,
-  select {
+  select,
+  .form-input {
     border: 1px solid $red;
+
+    &.helper-input {
+      border: unset;
+    }
   }
 }
 

--- a/app/javascript/src/components/form/Derivatives.svelte
+++ b/app/javascript/src/components/form/Derivatives.svelte
@@ -67,7 +67,8 @@
       </div>
 
       <Tags
-        name="derivatives"
+        prefix="post"
+        name="derivations"
         placeholder="CODE1,CODE2,etc."
         fillValues={ currentSources }
         hidden={ !showDerivative }

--- a/app/javascript/src/components/form/Tags.svelte
+++ b/app/javascript/src/components/form/Tags.svelte
@@ -184,7 +184,7 @@
     on:keydown={ keydown }
     { readOnly }
     { placeholder }
-    class="form-tags__input" />
+    class="form-tags__input helper-input" />
 
   <input
     id="{prefix}_{ name }"

--- a/app/javascript/src/components/form/Tags.svelte
+++ b/app/javascript/src/components/form/Tags.svelte
@@ -4,6 +4,7 @@
   import { onMount } from "svelte"
   import { flip } from "svelte/animate"
 
+  export let prefix = ""
   export let name = "tags"
   export let placeholder = "Insert tags here"
   export let delimiter = ","
@@ -47,7 +48,7 @@
     if (event.key == "Backspace" || event.key == "Delete") {
       if (input == "") removeTag(values.length - 1)
     }
-    
+
     if (event.key == "Enter") {
       event.preventDefault()
       return false
@@ -108,7 +109,7 @@
     values = [...values.slice(0, index), ...values.slice(index + 1)]
     placeholder = storePlaceholder
     inputElem.focus()
-    
+
     readOnly = false
   }
 
@@ -186,8 +187,8 @@
     class="form-tags__input" />
 
   <input
-    id="post_{ name }"
-    name="post[{ name }]"
+    id="{prefix}_{ name }"
+    name="{prefix}[{ name }]"
     value={ hidden ? null : values }
     type="hidden" />
 </div>

--- a/app/views/posts/validation.js.erb
+++ b/app/views/posts/validation.js.erb
@@ -10,7 +10,7 @@
 
     let elements;
     <% @post.errors.each do |error| %>
-      elements = document.querySelectorAll("[name*='post[<%= error.attribute %>']")
+      elements = document.querySelectorAll("[name*='post[<%= error.attribute %>]']")
       elements.forEach(element => {
         const formGroup = element.closest("[class^='form-group']")
         formGroup.classList.add("field_with_errors")

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -48,6 +48,7 @@ default: &default
     - .jpeg
     - .jpg
     - .webp
+    - .svelte
 
 development:
   <<: *default

--- a/spec/features/post_derivations_validation_spec.rb
+++ b/spec/features/post_derivations_validation_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "./spec/support/user_helpers"
+require "./spec/support/post_helpers"
+
+RSpec.configure do |c|
+  c.include Helpers::Users
+  c.include Helpers::Posts
+end
+
+RSpec.feature "Post Derivation Validation", type: :feature do
+  include Capybara::DSL
+
+  let!(:user) { create(:user, password: "password123") }
+  let!(:post) { create(:post, user_id: user.id) }
+
+  before(:each) do
+    sign_in_as(user, "password123")
+  end
+
+  context "while creating a post", js: true do
+    before(:each) do
+      visit new_post_path
+      @post_attrs = fill_in_post_form
+      # Toggle post derivatives on
+      page.find("[data-svelte-component='DerivativesForm'] label[for='show_derivative']").click
+    end
+
+    it "does not allow too many codes" do
+      ["AJERA", "NNKWC", "1DMTZ", "TXCXX", "HHHPHB"].each do |code|
+        add_code_as_source code
+      end
+      expect(find("[data-svelte-component='DerivativesForm'] input[type='text']").readonly?).to be true
+    end
+
+    it "does not allow using the same code as the post" do
+      add_code_as_source @post_attrs[:code]
+      click_on "Save"
+      expect(page).not_to have_content "Post successfully created"
+      expect(page).to have_content "Cannot derive from the same import code"
+    end
+  end
+end
+
+def add_code_as_source(code)
+  page.find("[data-svelte-component='DerivativesForm'] input[type='text']").fill_in(with: "#{code},")
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/rspec"
 require "capybara/rails"
+require File.expand_path('./support/webpack.rb', __dir__)
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/post_helpers.rb
+++ b/spec/support/post_helpers.rb
@@ -1,5 +1,8 @@
 module Helpers
   module Posts
+    # Assumes session has been navigated to a post create or edit form, and attempts to fill out the form with mock data.
+    #
+    # @return attributes used to fill out post form
     def fill_in_post_form
       post_attrs = attributes_for(:post)
 
@@ -30,6 +33,8 @@ module Helpers
 
       # Return to default tab
       click_on "Description"
+
+      post_attrs
     end
   end
 end

--- a/spec/support/webpack.rb
+++ b/spec/support/webpack.rb
@@ -1,0 +1,51 @@
+
+module WebpackTestBuild
+  TS_FILE = Rails.root.join("tmp", "webpack-spec-timestamp")
+  class << self
+    attr_accessor :already_built
+  end
+
+  def self.run_webpack
+    puts "running webpack-test"
+    unless Webpacker.compile
+      raise "Error: webpacker failed to build. Run 'bin/webpack', fix any issues, and try again."
+    end
+    puts "webpack-test compile complete"
+    self.already_built = true
+    File.open(TS_FILE, "w") { |f| f.write(Time.now.utc.to_i) }
+  end
+
+  def self.run_webpack_if_necessary
+    return if self.already_built
+
+    if timestamp_outdated?
+      run_webpack
+    end
+  end
+
+  def self.timestamp_outdated?
+    return true if !File.exists?(TS_FILE)
+
+    current = current_bundle_timestamp(TS_FILE)
+
+    return true if !current
+
+    expected = Dir[Rails.root.join("app", "javascript", "**", "*")].map do |f|
+      File.mtime(f).utc.to_i
+    end.max
+
+    return current < expected
+  end
+
+  def self.current_bundle_timestamp(file)
+    return File.read(file).to_i
+  rescue StandardError
+    nil
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:each, :js) do
+    WebpackTestBuild.run_webpack_if_necessary
+  end
+end


### PR DESCRIPTION
This PR creates a better UX for situations where a derivative may be invalid (e.g. when a derivative has the same import code as the post itself). Previously, the post creation would partially succeed, but the invalid record would cause an invisible error, which would potentially fail future attemps to save.

Now, if any part of the post form causes an error, the entire operation will atomically fail, meaning that a partial success save is no longer possible. In addition, a proper error is returned identifying which derivation caused the issue and for what reason.

![image](https://user-images.githubusercontent.com/10406383/222993422-5d9378d5-b370-4d9d-81ba-7b1b3b0856a3.png)
