### PR TITLE
feat: Duplicate Project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,6 +12,7 @@ class ProjectsController < ApplicationController
 
   def create
     @project = Project.create(title: project_params[:title], content_type: project_params[:content_type], user_id: current_user.id)
+    @project.content = project_params[:content] if project_params[:content].present?
     @project.is_owner = current_user.id == @project.user_id
 
     if @project.save

--- a/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
+++ b/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
@@ -1,0 +1,94 @@
+<script>
+  import { currentProject, isSignedIn } from "../../../stores/editor"
+  import { createProject, renameCurrentProject } from "../../../utils/project"
+  import { createEventDispatcher } from "svelte"
+  import { fade, fly } from "svelte/transition"
+
+  const dispatch = createEventDispatcher()
+
+  let loading
+  let value
+  let active = false
+  let modalType = "create"
+
+  export function showModalOfType(type, title = "") {
+    modalType = type
+    value = title
+    active = true
+  }
+
+  async function newProject() {
+    loading = true
+
+    const data = await createProject(value)
+    if (data) {
+      dispatch("setUrl", data.uuid)
+      active = false
+    }
+
+    loading = false
+  }
+
+  async function renameProject() {
+    if (!$isSignedIn) {
+      alert("You must be signed in to rename a project")
+      active = false
+      return
+    } else if (!$currentProject) {
+      alert("No project selected? This is probably a bug.")
+      active = false
+      return
+    }
+
+    loading = true
+
+    const data = await renameCurrentProject(value)
+    if (data) active = false
+
+    loading = false
+  }
+</script>
+
+{#if active}
+  <div class="modal modal--top" transition:fade={{ duration: 100 }} data-ignore>
+    <div class="modal__content p-0" transition:fly={{ y: 100, duration: 200 }}>
+      {#if !$isSignedIn}
+        <div class="warning warning--orange">
+          You are not signed in and this is for demonstration purposes only. This will not be saved.
+        </div>
+      {/if}
+
+      {#if modalType == "create"}
+        <div class="p-1/2">
+          <h3 class="mb-0 mt-0">Create a new project</h3>
+
+          <input type="text" class="form-input mt-1/4" placeholder="Project title" bind:value />
+
+          <button class="button w-100 mt-1/4" on:click={newProject} disabled={!value || loading}>
+            {#if loading}
+              ...
+            {:else}
+              Create
+            {/if}
+          </button>
+        </div>
+      {:else if modalType == "rename"}
+        <div class="p-1/2">
+          <h3 class="mb-0 mt-0">Rename {$currentProject?.title || "this project"}</h3>
+
+          <input type="text" class="form-input mt-1/4" placeholder="Project title" bind:value />
+
+          <button class="button w-100 mt-1/4" on:click={renameProject} disabled={!value || loading}>
+            {#if loading}
+              ...
+            {:else}
+              Rename
+            {/if}
+          </button>
+        </div>
+      {/if}
+    </div>
+
+    <div class="modal__backdrop" on:click={() => active = false} />
+  </div>
+{/if}

--- a/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
+++ b/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
@@ -54,7 +54,7 @@
     <div class="modal__content p-0" transition:fly={{ y: 100, duration: 200 }}>
       {#if !$isSignedIn}
         <div class="warning warning--orange">
-          You are not signed in and this is for demonstration purposes only. This will not be saved.
+          You are not signed in and this is for demonstration purposes only. Any changes you make will not be saved.
         </div>
       {/if}
 

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -45,7 +45,7 @@
   }
 
   async function duplicateProject() {
-    if (!confirm("This will create a copy of the current project. Please confirm!")) return
+    if (!confirm("This will create a copy of the current project. Do you want to continue?")) return
 
     loading = true
 

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -69,7 +69,6 @@
   }
 
   function setUrl(uuid) {
-    console.log('set url', uuid)
     const url = new URL(window.location)
     if (uuid) url.searchParams.set("uuid", uuid)
     else url.searchParams.delete("uuid")

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -2,7 +2,8 @@
   import SearchObjects from "./SearchObjects.svelte"
   import CreateProjectModal from "./Modals/CreateProjectModal.svelte"
   import { projects, currentProject } from "../../stores/editor"
-  import { destroyCurrentProject, fetchProject } from "../../utils/project"
+  import { getSaveContent } from "../../utils/editor"
+  import { createProject, destroyCurrentProject, fetchProject } from "../../utils/project"
   import { onMount } from "svelte"
   import { fly } from "svelte/transition"
   import { flip } from "svelte/animate"
@@ -43,8 +44,20 @@
     loading = false
   }
 
-  function duplicateProject() {
+  async function duplicateProject() {
     if (!confirm("This will create a copy of the current project. Please confirm!")) return
+
+    loading = true
+
+    const content = getSaveContent()
+    const data = await createProject($currentProject.title + " (Copy)", content)
+    if (data) {
+      setUrl(data.uuid)
+      await fetchProject(data.uuid)
+    }
+
+    showProjectSettings = false
+    loading = false
   }
 
   function outsideClick(event) {
@@ -56,6 +69,7 @@
   }
 
   function setUrl(uuid) {
+    console.log('set url', uuid)
     const url = new URL(window.location)
     if (uuid) url.searchParams.set("uuid", uuid)
     else url.searchParams.delete("uuid")

--- a/app/javascript/src/components/editor/Save.svelte
+++ b/app/javascript/src/components/editor/Save.svelte
@@ -1,7 +1,7 @@
 <script>
   import FetchRails from "../../fetch-rails"
-  import { currentProject, items } from "../../stores/editor"
-  import { defaultLanguage, selectedLanguages, translationKeys } from "../../stores/translationKeys"
+  import { currentProject } from "../../stores/editor"
+  import { getSaveContent } from "../../utils/editor"
   import { Confetti } from "svelte-confetti"
 
   let loading = false
@@ -37,17 +37,6 @@
       event.preventDefault()
       save()
     }
-  }
-
-  function getSaveContent() {
-    return JSON.stringify({
-      items: $items,
-      translations: {
-        keys: $translationKeys,
-        selectedLanguages: $selectedLanguages,
-        defaultLanguage: $defaultLanguage
-      }
-    })
   }
 
   function beforeUnload(event) {

--- a/app/javascript/src/utils/editor.js
+++ b/app/javascript/src/utils/editor.js
@@ -1,4 +1,5 @@
 import { currentItem, items, openFolders, projects, editorStates } from "../stores/editor"
+import { defaultLanguage, selectedLanguages, translationKeys } from "../stores/translationKeys"
 import { get } from "svelte/store"
 
 export function createNewItem(name, content, position = 9999, type = "item") {
@@ -183,14 +184,13 @@ export function toggleFolderState(item, state, set = true) {
   if (item.parent) toggleFolderState(getItemById(item.parent), true)
 }
 
-export function updateProject(uuid, params) {
-  get(projects).forEach(project => {
-    if (project.uuid != uuid) return
-
-    Object.entries(params).forEach(([key, value]) => {
-      project[key] = value
-    })
+export function getSaveContent() {
+  return JSON.stringify({
+    items: get(items),
+    translations: {
+      keys: get(translationKeys),
+      selectedLanguages: get(selectedLanguages),
+      defaultLanguage: get(defaultLanguage)
+    }
   })
-
-  projects.set([...get(projects)])
 }

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -4,7 +4,7 @@ import { projects, currentProjectUUID, currentProject, items, currentItem, isSig
 import { translationKeys, defaultLanguage, selectedLanguages } from "../stores/translationKeys"
 import { get } from "svelte/store"
 
-export async function createProject(title, content) {
+export async function createProject(title, content = null) {
   if (!get(isSignedIn)) {
     createDemoProject()
     return
@@ -16,7 +16,7 @@ export async function createProject(title, content) {
 
       const parsedData = JSON.parse(data)
 
-      projects.set([...get(projects), parsedData])
+      projects.set([parsedData, ...get(projects)])
       currentProjectUUID.set(parsedData.uuid)
       currentItem.set({})
       items.set([])
@@ -36,7 +36,7 @@ export function createDemoProject() {
     is_owner: true
   }
 
-  projects.set([...get(projects), newProject])
+  projects.set([newProject, ...get(projects)])
   currentProjectUUID.set(newProject.uuid)
   currentItem.set({})
   items.set([])
@@ -110,7 +110,7 @@ export async function renameCurrentProject(value) {
 }
 
 export async function destroyCurrentProject() {
-  new FetchRails(`/projects/${ get(currentProjectUUID) }`).post({ method: "delete" })
+  return await new FetchRails(`/projects/${ get(currentProjectUUID) }`).post({ method: "delete" })
     .then(data => {
       if (!data) throw Error("Create failed")
 

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -112,7 +112,7 @@ export async function renameCurrentProject(value) {
 export async function destroyCurrentProject() {
   return await new FetchRails(`/projects/${ get(currentProjectUUID) }`).post({ method: "delete" })
     .then(data => {
-      if (!data) throw Error("Create failed")
+      if (!data) throw Error("Destroying current project failed")
 
       projects.set(get(projects).filter(p => p.uuid != get(currentProjectUUID)))
       currentProjectUUID.set(null)

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -1,0 +1,127 @@
+import FetchRails from "../fetch-rails"
+import { addAlert } from "../lib/alerts"
+import { projects, currentProjectUUID, currentProject, items, currentItem, isSignedIn } from "../stores/editor"
+import { translationKeys, defaultLanguage, selectedLanguages } from "../stores/translationKeys"
+import { get } from "svelte/store"
+
+export async function createProject(title, content) {
+  if (!get(isSignedIn)) {
+    createDemoProject()
+    return
+  }
+
+  return await new FetchRails("/projects", { project: { title, content, content_type: "workshop_codes" } }).post()
+    .then(data => {
+      if (!data) throw Error("Create failed")
+
+      const parsedData = JSON.parse(data)
+
+      projects.set([...get(projects), parsedData])
+      currentProjectUUID.set(parsedData.uuid)
+      currentItem.set({})
+      items.set([])
+
+      return parsedData
+    })
+    .catch(error => {
+      console.error(error)
+      alert("Something went wrong while creating your project, please try again")
+    })
+}
+
+export function createDemoProject() {
+  const newProject = {
+    uuid: Math.random().toString(16).substring(2, 8),
+    title: value,
+    is_owner: true
+  }
+
+  projects.set([...get(projects), newProject])
+  currentProjectUUID.set(newProject.uuid)
+  currentItem.set({})
+  items.set([])
+}
+
+export async function fetchProject(uuid) {
+  const baseUrl = "/projects/"
+
+  return await new FetchRails(baseUrl + uuid).get()
+    .then(data => {
+      if (!data) throw Error("No results")
+
+      const parsedData = JSON.parse(data)
+
+      updateProject(parsedData.uuid, {
+        uuid: parsedData.uuid,
+        title: parsedData.title,
+        is_owner: parsedData.is_owner
+      })
+
+      currentProjectUUID.set(parsedData.uuid)
+
+      currentItem.set({})
+
+      const parsedContent = JSON.parse(parsedData.content)
+      items.set(parsedContent?.items || parsedContent || [])
+
+      translationKeys.set(parsedContent?.translations?.keys || {})
+      selectedLanguages.set(parsedContent?.translations?.selectedLanguages || ["en-US"])
+      defaultLanguage.set(parsedContent?.translations?.defaultLanguage || "en-US")
+
+      return parsedData
+    })
+    .catch(error => {
+      items.set([])
+      currentItem.set({})
+      console.error(error)
+      alert(`Something went wrong while loading, please try again. ${ error }`)
+    })
+}
+
+export function updateProject(uuid, params) {
+  get(projects).forEach(project => {
+    if (project.uuid != uuid) return
+
+    Object.entries(params).forEach(([key, value]) => {
+      project[key] = value
+    })
+  })
+
+  projects.set([...get(projects)])
+}
+
+export async function renameCurrentProject(value) {
+  return await new FetchRails(`/projects/${ get(currentProjectUUID) }`).request("PATCH", { parameters: { body: JSON.stringify({ project: { title: value } }) } })
+    .then(data => {
+      if (!data) throw Error("Project rename failed")
+
+      updateProject(get(currentProjectUUID), {
+        title: value
+      })
+
+      addAlert(`Project renamed to "${ get(currentProject).title }" `)
+
+      return data
+    })
+    .catch(error => {
+      console.error(error)
+      alert("Something went wrong while renaming your project. Please try again.")
+    })
+}
+
+export async function destroyCurrentProject() {
+  new FetchRails(`/projects/${ get(currentProjectUUID) }`).post({ method: "delete" })
+    .then(data => {
+      if (!data) throw Error("Create failed")
+
+      projects.set(get(projects).filter(p => p.uuid != get(currentProjectUUID)))
+      currentProjectUUID.set(null)
+      currentItem.set({})
+
+      return data
+    })
+    .catch(error => {
+      console.error(error)
+      alert("Something went wrong while destroying your project, please try again")
+    })
+}


### PR DESCRIPTION
Closes #285 

This PR adds the ability to duplicate a project, creating an exact copy of the content, but of course as a completely new project. This is done by simply passing the content along when creating a project. 

But you may be looking at this thinking "Gee, that's a lot of changes just for duplicating", and you'd be right. There was too much going on in the ProjectsDropdown so I decided to split it up.
1. First up, all common fetch functions have been moved to `utils/project.js`. This includes creating, updating, and destroying a project, among more things.
2. Next the Create modal was moved to it's own component with it's own logic, rather than being housed directly in the ProjectsDropdown component. The modal is still a little bit weird in that it also uses logic from non svelte components from our standard modal javascript. I will leave that refactor for another day. For now it was about clearing up the ProjectsDropdown component.

## Duplicating
![duplicate-project](https://user-images.githubusercontent.com/12848235/231906174-1dfda2c3-7e8d-4d86-a1a1-ac72d583e4ff.gif)
