### PR TITLE
Editor: @if directive

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,6 +30,7 @@ rules:
   indent:
     - error
     - 2
+    - SwitchCase: 1
   no-trailing-spaces:
     - error
     - skipBlankLines: true

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -154,8 +154,8 @@ function extractAndInsertMixins(joinedItems) {
 }
 
 const conditionalOperations = {
-  "==": (l, r) => l === r,
-  "!=": (l, r) => l !== r
+  "is not": (l, r) => l !== r,
+  "is": (l, r) => l === r
 }
 
 function evaluateConditionals(joinedItems) {

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -153,8 +153,13 @@ function extractAndInsertMixins(joinedItems) {
   return joinedItems
 }
 
+const conditionalOperations = {
+  "==": (l, r) => l === r,
+  "!=": (l, r) => l !== r
+}
+
 function evaluateConditionals(joinedItems) {
-  const conditionalStartRegex = /@if *\( *((?:.|\n)+?) *(==|!=) *((?:.|\n)+?)\) *[ \n]*\{/g
+  const conditionalStartRegex = new RegExp(`@if *\\( *((?:.|\\n)+?) *(${ Object.keys(conditionalOperations).join("|") }) *((?:.|\\n)+?)\\) *[ \\n]*\\{`, "g")
   const conditionalElseStartRegex = / *@else *\{/
 
   let match
@@ -185,20 +190,9 @@ function evaluateConditionals(joinedItems) {
       }
     }
 
-    let passed = null
     const sanitizedLeft = left.trimEnd()
     const sanitizedRight = right.trimStart()
-    switch (operation) {
-      case "==": {
-        passed = sanitizedLeft === sanitizedRight
-        break
-      }
-      case "!=": {
-        passed = sanitizedLeft !== sanitizedRight
-        break
-      }
-      // TODO: contains operator, regex operator?
-    }
+    const passed = conditionalOperations[operation]?.(sanitizedLeft, sanitizedRight)
 
     const finalContent = passed ? trueBlockContent : falseBlockContent
     joinedItems = replaceBetween(

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -149,7 +149,6 @@ function evaluateConditionals(source) {
 
     const afterClosingBracketIndex = getClosingBracket(source, "{", "}", afterMatchedTextIndex - 2)
     if (afterClosingBracketIndex < 0) {
-      // TODO: warn user?
       continue
     }
 
@@ -158,7 +157,7 @@ function evaluateConditionals(source) {
     const trueBlockContent = source.substring(afterMatchedTextIndex, afterClosingBracketIndex)
     let falseBlockContent = ""
 
-    conditionalElseStartRegex.lastIndex = afterClosingBracketIndex - 1
+    conditionalElseStartRegex.lastIndex = afterClosingBracketIndex - 1 // set start position for the exec below
     const elseMatch = conditionalElseStartRegex.exec(source)
     if (elseMatch != null) {
       const afterElseMatchedTextIndex = elseMatch.index + elseMatch[0].length
@@ -166,7 +165,7 @@ function evaluateConditionals(source) {
       if (matchingClosingBracketForElseIndex > 0) {
         falseBlockContent = source.substring(afterElseMatchedTextIndex, matchingClosingBracketForElseIndex)
         conditionalEndingIndex = matchingClosingBracketForElseIndex
-      } // TODO: else warn user?
+      }
     }
 
     let passed = null

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -153,9 +153,28 @@ function extractAndInsertMixins(joinedItems) {
   return joinedItems
 }
 
+const regexRegex = /^\/(.+)\/(\w*)$/
+
 const conditionalOperations = {
+  // order is deliberate as to not make RegExp work too much
   "is not": (l, r) => l !== r,
-  "is": (l, r) => l === r
+  "is": (l, r) => l === r,
+  "contains": (l, r) => l.includes(r),
+  "test": (l, r) => {
+    const match = r.match(regexRegex)
+    if (!match) {
+      // TODO: mark in linter
+      return false
+    }
+    const [_, pattern, flags] = match
+    let regex
+    try {
+      regex = new RegExp(pattern, flags)
+    } catch (err) {
+      return false
+    }
+    return regex.test(l)
+  }
 }
 
 function evaluateConditionals(joinedItems) {

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -17,7 +17,7 @@ export function compile(overwriteContent = null) {
 
   joinedItems = joinedItems.replace(settings, "")
   joinedItems = extractAndInsertMixins(joinedItems)
-  joinedItems = extractAndInsertConditionals(joinedItems)
+  joinedItems = evaluateConditionals(joinedItems)
   joinedItems = convertTranslations(joinedItems)
 
   const variables = compileVariables(joinedItems)
@@ -165,7 +165,7 @@ function findMatchingClosingBracketIndex(source, fromIndex) {
  * @param {string} source
  * @returns {string}
  */
-function extractAndInsertConditionals(source) {
+function evaluateConditionals(source) {
   const conditionalStartRegex = /@if *\( *((?:.|\n)+?) *(==|!=) *((?:.|\n)+?)\) *[ \n]*\{/g
   const conditionalElseStartRegex = / *@else *\{/
 
@@ -208,6 +208,7 @@ function extractAndInsertConditionals(source) {
         passed = sanitizedLeft !== sanitizedRight
         break
       }
+      case ""
       // TODO: contains operator, regex operator?
     }
 

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -178,7 +178,7 @@ const conditionalOperations = {
 }
 
 function evaluateConditionals(joinedItems) {
-  const conditionalStartRegex = new RegExp(`@if[ \\n]*\\([ \\n]*((?:.|\\n)+?)[ \\n]*(${ Object.keys(conditionalOperations).join("|") })[ \\n]*((?:.|\\n)+?)\\)[ \\n]*\\{`, "g")
+  const conditionalStartRegex = new RegExp(`@if[ \\n]*\\([ \\n]*((?:.|\\n)+?)[ \\n]*(${ Object.keys(conditionalOperations).join("|") })[ \\n]*((?:.|\\n)+?)[ \\n]*\\)[ \\n]*\\{`, "g")
   const conditionalElseStartRegex = /[ \n]*@else[ \n]*\{/
 
   let match

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -208,7 +208,6 @@ function evaluateConditionals(source) {
         passed = sanitizedLeft !== sanitizedRight
         break
       }
-      case ""
       // TODO: contains operator, regex operator?
     }
 

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -153,32 +153,32 @@ function extractAndInsertMixins(joinedItems) {
   return joinedItems
 }
 
-function evaluateConditionals(source) {
+function evaluateConditionals(joinedItems) {
   const conditionalStartRegex = /@if *\( *((?:.|\n)+?) *(==|!=) *((?:.|\n)+?)\) *[ \n]*\{/g
   const conditionalElseStartRegex = / *@else *\{/
 
   let match
-  while ((match = conditionalStartRegex.exec(source)) != null) {
+  while ((match = conditionalStartRegex.exec(joinedItems)) != null) {
     const [matchedConditionalStartText, left, operation, right] = match
     const afterMatchedTextIndex = match.index + matchedConditionalStartText.length
 
-    const afterClosingBracketIndex = getClosingBracket(source, "{", "}", afterMatchedTextIndex - 2)
+    const afterClosingBracketIndex = getClosingBracket(joinedItems, "{", "}", afterMatchedTextIndex - 2)
     if (afterClosingBracketIndex < 0) {
       continue
     }
 
     let conditionalEndingIndex = afterClosingBracketIndex - 1
 
-    const trueBlockContent = source.substring(afterMatchedTextIndex, afterClosingBracketIndex)
+    const trueBlockContent = joinedItems.substring(afterMatchedTextIndex, afterClosingBracketIndex)
     let falseBlockContent = ""
 
     conditionalElseStartRegex.lastIndex = afterClosingBracketIndex - 1 // set start position for the exec below
-    const elseMatch = conditionalElseStartRegex.exec(source)
+    const elseMatch = conditionalElseStartRegex.exec(joinedItems)
     if (elseMatch != null) {
       const afterElseMatchedTextIndex = elseMatch.index + elseMatch[0].length
-      const matchingClosingBracketForElseIndex = getClosingBracket(source, "{", "}", afterElseMatchedTextIndex - 2)
+      const matchingClosingBracketForElseIndex = getClosingBracket(joinedItems, "{", "}", afterElseMatchedTextIndex - 2)
       if (matchingClosingBracketForElseIndex > 0) {
-        falseBlockContent = source.substring(afterElseMatchedTextIndex, matchingClosingBracketForElseIndex)
+        falseBlockContent = joinedItems.substring(afterElseMatchedTextIndex, matchingClosingBracketForElseIndex)
         conditionalEndingIndex = matchingClosingBracketForElseIndex
       } else {
         continue
@@ -201,8 +201,8 @@ function evaluateConditionals(source) {
     }
 
     const finalContent = passed ? trueBlockContent : falseBlockContent
-    source = replaceBetween(
-      source,
+    joinedItems = replaceBetween(
+      joinedItems,
       finalContent,
       match.index,
       conditionalEndingIndex + 1
@@ -211,7 +211,7 @@ function evaluateConditionals(source) {
     conditionalStartRegex.lastIndex = match.index
   }
 
-  return source
+  return joinedItems
 }
 
 function compileVariables(joinedItems) {

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -178,8 +178,8 @@ const conditionalOperations = {
 }
 
 function evaluateConditionals(joinedItems) {
-  const conditionalStartRegex = new RegExp(`@if *\\( *((?:.|\\n)+?) *(${ Object.keys(conditionalOperations).join("|") }) *((?:.|\\n)+?)\\) *[ \\n]*\\{`, "g")
-  const conditionalElseStartRegex = / *@else *\{/
+  const conditionalStartRegex = new RegExp(`@if[ \\n]*\\([ \\n]*((?:.|\\n)+?)[ \\n]*(${ Object.keys(conditionalOperations).join("|") })[ \\n]*((?:.|\\n)+?)\\)[ \\n]*\\{`, "g")
+  const conditionalElseStartRegex = /[ \n]*@else[ \n]*\{/
 
   let match
   while ((match = conditionalStartRegex.exec(joinedItems)) != null) {

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -167,7 +167,7 @@ function findMatchingClosingBracketIndex(source, fromIndex) {
  */
 function extractAndInsertConditionals(source) {
   const conditionalStartRegex = /@if *\( *((?:.|\n)+?) *(==|!=) *((?:.|\n)+?)\) *[ \n]*\{/g
-  const conditionalElseStartRegex = /^ *@else *\{/
+  const conditionalElseStartRegex = / *@else *\{/
 
   let match
   while ((match = conditionalStartRegex.exec(source)) != null) {
@@ -185,9 +185,10 @@ function extractAndInsertConditionals(source) {
     const trueBlockContent = source.substring(afterMatchedTextIndex, matchingClosingBracketIndex)
     let falseBlockContent = ""
 
-    const elseMatch = conditionalElseStartRegex.exec(source.substring(matchingClosingBracketIndex + 1))
+    conditionalElseStartRegex.lastIndex = matchingClosingBracketIndex
+    const elseMatch = conditionalElseStartRegex.exec(source)
     if (elseMatch != null) {
-      const afterElseMatchedTextIndex = matchingClosingBracketIndex + 1 + elseMatch[0].length
+      const afterElseMatchedTextIndex = elseMatch.index + elseMatch[0].length
       const matchingClosingBracketForElseIndex = findMatchingClosingBracketIndex(source, afterElseMatchedTextIndex)
       if (matchingClosingBracketForElseIndex > 0) {
         falseBlockContent = source.substring(afterElseMatchedTextIndex, matchingClosingBracketForElseIndex)

--- a/app/javascript/src/utils/editor.js
+++ b/app/javascript/src/utils/editor.js
@@ -56,7 +56,7 @@ export function getClosingBracket(content, characterOpen = "{", characterClose =
       initial = false
     }
     else if (c == characterClose) counter--
-    if (counter > 20 || closePos > (100_000 + start) || closePos >= content.length) break
+    if (counter > 20 || closePos > (100_000 + start) || closePos >= content.length) return -1
   }
 
   return closePos


### PR DESCRIPTION
Syntax
```
@if (lefthand operator righthand) {
  put this
} @else {
  put this instead
}
```

where the `@else` is optional

- `lefthand` and `righthand` are (so far) only compared as raw strings
  - Currently supported operators are == and !=
- Runs after mixins, so it compares against Mixin values instead of `Mixin.XYZ`
- In classic `@mixin` fashion, there is no trimming of the content that gets replaced
  - but `lefthand` is right-trimmed and `righthand` is left-trimmed, for code convenience

Left a couple TODOs in the code, maybe we can tackle them in the code review.

Also, adjusted eslint rules so `switch` statements get an indent of 1 (the default in eslint is wrong and there is no way to make me change my mind about it)