### PR TITLE
Fix some issues with the parsing of @each in the Editor

### DIFF
--- a/app/javascript/src/utils/compiler/each.js
+++ b/app/javascript/src/utils/compiler/each.js
@@ -5,7 +5,7 @@ import { openArrayBracketRegex, openToClosingArrayBracketsMap } from "./constant
 import { get } from "svelte/store"
 
 export function evaluateEachLoops(joinedItems) {
-  const eachRegex = /@each\s*\((\w+)(?:,\s+(\w+))?\s+in\s+(\[.*\]|(?:Constant)\..+)\s*\)\s*\{/g
+  const eachRegex = /@each\s*\((\w+)(?:,\s+(\w+))?\s+in\s+(\[.*\]|(?:Constant)\.[\w\s]+)\s*\)\s*\{/gs
 
   let match
   while ((match = eachRegex.exec(joinedItems)) != null) {

--- a/app/javascript/src/utils/compiler/each.js
+++ b/app/javascript/src/utils/compiler/each.js
@@ -5,7 +5,7 @@ import { openArrayBracketRegex, openToClosingArrayBracketsMap } from "./constant
 import { get } from "svelte/store"
 
 export function evaluateEachLoops(joinedItems) {
-  const eachRegex = /@each\s*\((\w+)(?:,\s+(\w+))?\s+in\s+(\[.*\]|(?:Constant)\.[\w\s]+)\s*\)\s*\{/gs
+  const eachRegex = /@each\s*\((\w+)(?:,\s+(\w+))?\s+in\s+(\[.*?\]|(?:Constant)\.[\w\s]+)\s*\)\s*\{/gs
 
   let match
   while ((match = eachRegex.exec(joinedItems)) != null) {

--- a/spec/javascript/utils/compiler/each.test.js
+++ b/spec/javascript/utils/compiler/each.test.js
@@ -90,6 +90,26 @@ describe("for.js", () => {
       `
       expect(disregardWhitespace(evaluateEachLoops(input))).toBe(disregardWhitespace(expectedOutput))
     })
+
+    test("Should be able handle inner loops", () => {
+      const input = `
+        @each (innerArray in [[a, b], [c, d]]) {
+          @each (value in Each.innerArray) {
+            Each.value;
+          }
+          ---
+        }
+      `
+      const expectedOutput = `
+        a;
+        b;
+        ---
+        c;
+        d;
+        ---
+      `
+      expect(disregardWhitespace(evaluateEachLoops(input))).toBe(disregardWhitespace(expectedOutput))
+    })
   })
 
   describe("parseArrayValues", () => {

--- a/spec/javascript/utils/compiler/each.test.js
+++ b/spec/javascript/utils/compiler/each.test.js
@@ -72,6 +72,24 @@ describe("for.js", () => {
       `
       expect(disregardWhitespace(evaluateEachLoops(input))).toBe(disregardWhitespace(expectedOutput))
     })
+
+    test("Should be able handle each loop individually", () => {
+      const input = `
+        @each (thing in [loop1]) {
+          Each.thing;
+        }
+
+        @each (thing in [loop2]) {
+          Each.thing;
+        }
+      `
+      const expectedOutput = `
+        loop1;
+
+        loop2;
+      `
+      expect(disregardWhitespace(evaluateEachLoops(input))).toBe(disregardWhitespace(expectedOutput))
+    })
   })
 
   describe("parseArrayValues", () => {

--- a/spec/javascript/utils/compiler/each.test.js
+++ b/spec/javascript/utils/compiler/each.test.js
@@ -56,6 +56,22 @@ describe("for.js", () => {
       `
       expect(disregardWhitespace(evaluateEachLoops(input))).toBe(disregardWhitespace(expectedOutput))
     })
+
+    test("Should be able use new lines inside array literals", () => {
+      const input = `@each (thing in [
+        one,
+        two,
+        three
+      ]) {
+        Each.thing;
+      }`
+      const expectedOutput = `
+        one;
+        two;
+        three;
+      `
+      expect(disregardWhitespace(evaluateEachLoops(input))).toBe(disregardWhitespace(expectedOutput))
+    })
   })
 
   describe("parseArrayValues", () => {


### PR DESCRIPTION
1. Allow array literals to have new lines

    ```haskell
    @each (value in [
      one,
      two,
      three
    ]) {
      Each.pair
    }
    ```
1. Fix detection regex overconsuming when there are multiple loops with array literals in the file

    ![showcase](https://github.com/Mitcheljager/workshop.codes/assets/6181929/32a11875-791e-4370-9b5e-c3b7bacefa8b)

1. Add a test for nested loops