### PR TITLE
Actuall check all ranges in `matchAllOutsideRanges()`

### DIFF
--- a/app/javascript/src/utils/parse.js
+++ b/app/javascript/src/utils/parse.js
@@ -102,7 +102,7 @@ export function findRangesOfStrings(source) {
       if (currentRangeIndex == null) {
         currentRangeIndex = i
       } else if (source[i - 1] !== "\\") {
-        const range = [currentRangeIndex, i]
+        const range = [currentRangeIndex, i + 1]
         foundRanges.push(range)
 
         currentRangeIndex = null
@@ -116,7 +116,8 @@ export function findRangesOfStrings(source) {
 export function matchAllOutsideRanges(ranges, content, regex) {
   const matches = []
   for (const match of content.matchAll(regex)) {
-    if (match.index >= ranges[0] && match.index + match[0].length <= ranges[1]) {
+    const isInsideRange = ranges.some((range) => match.index >= range[0] && match.index + match[0].length <= range[1])
+    if (isInsideRange) {
       continue
     }
     matches.push(match)

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -124,6 +124,15 @@ describe("variables.js", () => {
       expect(getVariables(input)).toEqual(expectedOutput)
     })
 
+    test("Should ignore variable-likes inside strings", () => {
+      const input = "Custom String(\"Hello.World I8.5.3\")"
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: []
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
+
     test("Should handle duplicate variables", () => {
       const input = `
         Global.variable1 = 10;


### PR DESCRIPTION
Fixes variable-likes inside strings being extracted (test included).

Also, expand range by one character in `findRangesOfStrings()` to account for the closing quote.