### PR TITLE
Add VSCode launch task for Rails server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,10 +4,21 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
-		{
+    {
+      // Required gems: ruby-debug-base and ruby-debug-ide
+      // Required extension: rebornix.ruby
+      "name": "Rails server",
+      "type": "Ruby",
+      "request": "launch",
+      "program": "${workspaceRoot}/bin/rails",
+      "args": [
+        "server"
+      ]
+    },
+    {
 			"type": "chrome",
 			"request": "launch",
-			"name": "Launch Chrome against localhost:3000",
+			"name": "Chrome against localhost:3000",
 			"url": "http://localhost:3000",
 			"webRoot": "${workspaceFolder}/app"
 		}


### PR DESCRIPTION
Allows VSCode users to set breakpoints and inspect variables.

Turns out this was pretty easy: I just needed to use the template configuration, and to install gems and an extension.