### PR TITLE
Use new operator symbol for regex conditional check in Editor linter

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -465,7 +465,7 @@ function findTrailingCommas(content) {
 }
 
 function findConditionalsRegexErrors(content) {
-  const regex = /(test[ \n]*)(.*)[ \n]*\)[ \n]*\{/g // matches " test righthand) {" and " /regex/flags) {"
+  const regex = /(~=[ \n]*)(.*)[ \n]*\)[ \n]*\{/g // matches "~= righthand) {" and "~= /regex/flags) {"
   const regexRegex = /\/(.*)\/(\w*)/ // TODO: share this with compiler.js?
   let match
   while ((match = regex.exec(content)) != null) {


### PR DESCRIPTION
`test` → `~=`

As if anyone was using the test operator anyway lol.