### PR TITLE
minor value & constants fix

### DIFF
--- a/config/arrays/wiki/constants.yml
+++ b/config/arrays/wiki/constants.yml
@@ -1897,7 +1897,7 @@ Projectile Effect:
   Moira Heal Orb:
     en-US: Moira Heal Orb
   Orisa Fusion Driver:
-    en-US: Orissa Fusion Driver
+    en-US: Orisa Fusion Driver
   Pharah Rocket:
     en-US: Pharah Rocket
   Reinhardt Fire Strike:

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -4030,7 +4030,7 @@ workshopSettingToggle:
   - name: Default
     description: The default value for this setting.
     type: BoolLiteral
-    default: 0
+    default: False
   - name: Sort Order
     description: The sort order of the setting relative to other settings in the same category. Settings with a higher sort order will come after settings with a lower sort order.
     type: IntLiteral


### PR DESCRIPTION
Fixed errors caused by the game no longer accepting 0 instead of false for **Workshop Setting Toggle**, and the previously misspelled **Orissa** Fusion Driver