### PR TITLE
Editor: Fix crash when evaluating an empty expression

### DIFF
--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -166,8 +166,11 @@ function removeSurroundingParenthesis(source) {
 function getExpressionTree(expression) {
   expression = removeSurroundingParenthesis(expression)
 
-  const result = {
-    DEBUG__input: expression
+  const result = {}
+
+  if (expression.length === 0) {
+    result.value = ""
+    return result
   }
 
   for (let currentIndex = 0; currentIndex < expression.length; currentIndex++) {
@@ -234,7 +237,7 @@ function getExpressionTree(expression) {
 function evaluateExpressionTree(node) {
   if (node.invalid) {
     return null
-  } else if (node.value) {
+  } else if (node.value != null) {
     return node.value.trim()
   } else {
     const evaluatedArguments = node.arguments.map((argument) => evaluateExpressionTree(argument))


### PR DESCRIPTION
Fixes the `TypeError: Cannot read properties of undefined (reading 'map')` when there is an `@if` with an empty condition like so:
```
@if () {}
```

This has to be handled separately because, when parsing the expression, since there are no characters the for loop would just go to the end, returning an empty object.
