### PR TITLE
Change Preview button to "Edit" when previewing in the markdown editor

### DIFF
--- a/app/assets/stylesheets/logged_in_user/_inscryb-mde.scss
+++ b/app/assets/stylesheets/logged_in_user/_inscryb-mde.scss
@@ -226,6 +226,17 @@
 
   &.active {
     filter: brightness(1.15);
+
+    .fa-eye::before {
+      visibility: hidden;
+    }
+    .fa-eye::after {
+      position: absolute;
+      left: 0;
+      width: 100%;
+      text-align: center;
+      content: "Edit";
+    }
   }
 
   .fa-eye {


### PR DESCRIPTION
This is a hack on top of a hack to get the Preview button to say "Preview" in the first place.

Instead of simply setting the ::before content of `.fd-eye` to "Edit", I make the ::before invisible and use "Edit" on the ::after content. This is so the button preserves its width, and the other buttons don't shift around.

![preview → edit](https://user-images.githubusercontent.com/6181929/224841888-097f8255-dff9-4a84-a2e4-2ed5a1e13ced.gif)
