### PR TITLE
Make jsconfig.json inclusive, not exclusive

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,5 +3,5 @@
     "module": "CommonJS",
     "target": "ES2022"
   },
-  "exclude": ["node_modules"]
+  "include": ["./*.js", "./app/**/*.js", "./public/**/*.js"]
 }


### PR DESCRIPTION
VSCode complains that there is some large folder we are not taking into account and so IntelliSense will be disabled.

Instead of trying to find that large folder, we can just manually include the range of *.js files where we want IntelliSense to take effect.