### PR TITLE
Fix a couple of a cases of splitting parameters not being aware of strings or parenthesis

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -1,4 +1,4 @@
-import { getClosingBracket, getPhraseFromPosition } from "../utils/editor"
+import { getClosingBracket, getPhraseFromPosition, splitArgumentsString } from "../utils/editor"
 import { completionsMap, workshopConstants } from "../stores/editor"
 import { get } from "svelte/store"
 
@@ -123,7 +123,7 @@ function findIncorrectArgsLength(content) {
           safeIndex++
         }
 
-        const splitContent = argumentsString.split(",")
+        const splitContent = splitArgumentsString(argumentsString)
 
         if (item.args_min_length && splitContent.length >= item.args_min_length && splitContent.length <= item.args_length) break
         if (!item.args_min_length && splitContent.length == item.args_length) break

--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -89,7 +89,7 @@ function extractAndInsertMixins(joinedItems) {
     if (closingParen < 0) {
       continue
     }
-    const params = content.slice(firstOpenParen + 1, closingParen).replace(/\s/, "").split(",")
+    const params = splitArgumentsString(content.slice(firstOpenParen + 1, closingParen).replace(/\s/, ""))
     const paramsDefaults = params
       .map(param => {
         const slicedAt = param.indexOf("=")


### PR DESCRIPTION
Use `splitArgumentsString` in places where it should or could be used. On this PR:
- when splitting arguments in the linter
- when splitting parameters of a mixin