### PR TITLE
Fix some styling issues with the Editor line finder expanded snippet

### DIFF
--- a/app/assets/stylesheets/editor/_expandable-snippet.scss
+++ b/app/assets/stylesheets/editor/_expandable-snippet.scss
@@ -1,4 +1,16 @@
+.expandable-snippet-modal {
+  max-height: 100%;
+  display: flex;
+}
+
 .expandable-snippet {
+  width: 100%;
+  max-height: 100%;
+
+  &__code {
+    max-height: 100%;
+  }
+
   &__line {
     width: 100%;
 
@@ -11,7 +23,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    padding: 0.25rem;
+    padding: 0.5rem 0.75rem;
     cursor: pointer;
     display: inline-block;
 

--- a/app/javascript/src/components/editor/ExpandableSnippet.svelte
+++ b/app/javascript/src/components/editor/ExpandableSnippet.svelte
@@ -10,12 +10,14 @@
   let expanded = false
   let snippetLines
   let snippetStartLineIdx
-  let expandedCodeEl
+  let expandedCodeElement
 
   $: {
     snippetStartLineIdx = snippetHighlightedLineIndex - Math.max(0, Math.floor(snippetLineCount / 2))
     snippetLines = getLines(snippetLineCount)
   }
+  $: syntaxHighlight(expanded)
+  $: if (expanded) scrollToHighlightedLine()
 
   function getLines() {
     const lines = []
@@ -32,20 +34,16 @@
     microlight()
   }
 
-  $: syntaxHighlight(expanded)
-
   async function scrollToHighlightedLine() {
     await tick()
 
-    if (!expandedCodeEl) return
+    if (!expandedCodeElement) return
 
-    const highlightedLineEl = expandedCodeEl.querySelector(".expandable-snippet__line--highlighted")
-    if (!highlightedLineEl) return
+    const highlightedLineElement = expandedCodeElement.querySelector(".expandable-snippet__line--highlighted")
+    if (!highlightedLineElement) return
 
-    highlightedLineEl.scrollIntoViewIfNeeded()
+    highlightedLineElement.scrollIntoViewIfNeeded()
   }
-
-  $: if (expanded) scrollToHighlightedLine()
 
   function escapeLine(line) {
     return line.replaceAll(/\s/g, "&nbsp;").replaceAll(/\t/g, "&nbsp;&nbsp;")
@@ -73,7 +71,7 @@
         <Expand contract />
       </div>
       <div class="expandable-snippet__code overflow-auto">
-        <code class="block" bind:this={expandedCodeEl}>
+        <code class="block" bind:this={expandedCodeElement}>
           {#each fullContentLines as line, index}
             <div class="flex">
               {index}.&nbsp;<div

--- a/app/javascript/src/components/editor/ExpandableSnippet.svelte
+++ b/app/javascript/src/components/editor/ExpandableSnippet.svelte
@@ -53,18 +53,20 @@
 
 {#if expanded}
 <div class="modal modal--top" data-ignore>
-  <div class="modal__content" style="min-width: 600px; max-width: initial">
+  <div class="modal__content expandable-snippet-modal" style="min-width: 600px; max-width: initial;">
     <div class="expandable-snippet relative">
       <div class="expandable-snippet__expand-button" on:click={() => expanded = false}>
         <Expand contract />
       </div>
-      <code class="block overflow-auto">
-        {#each fullContentLines as line, index}
-          <div class="flex">
-            {index}.&nbsp;<div class="microlight expandable-snippet__line" class:expandable-snippet__line--highlighted={index === snippetHighlightedLineIndex}>{@html escapeLine(line || "")}</div>
-          </div>
-        {/each}
-      </code>
+      <div class="expandable-snippet__code overflow-auto">
+        <code class="block">
+          {#each fullContentLines as line, index}
+            <div class="flex">
+              {index}.&nbsp;<div class="microlight expandable-snippet__line" class:expandable-snippet__line--highlighted={index === snippetHighlightedLineIndex}>{@html escapeLine(line || "")}</div>
+            </div>
+          {/each}
+        </code>
+      </div>
     </div>
   </div>
 

--- a/app/javascript/src/components/editor/ExpandableSnippet.svelte
+++ b/app/javascript/src/components/editor/ExpandableSnippet.svelte
@@ -10,6 +10,7 @@
   let expanded = false
   let snippetLines
   let snippetStartLineIdx
+  let expandedCodeEl
 
   $: {
     snippetStartLineIdx = snippetHighlightedLineIndex - Math.max(0, Math.floor(snippetLineCount / 2))
@@ -32,6 +33,19 @@
   }
 
   $: syntaxHighlight(expanded)
+
+  async function scrollToHighlightedLine() {
+    await tick()
+
+    if (!expandedCodeEl) return
+
+    const highlightedLineEl = expandedCodeEl.querySelector(".expandable-snippet__line--highlighted")
+    if (!highlightedLineEl) return
+
+    highlightedLineEl.scrollIntoViewIfNeeded()
+  }
+
+  $: if (expanded) scrollToHighlightedLine()
 
   function escapeLine(line) {
     return line.replaceAll(/\s/g, "&nbsp;").replaceAll(/\t/g, "&nbsp;&nbsp;")
@@ -59,10 +73,13 @@
         <Expand contract />
       </div>
       <div class="expandable-snippet__code overflow-auto">
-        <code class="block">
+        <code class="block" bind:this={expandedCodeEl}>
           {#each fullContentLines as line, index}
             <div class="flex">
-              {index}.&nbsp;<div class="microlight expandable-snippet__line" class:expandable-snippet__line--highlighted={index === snippetHighlightedLineIndex}>{@html escapeLine(line || "")}</div>
+              {index}.&nbsp;<div
+                class="microlight expandable-snippet__line"
+                class:expandable-snippet__line--highlighted={index === snippetHighlightedLineIndex}
+              >{@html escapeLine(line || "")}</div>
             </div>
           {/each}
         </code>

--- a/app/javascript/src/components/editor/ExpandableSnippet.svelte
+++ b/app/javascript/src/components/editor/ExpandableSnippet.svelte
@@ -39,7 +39,7 @@
 </script>
 
 <div class="expandable-snippet relative">
-  <div class="expandable-codeblock__expand-button" on:click={() => expanded = true}>
+  <div class="expandable-snippet__expand-button" on:click={() => expanded = true}>
     <Expand />
   </div>
   <code class="block overflow-auto">
@@ -54,8 +54,8 @@
 {#if expanded}
 <div class="modal modal--top" data-ignore>
   <div class="modal__content" style="min-width: 600px; max-width: initial">
-    <div class="snippet relative">
-      <div class="snippet__expand-button" on:click={() => expanded = false}>
+    <div class="expandable-snippet relative">
+      <div class="expandable-snippet__expand-button" on:click={() => expanded = false}>
         <Expand contract />
       </div>
       <code class="block overflow-auto">


### PR DESCRIPTION
- Use correct CSS classes for the snippets
- Move scrollbar to the expanded snippet, not the whole page
  - Not to happy about how I did this. I had to work around the fact modal is a flex parent. Open to suggestions.
- Put highlighted line into view expanding snippet