### PR TITLE
Prevent Editor linter crash when event type is not in the list of known events with arguments

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -569,7 +569,7 @@ function findEventBlocksWithMissingArguments(content) {
 
     const requiredEventArgs = eventTypeToArgumentsMap[eventType.toLowerCase()]
 
-    if (requiredEventArgs.length !== givenEventArgs.length) {
+    if (requiredEventArgs && requiredEventArgs.length !== givenEventArgs.length) {
       const missingArguments = requiredEventArgs.slice(givenEventArgs.length)
       diagnostics.push({
         from: eventBlockStart,


### PR DESCRIPTION
This little bug disabled linting for the entire file. Oops.