### PR TITLE
Add simple VSCode Chrome launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch Chrome against localhost:3000",
+			"url": "http://localhost:3000",
+			"webRoot": "${workspaceFolder}/app"
+		}
+	]
+}


### PR DESCRIPTION
The launch task only opens the browser on localhost:3000. It does not start the webpack nor rails server.

The benefit of this is that the launched profile is persistant and isolated from your browser profiles. So you can install extensions specific to your workflow (e.g. Svelte DevTools, Rails Panel) and they won't clutter your normal browser experience.

---

This is a pattern I've been using recently, but I understand if it a little niche (even more than #260).

It might be worth to also include launch tasks for webpack and rails, but so far I'm okay with running the commands on the terminal and I didn't feel like debugging launch tasks.