### PR TITLE
feat: Add search to ProjectsDropdown

### DIFF
--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -192,10 +192,6 @@
     <div transition:fly={{ duration: 150, y: 20 }} class="dropdown__content dropdown__content--left block w-100">
       <div class="pl-1/8 pr-1/8">
         <SearchObjects objects={$projects} bind:filteredObjects={filteredProjects} />
-
-        {#if $projects?.length && !filteredProjects.length}
-          <em>No projects match your filter.</em>
-        {/if}
       </div>
 
       <hr />
@@ -205,6 +201,10 @@
           {project.title}
         </div>
       {/each}
+
+      {#if $projects?.length && !filteredProjects.length}
+        <em class="block text-dark text-small pl-1/8 pr-1/8">No projects match your filter.</em>
+      {/if}
 
       {#if $projects?.length}
         <hr />

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -1,11 +1,13 @@
 <script>
   import FetchRails from "../../fetch-rails"
+  import SearchObjects from "./SearchObjects.svelte"
   import { projects, currentProjectUUID, currentProject, items, currentItem, isSignedIn } from "../../stores/editor"
   import { translationKeys, defaultLanguage, selectedLanguages } from "../../stores/translationKeys"
   import { addAlert } from "../../lib/alerts"
-  import { fly, fade } from "svelte/transition"
-  import { onMount } from "svelte"
   import { updateProject } from "../../utils/editor"
+  import { onMount } from "svelte"
+  import { fly, fade } from "svelte/transition"
+  import { flip } from "svelte/animate"
 
   let value
   let loading = false
@@ -13,6 +15,7 @@
   let showModal = false
   let modalType = "create"
   let showProjectSettings = false
+  let filteredProjects = $projects
 
   onMount(() => {
     const urlParams = new URLSearchParams(window.location.search)
@@ -160,7 +163,7 @@
 
   function outsideClick(event) {
     if (!active && !showProjectSettings) return
-    if (event.target.classList.contains("dropdown")) return
+    if (event.target.classList.contains("dropdown") || event.target.closest(".dropdown")) return
 
     active = false
     showProjectSettings = false
@@ -187,8 +190,18 @@
 
   {#if active}
     <div transition:fly={{ duration: 150, y: 20 }} class="dropdown__content dropdown__content--left block w-100">
-      {#each $projects as project (project.uuid)}
-        <div class="dropdown__item" on:click={() => fetchProject(project.uuid)}>
+      <div class="pl-1/8 pr-1/8">
+        <SearchObjects objects={$projects} bind:filteredObjects={filteredProjects} />
+
+        {#if $projects?.length && !filteredProjects.length}
+          <em>No projects match your filter.</em>
+        {/if}
+      </div>
+
+      <hr />
+
+      {#each filteredProjects as project (project.uuid)}
+        <div class="dropdown__item" animate:flip={{ duration: 100 }} on:click={() => fetchProject(project.uuid)}>
           {project.title}
         </div>
       {/each}

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -205,7 +205,7 @@
       {/each}
 
       {#if $projects?.length && !filteredProjects.length}
-        <em class="block text-dark text-small pl-1/8 pr-1/8">No projects match your filter.</em>
+        <em class="block text-dark text-small pl-1/8 pr-1/8">No projects match your search.</em>
       {/if}
 
       {#if $projects?.length}

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -17,6 +17,8 @@
   let showProjectSettings = false
   let filteredProjects = $projects
 
+  $: if (showModal) active = false
+
   onMount(() => {
     const urlParams = new URLSearchParams(window.location.search)
     const uuid = urlParams.get("uuid")

--- a/app/javascript/src/components/editor/SearchObjects.svelte
+++ b/app/javascript/src/components/editor/SearchObjects.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let objects = []
+  export let key = "title"
+  export let placeholder = "Search..."
+  export let filteredObjects = objects
+
+  let query = ""
+
+  $: if (objects) search(query)
+
+  function search() {
+    if (query) filteredObjects = objects.filter(o => o[key].toLowerCase().indexOf(query.toLowerCase()) !== -1)
+    else filteredObjects = objects
+
+  }
+</script>
+
+<input type="text" class="form-input bg-darker" {placeholder} bind:value={query} />


### PR DESCRIPTION
This PR adds a search box to the ProjectsDropdown component. This allows you to filter the dropdown contents by their title. The search component is fairly generic, allowing it to be used for any other array of objects for any key. The results can be retrieved via a two way bind.

## Filter
![search-flip](https://user-images.githubusercontent.com/12848235/231610464-6cde5bdb-119c-4208-ad6e-e9ca5363472b.gif)

## Empty
![image](https://user-images.githubusercontent.com/12848235/231610795-ccb48e8f-2531-4967-be42-82267318d77f.png)

