### PR TITLE
Make Editor Workshop.codes logo take you to the home page, add icon to still go to the Editor Welcome page

### DIFF
--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -17,8 +17,8 @@
   import ItemFinder from "./ItemFinder.svelte"
   import FindReplaceAll from "./FindReplaceAll.svelte"
   import LineFinder from "./LineFinder.svelte"
+  import Info from "../icon/Info.svelte"
   import * as logo from "../../../../assets/images/logo.svg"
-  import Info from '../icon/Info.svelte';
 
   export let events
   export let values

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -18,6 +18,7 @@
   import FindReplaceAll from "./FindReplaceAll.svelte"
   import LineFinder from "./LineFinder.svelte"
   import * as logo from "../../../../assets/images/logo.svg"
+  import Info from '../icon/Info.svelte';
 
   export let events
   export let values
@@ -115,9 +116,14 @@
 <div class="editor">
   <div class="editor__top">
     <img on:click={() => {
+      window.location.pathname = "/"
+    }} class="mr-1/4 cursor-pointer" src={logo} height=50 alt="Workshop.codes" />
+    <span on:click={() => {
       $currentProjectUUID = null
       setOpenProjectInUrl(null, false)
-    }} class="mr-1/4 cursor-pointer" src={logo} height=50 alt="Workshop.codes" />
+    }} class="mr-1/4 cursor-pointer">
+      <Info />
+    </span>
 
     {#if $projects}
       <ProjectsDropdown />

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from "svelte"
   import { currentItem, currentProject, currentProjectUUID, items, sortedItems, projects, isSignedIn, completionsMap } from "../../stores/editor"
+  import { setOpenProjectInUrl } from "../../utils/routing"
   import EditorAside from "./EditorAside.svelte"
   import EditorWiki from "./EditorWiki.svelte"
   import CodeMirror from "./CodeMirror.svelte"
@@ -113,7 +114,10 @@
 
 <div class="editor">
   <div class="editor__top">
-    <img on:click={() => $currentProjectUUID = null} class="mr-1/2 cursor-pointer" src={logo} height=50 alt="Workshop.codes" />
+    <img on:click={() => {
+      $currentProjectUUID = null
+      setOpenProjectInUrl(null, false)
+    }} class="mr-1/4 cursor-pointer" src={logo} height=50 alt="Workshop.codes" />
 
     {#if $projects}
       <ProjectsDropdown />

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -6,6 +6,7 @@
   import { fly, fade } from "svelte/transition"
   import { onMount } from "svelte"
   import { updateProject } from "../../utils/editor"
+  import { setOpenProjectInUrl } from "../../utils/routing"
 
   let value
   let loading = false
@@ -33,7 +34,7 @@
 
         const parsedData = JSON.parse(data)
 
-        setUrl(parsedData.uuid)
+        setOpenProjectInUrl(parsedData.uuid, true)
         updateProject(parsedData.uuid, {
           uuid: parsedData.uuid,
           title: parsedData.title,
@@ -74,7 +75,7 @@
 
         const parsedData = JSON.parse(data)
 
-        setUrl(parsedData.uuid)
+        setOpenProjectInUrl(parsedData.uuid, true)
 
         $projects = [...$projects, parsedData]
         $currentProjectUUID = parsedData.uuid
@@ -145,7 +146,7 @@
       .then(data => {
         if (!data) throw Error("Create failed")
 
-        setUrl()
+        setOpenProjectInUrl(null, true)
 
         $projects = $projects.filter(p => p.uuid != $currentProjectUUID)
         $currentProjectUUID = null
@@ -164,13 +165,6 @@
 
     active = false
     showProjectSettings = false
-  }
-
-  function setUrl(uuid) {
-    const url = new URL(window.location)
-    if (uuid) url.searchParams.set("uuid", uuid)
-    else url.searchParams.delete("uuid")
-    window.history.replaceState("", "", url)
   }
 </script>
 

--- a/app/javascript/src/components/icon/Info.svelte
+++ b/app/javascript/src/components/icon/Info.svelte
@@ -1,0 +1,10 @@
+<style>
+svg {
+  height: 1.15rem;
+  width: auto;
+  fill: var(--white);
+}
+</style>
+
+<!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg>

--- a/app/javascript/src/utils/routing.js
+++ b/app/javascript/src/utils/routing.js
@@ -1,0 +1,14 @@
+export function setOpenProjectInUrl(uuid, replaceState = false) {
+  const url = new URL(window.location.href)
+  if (uuid) {
+    url.searchParams.set("uuid", uuid)
+  } else {
+    url.searchParams.delete("uuid")
+  }
+
+  if (replaceState) {
+    window.history.replaceState(window.history.state, "", url)
+  } else {
+    window.history.pushState(window.history.state, "", url)
+  }
+}


### PR DESCRIPTION
- The workshop.codes logo now takes you to https://workshop.codes/
- The new Info icon keeps the old behavior of the logo
![image](https://user-images.githubusercontent.com/6181929/231603368-ea8d2d3c-e509-41b8-9df3-eb31d50fc839.png)

I'm not too happy with the info icon (I quickly took it from fontawesome.com, suggestions are welcome here).

---

Also: make the new icon that takes you to the Editor Welcome page replace the URL (`/editor?uuid=...` → `/editor`). This is done in a way that users can use the browser's back navigation button to take them back to the project you were working on. See commits for details.