### PR TITLE
Add upper Y bound to April Fools 2023 Impetus

### DIFF
--- a/app/javascript/src/april-fools.js
+++ b/app/javascript/src/april-fools.js
@@ -25,6 +25,7 @@ async function hiimpetus(event) {
     source: element,
     friction: 0.96,
     boundX: [(window.innerWidth - element.offsetWidth - 100) * -0.5, (window.innerWidth - element.offsetWidth - 100) * 0.5],
+    boundY: [-element.offsetHeight, Infinity],
     update: function(x, y) {
       element.style.transform = `translateX(${ x }px) translateY(${ y }px)`
       element.dataset.x = x


### PR DESCRIPTION
It was possible for the element to go too far up, and not be recoverable. This PR adds an upper bound (but leaves the lower bound at Infinity) so we don't have to worry about that.