### PR TITLE
Replace keyCode → key throughout the Editor code

### DIFF
--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -108,7 +108,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.keyCode == 50) {
+    if (event.ctrlKey && event.key === "2") {
       event.preventDefault()
       view.focus()
     }

--- a/app/javascript/src/components/editor/Compiler.svelte
+++ b/app/javascript/src/components/editor/Compiler.svelte
@@ -32,7 +32,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.shiftKey && event.keyCode == 83) {
+    if (event.ctrlKey && event.shiftKey && event.key === "s") {
       event.preventDefault()
       doCompile()
     }

--- a/app/javascript/src/components/editor/EditorAside.svelte
+++ b/app/javascript/src/components/editor/EditorAside.svelte
@@ -6,7 +6,7 @@
   let element
 
   function keydown(event) {
-    if (event.ctrlKey && event.keyCode == 49) {
+    if (event.ctrlKey && event.key === "1") {
       event.preventDefault()
       element.focus()
     }

--- a/app/javascript/src/components/editor/EditorWikiSearch.svelte
+++ b/app/javascript/src/components/editor/EditorWikiSearch.svelte
@@ -43,7 +43,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.keyCode == 51) {
+    if (event.ctrlKey && event.key === "3") {
       event.preventDefault()
       input.focus()
     }

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -114,7 +114,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.shiftKey && event.keyCode == 70) { // F key
+    if (event.ctrlKey && event.shiftKey && event.key === "f") {
       event.preventDefault()
       active = !active
       if (active) {
@@ -129,16 +129,16 @@
     if (input != document.activeElement && replaceInput != document.activeElement) return
     if (!active) return
 
-    if (selected && event.keyCode == 13) { // Enter key
+    if (selected && event.key === "Enter") {
       selectItem(itemMatches[selected].id)
     }
 
-    if (event.keyCode == 40) { // Down array
+    if (event.key === "ArrowDown") {
       event.preventDefault()
       setSelected(1)
     }
 
-    if (event.keyCode == 38) { // Up array
+    if (event.key === "ArrowUp") {
       event.preventDefault()
       setSelected(-1)
     }

--- a/app/javascript/src/components/editor/ItemFinder.svelte
+++ b/app/javascript/src/components/editor/ItemFinder.svelte
@@ -67,7 +67,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.keyCode == 81) {
+    if (event.ctrlKey && event.key === "q") {
       event.preventDefault()
       active = !active
       focusInput()
@@ -75,9 +75,9 @@
 
     if (!active) return
 
-    if (event.keyCode == 13) selectItem(matches[selected].id) // Enter key
-    if (event.keyCode == 40) setSelected(1) // Down key
-    if (event.keyCode == 38) setSelected(-1) // Up key
+    if (event.key === "Enter") selectItem(matches[selected].id)
+    if (event.key === "ArrowDown") setSelected(1)
+    if (event.key === "ArrowUp") setSelected(-1)
   }
 
   async function focusInput() {

--- a/app/javascript/src/components/editor/LineFinder.svelte
+++ b/app/javascript/src/components/editor/LineFinder.svelte
@@ -30,7 +30,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.keyCode == 66) {
+    if (event.ctrlKey && event.key === "b") {
       event.preventDefault()
       active = !active
       focusInput()
@@ -38,7 +38,7 @@
 
     if (!active) return
 
-    if (event.keyCode == 13) find() // Enter key
+    if (event.key === "Enter") find()
   }
 
   function find() {

--- a/app/javascript/src/components/editor/Save.svelte
+++ b/app/javascript/src/components/editor/Save.svelte
@@ -33,7 +33,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && !event.shiftKey && event.keyCode == 83) {
+    if (event.ctrlKey && !event.shiftKey && event.key === "s") {
       event.preventDefault()
       save()
     }

--- a/app/javascript/src/components/form/Tags.svelte
+++ b/app/javascript/src/components/form/Tags.svelte
@@ -45,11 +45,11 @@
   onMount(() => fillValues.forEach(code => addTag(code)))
 
   function keydown(event) {
-    if (event.key == "Backspace" || event.key == "Delete") {
-      if (input == "") removeTag(values.length - 1)
+    if (event.key === "Backspace" || event.key === "Delete") {
+      if (input === "") removeTag(values.length - 1)
     }
 
-    if (event.key == "Enter") {
+    if (event.key === "Enter") {
       event.preventDefault()
       return false
     }
@@ -59,17 +59,17 @@
 
   function inputHandleAutoComplete(event) {
     // TAB: If autocompleting, and a value can be found, add the first value
-    if (event.key == "Tab") {
+    if (event.key === "Tab") {
       event.preventDefault()
       resultsList.querySelectorAll("li.tag-item")[0].click()
     }
     // ArrowDown: focus first element of results
-    if (event.key == "ArrowDown" || event.key == "Down") {
+    if (event.key === "ArrowDown" || event.key === "Down") {
       event.preventDefault()
       resultsList.querySelector("li:first-child").focus()
     }
     // ArrowUp: focus last element of results
-    if (event.key == "ArrowUp" || event.key == "Up") {
+    if (event.key === "ArrowUp" || event.key === "Up") {
       event.preventDefault()
       resultsList.querySelector("li:last-child").focus()
     }
@@ -132,7 +132,7 @@
 
     event.preventDefault()
 
-    if (event.key == "ArrowDown" || event.key == "Down") {
+    if (event.key === "ArrowDown" || event.key === "Down") {
       if (index + 1 >= length) {
         resultsList.querySelector("li:first-child").focus()
         return
@@ -141,7 +141,7 @@
       return
     }
 
-    if (event.key == "ArrowUp" || event.key == "Up") {
+    if (event.key === "ArrowUp" || event.key === "Up") {
       if (index <= 0) {
         resultsList.querySelector("li:last-child").focus()
         return
@@ -150,12 +150,12 @@
       return
     }
 
-    if (event.key == "Enter") {
+    if (event.key === "Enter") {
       addTag(label)
       return
     }
 
-    if (event.key == "Escape" || event.key == "Esc") {
+    if (event.key === "Escape" || event.key === "Esc") {
       inputElem.focus()
     }
   }


### PR DESCRIPTION
`KeyboardEvent.key` has been a standard for years. There is no reason to use `.keyCode` anymore.

This improves readability and allows for searching for keybinds more easily.

This PR also enhances the use === instead of == (because why wouldn't you use triple equals unless in very specific cases).