### PR TITLE
fix: properly validate carousel video field

### DIFF
--- a/app/assets/stylesheets/general/_form.scss
+++ b/app/assets/stylesheets/general/_form.scss
@@ -264,6 +264,11 @@ input[type="file"] {
   }
 }
 
+.error-help-text {
+  display: none;
+  color: $red;
+}
+
 .field_with_errors {
   display: inline;
 
@@ -275,6 +280,10 @@ input[type="file"] {
     &.helper-input {
       border: unset;
     }
+  }
+
+  .error-help-text {
+    display: block;
   }
 }
 

--- a/app/views/posts/form/_image_upload.html.erb
+++ b/app/views/posts/form/_image_upload.html.erb
@@ -24,6 +24,8 @@
       </div>
 
       <%= form.text_field :carousel_video, class: "form-input", placeholder: t("posts.form.images.video.placeholder") %>
+
+      <p class="error-help-text mb-0"><%= t("posts.form.images.video.invalid") %></p>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,9 +192,10 @@ en:
           label: Drop images here to add them to your post
           help: Images will be displayed in a 900x500 format (max 2MB per image, jpeg/png only)
         video:
-          label: Youtube video
+          label: YouTube video
           help_html: "Include a video as the first item in the carousel. Enter only the YouTube video ID, not the full url. (Video ID is in bold: youtube.com/watch?v=<strong>FqnKB22pOC0</strong>)"
           placeholder: "A video ID looks like this: FqnKB22pOC0"
+          invalid: "Please provide a valid YouTube video link or video ID"
       description:
         title: Description
         help_html: |

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -160,6 +160,7 @@ ko:
           label: 유튜브 동영상
           help_html: "캐러셀의 첫 번째 항목으로 동영상을 포함하세요. 전체 URL이 아닌 YouTube 동영상 ID 만 입력하세요. (동영상 ID는 굵게 표시됨 : youtube.com/watch?v=<strong>FqnKB22pOC0</strong>)"
           placeholder: "동영상 ID는 다음과 같이 보입니다. FqnKB22pOC0"
+          invalid: "유효한 YouTube 동영상 링크 또는 동영상 ID를 입력하세요."
       description:
         title: 설명
         help_html: |

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -67,7 +67,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "Creating a post with an invalid carousel video ID does not create a post" do
+  test "Creating a post with an invalid carousel video URL does not create a post" do
     sign_in_as users(:user_one)
 
     visit new_post_url
@@ -79,6 +79,23 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_no_changes "Post.count" do
       click_button "Create Post"
       assert page.has_content? "Create new Workshop Code"
+      assert_nil Post.last.carousel_video
+    end
+  end
+
+  test "Creating a post with a filepath (from dragging file into browser) does not succeed" do
+    sign_in_as users(:user_one)
+
+    visit new_post_url
+
+    fill_in_post_details
+
+    fill_in "post_carousel_video", with: "\"C:\\Users\\user\\Videos\\Overwatch\\Overwatch 2016.12.20 - 15.53.29.mp4\""
+
+    assert_no_changes "Post.count" do
+      click_button "Create Post"
+      assert page.has_content? "Create new Workshop Code"
+      assert_nil Post.last.carousel_video
     end
   end
 

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -27,19 +27,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert page.has_content? "Create new"
 
-    code = SecureRandom.alphanumeric(5)
-
-    fill_in "post_title", with: @post.title
-    fill_in "post_code", with: SecureRandom.alphanumeric(5)
-    fill_in "post_description", with: @post.description
-    fill_in "post_tags", with: @post.tags
-    fill_in "post_version", with: @post.version
-
-    find("#post_categories").find("option[value='Team Deathmatch']").select_option
-    find("#post_heroes_reinhardt").set(true)
-    find("#post_maps_hanamura").set(true)
-    find("#post_min_players", visible: false).set(1)
-    find("#post_max_players", visible: false).set(12)
+    fill_in_post_details
 
     assert_difference "Post.count", 1 do
       click_button "Create Post"
@@ -78,4 +66,63 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
       first(".item--small").click_link "Delete"
     end
   end
+
+  test "Creating a post with an invalid carousel video ID does not create a post" do
+    sign_in_as users(:user_one)
+
+    visit new_post_url
+
+    fill_in_post_details
+
+    fill_in "post_carousel_video", with: "https://www.bilibili.com/video/BV1yw411Z7cV/"
+
+    assert_no_changes "Post.count" do
+      click_button "Create Post"
+      assert page.has_content? "Create new Workshop Code"
+    end
+  end
+
+  test "Creating a post with a YouTube video ID" do
+    sign_in_as users(:user_one)
+
+    visit new_post_url
+
+    fill_in_post_details
+
+    fill_in "post_carousel_video", with: "DAcqc5B2uEM"
+
+    click_button "Create Post"
+
+    assert_equal find(".video__iframe")["src"], "https://www.youtube-nocookie.com/embed/DAcqc5B2uEM?enablejsapi=1"
+  end
+
+  test "Creating a post with a YouTube link instead of a YouTube video ID still works as expected" do
+    sign_in_as users(:user_one)
+
+    visit new_post_url
+
+    fill_in_post_details
+
+    fill_in "post_carousel_video", with: "https://www.youtube.com/watch?v=DAcqc5B2uEM&t=20s"
+
+    click_button "Create Post"
+
+    assert_equal find(".video__iframe")["src"], "https://www.youtube-nocookie.com/embed/DAcqc5B2uEM?enablejsapi=1"
+  end
+end
+
+def fill_in_post_details
+  code = SecureRandom.alphanumeric(5)
+
+  fill_in "post_title", with: @post.title
+  fill_in "post_code", with: SecureRandom.alphanumeric(5)
+  fill_in "post_description", with: @post.description
+  fill_in "post_tags", with: @post.tags
+  fill_in "post_version", with: @post.version
+
+  find("#post_categories").find("option[value='Team Deathmatch']").select_option
+  find("#post_heroes_reinhardt").set(true)
+  find("#post_maps_hanamura").set(true)
+  find("#post_min_players", visible: false).set(1)
+  find("#post_max_players", visible: false).set(12)
 end


### PR DESCRIPTION
This pull request fixes a bug where the carousel video field would not properly extract a YouTube video link's video ID upon first post creation. It also adds improved validation of the carousel video field, along with more user feedback when providing an invalid carousel video ID or URL.

*Title + code section after submitting with an invalid carousel video field*
![image](https://github.com/Mitcheljager/workshop.codes/assets/10406383/34841077-4728-46f7-a931-6a1c5ea9630d)

*Carousel image upload + video field after submitting with an invalid carousel video field*
![image](https://github.com/Mitcheljager/workshop.codes/assets/10406383/58b19dee-6791-480e-8cfa-ca8c58401881)

