### PR TITLE
Remove z-index property from DragHandle in Editor

### DIFF
--- a/app/assets/stylesheets/editor/_editor.scss
+++ b/app/assets/stylesheets/editor/_editor.scss
@@ -116,7 +116,6 @@ $top-height: 4rem;
   top: 0;
   right: 0;
   transform: translateX(50%);
-  z-index: 20;
   opacity: 0;
   cursor: ew-resize;
 


### PR DESCRIPTION
This made the handle go over dropdowns like the project select.