### PR TITLE
Use vertical resize cursor on Editor drag handle when in the mobile layout

### DIFF
--- a/app/assets/stylesheets/editor/_editor.scss
+++ b/app/assets/stylesheets/editor/_editor.scss
@@ -131,9 +131,10 @@ $top-height: 4rem;
   bottom: 0;
   right: 0;
   opacity: 0;
-  cursor: ew-resize;
+  cursor: ns-resize;
 
   @include media-min(mbl) {
+    cursor: ew-resize;
     height: 100%;
     width: 0.5rem;
   }


### PR DESCRIPTION
While mobile phones don't have cursors*, users can resize the window to be small enough to see the mobile layout.

*Users can attach peripherals like mice, and the OS will display a pointer on the screen.