### PR TITLE
feat: Improve data provided by report notifications

### DIFF
--- a/app/assets/stylesheets/utilities/_colors.scss
+++ b/app/assets/stylesheets/utilities/_colors.scss
@@ -72,6 +72,10 @@
   }
 }
 
+.text-green {
+  color: $green;
+}
+
 .bg-red {
   background: $red;
 }

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -6,7 +6,7 @@
       <div>
         <h3 class="mt-0">Report for: <strong><%= report.concerns_model %> <%= report.concerns_id %></strong></h3>
 
-        Status: <span class="<%= "text-primary" if report.status == "accepted" %> <%= "text-red" if report.status == "rejected" %>"><%= report.status %></span> <br>
+        Status: <span class="<%= "text-green" if report.status == "accepted" %> <%= "text-red" if report.status == "rejected" %>"><%= report.status %></span> <br>
         Created at: <%= report.created_at %> <br>
 
         <%= link_to "View", admin_report_path(report), class: "button button--link pt-1/4 pb-0" %>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -4,7 +4,7 @@
   <h3 class="mt-0">Report for: <strong><%= @report.concerns_model %> <%= @report.concerns_id %></strong></h3>
 
   <div class="mb-1/2">
-    Status: <span class="<%= "text-primary" if @report.status == "accepted" %> <%= "text-red" if @report.status == "rejected" %>"><%= @report.status %></span> <br>
+    Status: <span class="<%= "text-green" if @report.status == "accepted" %> <%= "text-red" if @report.status == "rejected" %>"><%= @report.status %></span> <br>
     Created at: <%= @report.created_at %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
     delete "linked_users/:id", to: "linked_users#destroy", as: "destroy_linked_user"
 
     resources :reports, only: [:create, :new, :destroy, :update]
+    get "reports/:id/:status", to: "reports#update", as: "report_submit"
     resources :notifications, only: [:index], concerns: :paginatable
     get "unread-notifications", to: "notifications#get_unread_notifications"
     get "unread-notifications-count", to: "notifications#get_unread_notifications_count"


### PR DESCRIPTION
With this PR notifications send to Discord will provide more data with actionable links right from the embed. The notify_discord action is split up in to two different ones, one for posts and one for comments. They could probably have been combined in some smart way, but this felt like the cleaner (and easier) solution.

Posts contain info about the post itself. Namely the title, code, image, if it has a snippet, and the start of a description. All of which are useful when determining if a code is real.

Comments contains the comment body itself. There are no links set up to view the comment in the admin or on the post itself. We rarely (if ever) get comment reports so I decided not to spend time on it for now.

Both have Accept and Reject buttons, which are really just links, but they do accept or reject the report as you'd expect.

| Posts | Comments |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/12848235/233807086-6e3d945e-6af7-4d43-ab10-cb0812382623.png) | ![image](https://user-images.githubusercontent.com/12848235/233807101-1c277a8a-08fd-44de-977f-dc2430375918.png) |
