### PR TITLE
Set custom CSS with `.textContent` instead of `.innerHTML`

### DIFF
--- a/app/javascript/src/apply-custom-css.js
+++ b/app/javascript/src/apply-custom-css.js
@@ -8,5 +8,5 @@ function applyCustomCSS(event) {
   const value = this.value
   const styleTag = document.querySelector("#custom-css")
 
-  styleTag.innerHTML = value
+  styleTag.textContent = value
 }


### PR DESCRIPTION
Even if you have a sanitizer in the middle, sanitizers tend to be bypassable.