### PR TITLE
When compiling mixins in the Editor, avoid name overlap by replacing arguments with longer names first

### DIFF
--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -95,11 +95,12 @@ export function extractAndInsertMixins(joinedItems) {
       replaceWith = replaceWith.replace("@contents;", contents || "")
     }
 
-    let paramIndex = 0
-    ;[... mixin.params].sort((p1, p2) => p2.key.length - p1.key.length).forEach(param => {
-      replaceWith = replaceWith.replaceAll("Mixin." + param.key, splitArguments[paramIndex]?.trim() || param.default)
-      paramIndex++
-    })
+    mixin.params
+      .map((param, index) => ({ ...param, index }))
+      .sort((p1, p2) => p2.key.length - p1.key.length)
+      .forEach(param => {
+        replaceWith = replaceWith.replaceAll("Mixin." + param.key, splitArguments[param.index]?.trim() || param.default)
+      })
 
     const closingSemicolon = (!mixin.hasContents || !contents) && joinedItems[closing + 1] == ";"
 

--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -96,7 +96,7 @@ export function extractAndInsertMixins(joinedItems) {
     }
 
     let paramIndex = 0
-    ([... mixin.params]).sort((p1, p2) => p2.key.length - p1.key.length).forEach(param => {
+    ;[... mixin.params].sort((p1, p2) => p2.key.length - p1.key.length).forEach(param => {
       replaceWith = replaceWith.replaceAll("Mixin." + param.key, splitArguments[paramIndex]?.trim() || param.default)
       paramIndex++
     })

--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -96,7 +96,7 @@ export function extractAndInsertMixins(joinedItems) {
     }
 
     let paramIndex = 0
-    mixin.params.forEach(param => {
+    ([... mixin.params]).sort((p1, p2) => p2.key.length - p1.key.length).forEach(param => {
       replaceWith = replaceWith.replaceAll("Mixin." + param.key, splitArguments[paramIndex]?.trim() || param.default)
       paramIndex++
     })

--- a/spec/javascript/utils/compiler/mixins.test.js
+++ b/spec/javascript/utils/compiler/mixins.test.js
@@ -90,11 +90,11 @@ describe("mixins.js", () => {
       expect(disregardWhitespace(extractAndInsertMixins(input))).toBe(disregardWhitespace(expectedOutput))
     })
 
-    it("Should replace Mixin variables with given arguments", () => {
+    it("Should avoid replacing one Mixin variable with the value of another when the variable names overlap", () => {
       const input = `
-        @mixin testMixin(someArg, someOtherArg) {
+        @mixin testMixin(someArg, someArg2) {
           Mixin.someArg;
-          Some Action(Mixin.someOtherArg);
+          Some Action(Mixin.someArg2);
         }
         @include testMixin(One, Two)`
 


### PR DESCRIPTION
Fixes a problem where given
```
@mixin foo(arg, arg2) {
  Mixin.arg2
}
```
`@include foo(a, b)` would render "a2" instead of "b"