### PR TITLE
Rework variable extraction in the Editor, debounce autocomplete suggestion extraction

### DIFF
--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -3,6 +3,7 @@ import { getVariables } from "../utils/compiler/variables"
 import { isAnyParentHidden } from "../utils/editor"
 import { getMixins } from "../utils/compiler/mixins"
 import { getSubroutines } from "../utils/compiler/subroutines"
+import { debounced } from "../utils/store"
 
 // Preferably keep below the debounce time for the linter, so it
 // has access to the most up-to-date information from the store.

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -39,15 +39,19 @@ export const openFolders = writable([])
 export const isSignedIn = writable(false)
 
 export const completionsMap = writable([])
-export const variablesMap = derived(flatItems, $flatItems => {
-  const { globalVariables, playerVariables } = getVariables($flatItems)
-  const subroutines = getSubroutines($flatItems)
+export const variablesMap = derived(flatItems, ($flatItems, set) => {
+  const timeout = setTimeout(() => {
+    const { globalVariables, playerVariables } = getVariables($flatItems)
+    const subroutines = getSubroutines($flatItems)
 
-  return [
-    ...globalVariables.map(v => ({ detail: "Global Variable", label: v, type: "variable" })),
-    ...playerVariables.map(v => ({ detail: "Player Variable", label: v, type: "variable" })),
-    ...subroutines.map(v => ({ detail: "Subroutine", label: v, type: "variable" }))
-  ]
+    return set([
+      ...globalVariables.map(v => ({ detail: "Global Variable", label: v, type: "variable" })),
+      ...playerVariables.map(v => ({ detail: "Player Variable", label: v, type: "variable" })),
+      ...subroutines.map(v => ({ detail: "Subroutine", label: v, type: "variable" }))
+    ])
+  }, 500)
+
+  return () => clearTimeout(timeout)
 })
 
 export const mixinsMap = derived(flatItems, $flatItems => {

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -3,7 +3,7 @@ import { getVariables } from "../utils/compiler/variables"
 import { isAnyParentHidden } from "../utils/editor"
 import { getMixins } from "../utils/compiler/mixins"
 import { getSubroutines } from "../utils/compiler/subroutines"
-import { debounced } from "../utils/store"
+import { debounced } from "../utils/debounceStore"
 
 // Preferably keep below the debounce time for the linter, so it
 // has access to the most up-to-date information from the store.

--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -15,7 +15,7 @@ const invalidVariablePrefixRegex = /[^\w.](?:\d+|D)$/
 
 const maxVariableNameLength = 32
 
-const actionsDefiningVariablesRegex = /(?:(?:Set|Modify|For) (?:Global|Player) Variable|Chase (?:Global|Player) Variable (?:Over Time|At Rate))\(/g
+const actionsDefiningVariablesRegex = /(?:(?:Set|Modify) (?:Global|Player) Variable(?: At Index)?|For (?:Global|Player) Variable|Chase (?:Global|Player) Variable (?:Over Time|At Rate))\(/g
 
 export function compileVariables(joinedItems) {
   const { globalVariables, playerVariables } = getVariables(joinedItems)

--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -1,3 +1,22 @@
+import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "../parse"
+
+/**
+ * This regex tries to capture:
+ *   "Event Player.playerVar" => ".playerVar"
+ *   "Event Player.playerVar.otherPlayerVar" => ".playerVar", ".otherPlayerVar"
+ *   "Global.myGlobalVar" => ❌ no match
+ *   "Global.myGlobalVar.myPlayerVar" => ".myPlayerVar"
+ *   "Global.myGlobalVar.myPlayerVar.otherPlayerVar" => ".myPlayerVar", ".otherPlayerVar"
+ *   "Global.Global.Global.myPlayerVar.otherPlayerVar" => "Global" (the second one), ".myPlayerVar", ".otherPlayerVar"
+ */
+const possiblePlayerVariablesRegex = /(?<![^\w.]Global)\.(?<variableName>[^\s,.[\]));"]+)/g
+
+const invalidVariablePrefixRegex = /[^\w.](?:\d+|D)$/
+
+const maxVariableNameLength = 32
+
+const actionsDefiningVariablesRegex = /(?:(?:Set|Modify|For) (?:Global|Player) Variable|Chase (?:Global|Player) Variable (?:Over Time|At Rate))\(/g
+
 export function compileVariables(joinedItems) {
   const { globalVariables, playerVariables } = getVariables(joinedItems)
 
@@ -13,14 +32,46 @@ ${ playerVariables.map((v, i) => `    ${ i }: ${ v }`).join("\n") }
 }\n\n`
 }
 
-export function getVariables(joinedItems) {
-  let globalVariables = joinedItems.match(/(?<=Global\.)[^\s,.[\]);]+/g) || []
-  globalVariables = [...globalVariables, ...(joinedItems.match(/(?<=For Global Variable\()[^\s,.[\]);]+/g) || [])]
-  globalVariables = [...new Set(globalVariables)]
+function getLiteralPlayerVariables(source, stringRanges) {
+  const literalPlayerVariables = []
+  for (const match of matchAllOutsideRanges(stringRanges, source, possiblePlayerVariablesRegex)) {
+    const matchPrefix = source.substring(match.index - maxVariableNameLength, match.index)
+    if (invalidVariablePrefixRegex.test(matchPrefix)) {
+      continue
+    }
 
-  const playerForLoops =  [...joinedItems.matchAll(/(?<=For Player Variable\()[^,]+[, \t]+([^\s,]+)/g)].map(v => v[1])
-  let playerVariables = joinedItems.match(/(?<=(Event Player|Victim|Attacker|Healer|Healee|Local Player|Host Player)\.)[^\s,.[\]);]+/g) || []
-  playerVariables = [...new Set([...playerVariables, ...playerForLoops])]
+    const { variableName } = match.groups
+    literalPlayerVariables.push(variableName)
+  }
+  return literalPlayerVariables
+}
+
+export function getVariables(joinedItems) {
+  const stringRanges = findRangesOfStrings(joinedItems)
+
+  const playerVariablesFromActions = []
+  const globalVariablesFromActions = []
+  for (const match of matchAllOutsideRanges(stringRanges, joinedItems, actionsDefiningVariablesRegex)) {
+    const argsContent = joinedItems.substring(
+      match.index + match[0].length,
+      getClosingBracket(joinedItems, "(", ")", match.index) - 1
+    )
+    const args = splitArgumentsString(argsContent)
+
+    const isPlayer = match[0].includes("Player")
+
+    if (isPlayer) {
+      playerVariablesFromActions.push(args[1])
+    } else {
+      globalVariablesFromActions.push(args[0])
+    }
+  }
+
+  const literalGlobalVariables = matchAllOutsideRanges(stringRanges, joinedItems, /(?<=Global\.)[^\s,.[\]);]+/g).map((match) => match[0])
+  const literalPlayerVariables = getLiteralPlayerVariables(joinedItems, stringRanges)
+
+  const playerVariables = [...new Set([...literalPlayerVariables, ...playerVariablesFromActions])]
+  const globalVariables = [...new Set([...literalGlobalVariables, ...globalVariablesFromActions])]
 
   return { globalVariables, playerVariables }
 }

--- a/app/javascript/src/utils/debounceStore.js
+++ b/app/javascript/src/utils/debounceStore.js
@@ -1,8 +1,8 @@
-export function debounced(cb, ms) {
+export function debounced(callback, wait) {
   return (values, set) => {
     const timeout = setTimeout(() => {
-      return set(cb(values))
-    }, ms)
+      return set(callback(values))
+    }, wait)
     return () => clearTimeout(timeout)
   }
 }

--- a/app/javascript/src/utils/parse.js
+++ b/app/javascript/src/utils/parse.js
@@ -99,7 +99,7 @@ export function findRangesOfStrings(source) {
 
   for (let i = 0; i < source.length; i++) {
     if (source[i] === "\"") {
-      if (currentRange == null) {
+      if (currentRangeIndex == null) {
         currentRangeIndex = i
       } else if (source[i - 1] !== "\\") {
         const range = [currentRangeIndex, i]

--- a/app/javascript/src/utils/parse.js
+++ b/app/javascript/src/utils/parse.js
@@ -91,3 +91,35 @@ export function removeSurroundingParenthesis(source) {
     ? removeSurroundingParenthesis(source.substring(openMatch.index + openMatch[0].length, closeMatch.index))
     : source
 }
+
+export function findRangesOfStrings(source) {
+  const foundRanges = []
+
+  let currentRangeIndex = null
+
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\"") {
+      if (currentRange == null) {
+        currentRangeIndex = i
+      } else if (source[i - 1] !== "\\") {
+        const range = [currentRangeIndex, i]
+        foundRanges.push(range)
+
+        currentRangeIndex = null
+      }
+    }
+  }
+
+  return foundRanges
+}
+
+export function matchAllOutsideRanges(ranges, content, regex) {
+  const matches = []
+  for (const match of content.matchAll(regex)) {
+    if (match.index >= ranges[0] && match.index + match[0].length <= ranges[1]) {
+      continue
+    }
+    matches.push(match)
+  }
+  return matches
+}

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -8,14 +8,16 @@ describe("variables.js", () => {
         Global.variable1 = Test;
         Set Global Variable(variable2, Test);
         Modify Global Variable(variable3, Test);
-        Chase Global Variable At Rate(variable4, Test, ...);
-        Chase Global Variable Over Time(variable5, Test, ...);
-        For Global Variable(variable6, 0, 1) {
+        Set Global Variable(variable4, Test);
+        Modify Global Variable(variable5, Test);
+        Chase Global Variable At Rate(variable6, Test, ...);
+        Chase Global Variable Over Time(variable7, Test, ...);
+        For Global Variable(variable8, 0, 1) {
           // Do something
         }
       `
       const expectedOutput = {
-        globalVariables: ["variable1", "variable2", "variable3", "variable4", "variable5", "variable6"],
+        globalVariables: ["variable1", "variable2", "variable3", "variable4", "variable5", "variable6", "variable7", "variable8"],
         playerVariables: []
       }
       expect(getVariables(input)).toEqual(expectedOutput)
@@ -31,16 +33,18 @@ describe("variables.js", () => {
         Local Player.variable6 = Test;
         Host Player.variable7 = Test;
         Set Player Variable(Event Player, variable8, Test);
-        Modify Player Variable(Event Player, variable9, Test);
-        Chase Player Variable At Rate(Event Player, variable10, Test, ...);
-        Chase Player Variable Over Time(Event Player, variable11, Test, ...);
-        For Player Variable(Event Player, variable12, 1) {
+        Set Player Variable At Index(Event Player, variable9, Test);
+        Modify Player Variable(Event Player, variable10, Test);
+        Modify Player Variable At Index(Event Player, variable11, Test);
+        Chase Player Variable At Rate(Event Player, variable12, Test, ...);
+        Chase Player Variable Over Time(Event Player, variable13, Test, ...);
+        For Player Variable(Event Player, variable14, 1) {
           // Do something
         }
       `
       const expectedOutput = {
         globalVariables: [],
-        playerVariables: ["variable1", "variable2", "variable3", "variable4", "variable5", "variable6", "variable7", "variable8", "variable9", "variable10", "variable11", "variable12"]
+        playerVariables: ["variable1", "variable2", "variable3", "variable4", "variable5", "variable6", "variable7", "variable8", "variable9", "variable10", "variable11", "variable12", "variable13", "variable14"]
       }
       expect(getVariables(input)).toEqual(expectedOutput)
     })

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -79,47 +79,45 @@ describe("variables.js", () => {
       expect(getVariables(input)).toEqual(expectedOutput)
     })
 
-    describe("Player variable edge cases", () => {
-      test("Should ignore decimals of a number", () => {
-        const input = `
-          1.234;
-          1.abc;
-        `
-        const expectedOutput = {
-          globalVariables: [],
-          playerVariables: []
-        }
-        expect(getVariables(input)).toEqual(expectedOutput)
-      })
+    test("Should ignore decimals of a number", () => {
+      const input = `
+        1.234;
+        1.abc;
+      `
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: []
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
 
-      test("Should not ignore nested variables ending in a number", () => {
-        const input = `
-          Event Player.variable1.variable2;
-        `
-        const expectedOutput = {
-          globalVariables: [],
-          playerVariables: ["variable1", "variable2"]
-        }
-        expect(getVariables(input)).toEqual(expectedOutput)
-      })
+    test("Should not ignore nested variables ending in a number", () => {
+      const input = `
+        Event Player.variable1.variable2;
+      `
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: ["variable1", "variable2"]
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
 
-      test("Should ignore constants with periods", () => {
-        const input = "Hero(D.Va)"
-        const expectedOutput = {
-          globalVariables: [],
-          playerVariables: []
-        }
-        expect(getVariables(input)).toEqual(expectedOutput)
-      })
+    test("Should ignore constants with periods", () => {
+      const input = "Hero(D.Va)"
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: []
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
 
-      test("Should not ignore player variables that look like constants with periods", () => {
-        const input = "Event Player.D.Va"
-        const expectedOutput = {
-          globalVariables: [],
-          playerVariables: ["D", "Va"]
-        }
-        expect(getVariables(input)).toEqual(expectedOutput)
-      })
+    test("Should not ignore player variables that look like constants with periods", () => {
+      const input = "Event Player.D.Va"
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: ["D", "Va"]
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
     })
 
     test("Should handle duplicate variables", () => {


### PR DESCRIPTION
- Ignore variables inside strings
- Detect variables used in Set, Modify, and Chase Variable actions
- Overhaul detection of player variables
  - Any variable delimited with a period counts as a player variable
  - Detect nested player variables. E.g.:
    ```
    Event Player.pVar1.pVar2;
    Global.gVar1.pVar1; // always assumes gVar1 is a Player
    ```
- Update tests with new features and edge cases

Aside from the unit tests, I have also tested this by importing and then recompiling the following real-world game modes: [JHEM2 v1.3.0](https://workshop.codes/JHEM2), [1DMTZ v4.0.8](https://workshop.codes/1DMTZ), [7S44N v1.1.1](https://workshop.codes/7S44N), and [PZDS2 v1.0.3](https://workshop.codes/PZDS2). All variables matched, except for variables that were given names but went unused.