### PR TITLE
feat: Adjust editor empty state

### DIFF
--- a/app/assets/stylesheets/editor/_project.scss
+++ b/app/assets/stylesheets/editor/_project.scss
@@ -1,0 +1,13 @@
+.project {
+  display: block;
+  padding: $margin / 8;
+  margin-bottom: $margin / 16;
+  border-radius: $border-radius / 2;
+  background: $bg-darker;
+  color: $text-color;
+  text-align: left;
+
+  &:hover {
+    background: darken($bg-dark, 7.5%);
+  }
+}

--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -22,6 +22,6 @@ class EditorController < ApplicationController
   private
 
   def current_user_projects(content_type)
-    @projects = current_user.present? ? current_user.projects.where(content_type: content_type).order(updated_at: :desc).select("uuid", "title", "content_type") : []
+    @projects = current_user.present? ? current_user.projects.where(content_type: content_type).order(updated_at: :desc).select("uuid", "title", "content_type", "updated_at") : []
   end
 end

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -153,15 +153,15 @@
         <CodeMirror on:search={({ detail }) => fetchArticle(`wiki/search/${ detail }`, true)} />
       {/if}
     </div>
-
-    <div class="editor__popout editor__scrollable" in:fly={$isMobile ? { y: 10, duration: 200 } : { x: 10, duration: 200 }}>
-      <EditorWiki bind:fetchArticle />
-
-      <DragHandle key="popout-width" currentSize=300 align="left" />
-    </div>
   {:else}
     <Empty />
   {/if}
