### PR TITLE
Add link to open wiki article on a new tab in the editor wiki sidebar

### DIFF
--- a/app/javascript/src/components/editor/EditorWiki.svelte
+++ b/app/javascript/src/components/editor/EditorWiki.svelte
@@ -1,6 +1,7 @@
 <script>
   import FetchRails from "../../fetch-rails"
   import EditorWikiSearch from "./EditorWikiSearch.svelte"
+  import ExternalLinkIcon from "../icon/ExternalLink.svelte"
 
   let article
 
@@ -41,7 +42,9 @@
 {#if article}
   <div class="mt-1/2" on:click={click}>
     <div class="text-dark mb-1/8">{article.category.title}</div>
-    <h2 class="mt-0 mb-1/8">{article.title}</h2>
+    <h2 class="mt-0 mb-1/8">
+      {article.title} <a href={`/wiki/articles/${ article.slug }`} target="_blank"><ExternalLinkIcon /></a>
+    </h2>
     {#if article.subtitle}
       <h5 class="mt-0">{article.subtitle}</h5>
     {/if}

--- a/app/javascript/src/components/icon/ExternalLink.svelte
+++ b/app/javascript/src/components/icon/ExternalLink.svelte
@@ -1,0 +1,18 @@
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg
+  width="16"
+  height="16"
+  viewBox="0 0 3 3"
+  fill="none"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg">
+  <path
+    d="m 10.0002,5 h -1.8 C 7.08009,5 6.51962,5 6.0918,5.21799 5.71547,5.40973 5.40973,5.71547 5.21799,6.0918 5,6.51962 5,7.08009 5,8.2002 v 7.6 c 0,1.1201 0,1.6799 0.21799,2.1077 0.19174,0.3763 0.49748,0.6826 0.87381,0.8743 C 6.5192,19 7.07899,19 8.19691,19 h 7.60619 c 1.1179,0 1.6769,0 2.1043,-0.2178 0.3763,-0.1917 0.6831,-0.4983 0.8748,-0.8746 C 19,17.4802 19,16.921 19,15.8031 V 14 M 20,9 V 4 m 0,0 h -5 m 5,0 -7,7"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    style="stroke:currentColor;stroke-width:2.64775;stroke-dasharray:none;stroke-opacity:1"
+    transform="matrix(0.16995555,0,0,0.16995559,-0.62411079,-0.45482273)"
+  />
+</svg>


### PR DESCRIPTION
![](https://github.com/Mitcheljager/workshop.codes/assets/6181929/022c5f58-d186-4f7e-a66a-9316ce462ccc)
![](https://github.com/Mitcheljager/workshop.codes/assets/6181929/5102b304-defd-490a-a560-5645ca43347b)

Useful when you want to see the article in full screen, or need to see parts of the article which couldn't be rendered otherwise (_\*cough\* \*cough\*_ galleries _\*cough\* \*cough\*_).

Open to suggestions about the design. I'm not too happy with it.

`ExternalLink` icon from https://www.svgrepo.com/svg/510970/external-link