### PR TITLE
Fix the Editor script importer so it is able to find rules with spaces before the name

### DIFF
--- a/app/javascript/src/components/editor/ScriptImporter.svelte
+++ b/app/javascript/src/components/editor/ScriptImporter.svelte
@@ -20,7 +20,7 @@
   }
 
   function findAllRules() {
-    const rules = value.split(/(?=(disabled rule|(?<!disabled\s+)rule)\()/g)
+    const rules = value.split(/(?=(?:disabled\s+)?rule\s*\()/g)
     const newItems = []
 
     let counter = 0
@@ -36,7 +36,7 @@
   }
 
   function getTypeName(content) {
-    const regex = new RegExp(/rule\("(.*)"\)/g)
+    const regex = new RegExp(/rule\s*\("(.*)"\)/g)
     const match = regex.exec(content)
 
     if (!match) return


### PR DESCRIPTION
This fixes an issue when importing Workshop code generated via OverPy.

I've also simplified the regex for splitting rules a bit.