+
+  <div class="editor__popout editor__scrollable" in:fly={$isMobile ? { y: 10, duration: 200 } : { x: 10, duration: 200 }}>
+    <EditorWiki bind:fetchArticle />
+
+    <DragHandle key="popout-width" currentSize=300 align="left" />
+  </div>
 </div>
 
 {#if !$isSignedIn}

--- a/app/javascript/src/components/editor/Empty.svelte
+++ b/app/javascript/src/components/editor/Empty.svelte
@@ -1,47 +1,55 @@
+<script>
+  import { isSignedIn, projects } from "../../stores/editor"
+  import { createDemoProject, createProject, fetchProject, setUrl } from "../../utils/project"
+
+  async function getProject(uuid) {
+    const data = await fetchProject(uuid)
+    if (data) setUrl(data.uuid)
+  }
+</script>
+
 <div />
 <div class="p-1/2 editor__scrollable w-100">
-  <h1 class="mb-0">Welcome to the Workshop.codes Overwatch Workshop Script Editor</h1>
-  <small class="text-dark">Catchy name, right?</small>
+  <div style="max-width: 40rem; margin: 0 auto">
+    <h1 class="mb-0">Welcome to the Workshop.codes <mark>Overwatch Workshop Script Editor</mark></h1>
+    <small class="text-dark">Catchy name, right?</small>
 
-  <div class="line-height-3/2">
-    <p>With this editor, you can create and edit your Workshop modes using a text based editor. If you have not used the Workshop before, using this editor as a starting point might be difficult. If you have never used a text based editor before but you have used the Workshop, consider this the second step to becoming a programmer!</p>
+    <div class="line-height-3/2">
+      <p>With this editor, you can create and edit your Workshop modes using a text based editor. If you have not used the Workshop before, using this editor as a starting point might be difficult. If you have never used a text based editor before but you have used the Workshop, consider this the second step to becoming a programmer!</p>
 
-    <p>
-      <strong class="text-white">Features:</strong>
-      <ul>
-        <li><mark class="text-white">Autocomplete</mark> any Workshop actions and values.</li>
-        <li><mark class="text-white">Automatic variable detecting</mark>, no need to declare your variables anywhere.</li>
-        <li>Relevant <mark class="text-white">syntax highlighting.</mark></li>
-        <li><mark class="text-white">Folders</mark>, wow!</li>
-        <li>Integrated <mark class="text-white">Wiki</mark> search.</li>
-        <li>Automatic <mark class="text-white">error detection</mark> (it's a bit limited, but still).</li>
-        <li>Reduce code repetition using <mark class="text-white">Mixins</mark>.</li>
-        <li>Easy to manage <mark class="text-white">dynamic translation keys</mark>.</li>
-      </ul>
-    <p>
+      <p>
+        <strong class="text-white">Features:</strong>
+        <ul>
+          <li><mark class="text-white">Autocomplete</mark> any Workshop actions and values.</li>
+          <li><mark class="text-white">Automatic variable detecting</mark>, no need to declare your variables anywhere.</li>
+          <li>Relevant <mark class="text-white">syntax highlighting.</mark></li>
+          <li><mark class="text-white">Folders</mark>, wow!</li>
+          <li>Integrated <mark class="text-white">Wiki</mark> search.</li>
+          <li>Automatic <mark class="text-white">error detection</mark> (it's a bit limited, but still).</li>
+          <li>Reduce code repetition using <mark class="text-white">Mixins</mark>, <mark class="text-white">Loops</mark>, and <mark class="text-white">Conditionals</mark>.</li>
+          <li>Easily manage <mark class="text-white">translations</mark> for all supported languages.</li>
+          <li><mark class="text-white">Share</mark> your projects with others (Maybe even collaborate together in the future!).</li>
+        </ul>
+      <p>
 
-    <p>Create a new project to get started. Import your existing script or start from zero.</p>
+      {#if $projects?.length}
+        <h2 class="mt-1/1">Your projects</h2>
 
-    <p class="text-white">
-      <mark>This editor is currently in alpha. Expect bugs, many of them!</mark>
-    </p>
+        {#each $projects as { title, uuid, updated_at }}
+          <button class="empty-button project" on:click={() => getProject(uuid)}>
+            <div class="text-white">{title}</div>
+            <small>Last updated: { new Date(updated_at).toLocaleString() }</small>
+          </button>
+        {/each}
+      {:else}
+        <p>Create a new project to get started. Import your existing script or start from zero.</p>
 
-    <p>
-      The editor is missing many features that would make it much more useful. Here is a list is planned features:
-      <ul>
-        <li>Automatic wiki searching on auto complete.</li>
-        <li>Optional semicolons.</li>
-        <li>More customisation; colors, fonts, sizes, etc.</li>
-      </ul>
-    <p>
+        <button class="button" on:click={() => ($isSignedIn ? createProject : createDemoProject)("My First Project")}>
+          Create your first project
+        </button>
 
-    <p>
-      <strong class="text-white">Known bugs:</strong>
-      <ul>
-        <li>Variables that are only stated in a For Global (or Player) Variable Loop will not be properly compiled.</li>
-        <li>Some actions or values may incorrectly indicate a wrong number of arguments.</li>
-        <li>Rules without names might not be properly imported.</li>
-      </ul>
-    <p>
+        <a class="button button--ghost" href="https://workshop.codes/editor?uuid=c7b3c40a-2f86-45c4-9b3f-f39d3c2974bc">Check out a sample project</a>
+      {/if}
+    </div>
   </div>
 </div>

--- a/app/javascript/src/components/editor/Empty.svelte
+++ b/app/javascript/src/components/editor/Empty.svelte
@@ -1,6 +1,7 @@
 <script>
   import { isSignedIn, projects } from "../../stores/editor"
   import { createDemoProject, createProject, fetchProject, setUrl } from "../../utils/project"
+  import CreateProjectModal from "./Modals/CreateProjectModal.svelte"
 
   async function getProject(uuid) {
     const data = await fetchProject(uuid)
@@ -33,7 +34,12 @@
       <p>
 
       {#if $projects?.length}
-        <h2 class="mt-1/1">Your projects</h2>
+        <div class="flex align-center justify-between mt-1/1">
+          <h2>Your projects</h2>
+          <CreateProjectModal let:showModalOfType on:setUrl={({ detail }) => setUrl(detail)}>
+            <button class="button button--ghost button--small" on:click={() => showModalOfType("create")}>Create new</button>
+          </CreateProjectModal>
+        </div>
 
         {#each $projects as { title, uuid, updated_at }}
           <button class="empty-button project" on:click={() => getProject(uuid)}>

--- a/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
+++ b/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
@@ -49,6 +49,8 @@
   }
 </script>
 
+<slot {showModalOfType} />
+
 {#if active}
   <div class="modal modal--top" transition:fade={{ duration: 100 }} data-ignore>
     <div class="modal__content p-0">

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -3,7 +3,7 @@
   import CreateProjectModal from "./Modals/CreateProjectModal.svelte"
   import { projects, currentProject, isSignedIn, isMobile } from "../../stores/editor"
   import { getSaveContent } from "../../utils/editor"
-  import { createProject, destroyCurrentProject, fetchProject } from "../../utils/project"
+  import { createProject, destroyCurrentProject, fetchProject, setUrl } from "../../utils/project"
   import { escapeable } from "../actions/escapeable"
   import { onMount } from "svelte"
   import { fly } from "svelte/transition"
@@ -69,13 +69,6 @@
 
     active = false
     showProjectSettings = false
-  }
-
-  function setUrl(uuid) {
-    const url = new URL(window.location)
-    if (uuid) url.searchParams.set("uuid", uuid)
-    else url.searchParams.delete("uuid")
-    window.history.replaceState("", "", url)
   }
 </script>
 

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -124,3 +124,10 @@ export async function destroyCurrentProject() {
       alert("Something went wrong while destroying your project, please try again")
     })
 }
+
+export function setUrl(uuid) {
+  const url = new URL(window.location)
+  if (uuid) url.searchParams.set("uuid", uuid)
+  else url.searchParams.delete("uuid")
+  window.history.replaceState("", "", url)
+}


### PR DESCRIPTION
This PR adjusts the initial empty state of the Editor, which appears when you are logged out, don't have any projects, or by pressing the logo in the top left.
There are multiple purposes behind these changes;
- The empty state still stated the editor was in Alpha. While this isn't false, it's also a bit meaningless at this point.
- Several of the known bugs were outdated
- It wasn't very actionable

Additionally the wiki sidebar is now always visible.

## Logged out
Showing 2 clear actions;
- "Create your first project" will create a demo project.
- "Check out sample project" will take you to my "Fishing in Antarctica", which is a nice enough demonstration of the editor.
![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/0c11a835-4790-48e6-8c5c-4cb401428402)

## Logged in without any projects
This time the "Create your first project" button will create an empty project with the title "My First Project". One click, no need to input anything yourself. Otherwise this view is identical to the logged out view
![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/15ea0a2c-cef5-40cd-895c-062391f28116)
 
## Logged in with projects
All your projects are listed with dates when you last edited them.
![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/f51b93dd-9186-4a45-acf5-6affb3842766)
