### PR TITLE
Allow Editor to be installable as a Progressive Web App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 /yarn-error.log
 
 /public/assets
+/public/service-worker.js*
 .byebug_history
 
 # Ignore master key for decrypting credentials and more.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,10 @@ module ApplicationHelper
     controller_path.split('/').first == "wiki" ? true : false
   end
 
+  def is_editor?
+    controller_path.split('/').first == "editor" ? true : false
+  end
+
   def is_admin_controller?
     controller_path.split('/').first == "admin" ? true : false
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -75,6 +75,8 @@ document.addEventListener("turbolinks:load", function() {
 
   timeago.initialize()
   scrollIntoViewOnLoad.initialize()
+
+  navigator.serviceWorker.register("/service-worker.js")
 })
 
 document.addEventListener("turbolinks:before-cache", function() {

--- a/app/javascript/service-workers/service-worker.js
+++ b/app/javascript/service-workers/service-worker.js
@@ -1,0 +1,3 @@
+self.addEventListener("fetch", function(event) {
+  // TODO: show offline page?
+})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,11 @@
     <link rel="alternate" href="<%= request.base_url + url_for(params.clone.permit!.merge(locale: nil)) %>" hreflang="en" />
     <link rel="alternate" href="<%= request.base_url + url_for(params.clone.permit!.merge(locale: :ko)) %>" hreflang="ko" />
 
-    <link rel="manifest" href="/manifest.json">
+    <% if is_editor? %>
+      <link rel="manifest" href="/editor-manifest.json">
+    <% else %>
+      <link rel="manifest" href="/manifest.json">
+    <% end %>
 
     <link rel="preload"
       href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@600&display=swap"

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,7 +1,11 @@
-const { environment } = require("@rails/webpacker")
+const { config, environment } = require("@rails/webpacker")
+
+const WebpackerPwa = require("webpacker-pwa")
 
 const globCssImporter = require("node-sass-glob-importer")
 const svelte = require("./loaders/svelte")
+
+new WebpackerPwa(config, environment)
 
 environment.loaders.prepend("svelte", svelte)
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -18,6 +18,8 @@ default: &default
   # Extract and emit a css file
   extract_css: false
 
+  service_workers_entry_path: service-workers
+
   static_assets_extensions:
     - .jpg
     - .jpeg

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "webp-loader": "^0.6.0",
     "webpack": "4.46.0",
     "webpack-cli": "3.3.12",
+    "webpacker-pwa": "^0.1.2",
     "webpacker-svelte": "^1.0.0"
   },
   "devDependencies": {

--- a/public/editor-manifest.json
+++ b/public/editor-manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Workshop.codes Script Editor",
+  "short_name": "Workshop.codes Editor",
+  "id": "workshop.codes/editor",
+  "start_url": "/editor",
+  "icons": [
+    {
+      "src": "/assets/favicon/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/favicon/favicon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/favicon/favicon.svg",
+      "sizes": "270x270",
+      "type": "image/svg"
+    }
+  ],
+  "display": "standalone",
+  "background_color": "#1f2326",
+  "theme_color": "#f06414"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10711,6 +10711,11 @@ webpack@4.46.0, webpack@^4.46.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
+webpacker-pwa@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/webpacker-pwa/-/webpacker-pwa-0.1.2.tgz#7b44f6f23383f830206b5c66dc1885ecc34e46d4"
+  integrity sha512-DfKbInyb9Z+p4Bl+9deKJW4MSiQaqcfK24DGJnzq+c2DwzhL6GpnrXHPr7GXcXq4SLnAh4O8u1JhUGay2htkVA==
+
 webpacker-svelte@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/webpacker-svelte/-/webpacker-svelte-1.0.0.tgz#c1bac3dc557fcfae6fa2fd883614a8ce17037678"


### PR DESCRIPTION
- Add webpacker-pwa which takes care of changing webpack to compile the service worker to public/
- Add manifest.json for the Editor page
- Add less-than-barebones service worker with a no-op `fetch` event handler so browsers show the Install button

Ideally we'd want the service worker to serve an offline page, but we can care about that later.