### PR TITLE
Replace `KeyboardEvent.key` → `KeyboardEvent.code` wherever possible

### DIFF
--- a/app/javascript/src/components/editor/Compiler.svelte
+++ b/app/javascript/src/components/editor/Compiler.svelte
@@ -32,7 +32,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.shiftKey && event.key === "s") {
+    if (event.ctrlKey && event.shiftKey && event.code === "KeyS") {
       event.preventDefault()
       doCompile()
     }

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -114,7 +114,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.shiftKey && event.key === "f") {
+    if (event.ctrlKey && event.shiftKey && event.code === "KeyF") {
       event.preventDefault()
       active = !active
       if (active) {
@@ -129,16 +129,16 @@
     if (input != document.activeElement && replaceInput != document.activeElement) return
     if (!active) return
 
-    if (selected && event.key === "Enter") {
+    if (selected && event.code === "Enter") {
       selectItem(itemMatches[selected].id)
     }
 
-    if (event.key === "ArrowDown") {
+    if (event.code === "ArrowDown") {
       event.preventDefault()
       setSelected(1)
     }
 
-    if (event.key === "ArrowUp") {
+    if (event.code === "ArrowUp") {
       event.preventDefault()
       setSelected(-1)
     }

--- a/app/javascript/src/components/editor/ItemFinder.svelte
+++ b/app/javascript/src/components/editor/ItemFinder.svelte
@@ -67,7 +67,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.key === "q") {
+    if (event.ctrlKey && event.code === "KeyQ") {
       event.preventDefault()
       active = !active
       focusInput()
@@ -75,9 +75,9 @@
 
     if (!active) return
 
-    if (event.key === "Enter") selectItem(matches[selected].id)
-    if (event.key === "ArrowDown") setSelected(1)
-    if (event.key === "ArrowUp") setSelected(-1)
+    if (event.code === "Enter") selectItem(matches[selected].id)
+    if (event.code === "ArrowDown") setSelected(1)
+    if (event.code === "ArrowUp") setSelected(-1)
   }
 
   async function focusInput() {

--- a/app/javascript/src/components/editor/LineFinder.svelte
+++ b/app/javascript/src/components/editor/LineFinder.svelte
@@ -30,7 +30,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && event.key === "b") {
+    if (event.ctrlKey && event.code === "KeyB") {
       event.preventDefault()
       active = !active
       focusInput()
@@ -38,7 +38,7 @@
 
     if (!active) return
 
-    if (event.key === "Enter") find()
+    if (event.code === "Enter") find()
   }
 
   function find() {

--- a/app/javascript/src/components/editor/Save.svelte
+++ b/app/javascript/src/components/editor/Save.svelte
@@ -33,7 +33,7 @@
   }
 
   function keydown(event) {
-    if (event.ctrlKey && !event.shiftKey && event.key === "s") {
+    if (event.ctrlKey && !event.shiftKey && event.code === "KeyS") {
       event.preventDefault()
       save()
     }

--- a/app/javascript/src/components/form/Tags.svelte
+++ b/app/javascript/src/components/form/Tags.svelte
@@ -45,11 +45,11 @@
   onMount(() => fillValues.forEach(code => addTag(code)))
 
   function keydown(event) {
-    if (event.key === "Backspace" || event.key === "Delete") {
+    if (event.code === "Backspace" || event.code === "Delete") {
       if (input === "") removeTag(values.length - 1)
     }
 
-    if (event.key === "Enter") {
+    if (event.code === "Enter") {
       event.preventDefault()
       return false
     }
@@ -59,17 +59,17 @@
 
   function inputHandleAutoComplete(event) {
     // TAB: If autocompleting, and a value can be found, add the first value
-    if (event.key === "Tab") {
+    if (event.code === "Tab") {
       event.preventDefault()
       resultsList.querySelectorAll("li.tag-item")[0].click()
     }
     // ArrowDown: focus first element of results
-    if (event.key === "ArrowDown" || event.key === "Down") {
+    if (event.code === "ArrowDown") {
       event.preventDefault()
       resultsList.querySelector("li:first-child").focus()
     }
     // ArrowUp: focus last element of results
-    if (event.key === "ArrowUp" || event.key === "Up") {
+    if (event.code === "ArrowUp") {
       event.preventDefault()
       resultsList.querySelector("li:last-child").focus()
     }
@@ -132,7 +132,7 @@
 
     event.preventDefault()
 
-    if (event.key === "ArrowDown" || event.key === "Down") {
+    if (event.code === "ArrowDown" || event.code === "Down") {
       if (index + 1 >= length) {
         resultsList.querySelector("li:first-child").focus()
         return
@@ -141,7 +141,7 @@
       return
     }
 
-    if (event.key === "ArrowUp" || event.key === "Up") {
+    if (event.code === "ArrowUp" || event.code === "Up") {
       if (index <= 0) {
         resultsList.querySelector("li:last-child").focus()
         return
@@ -150,12 +150,12 @@
       return
     }
 
-    if (event.key === "Enter") {
+    if (event.code === "Enter") {
       addTag(label)
       return
     }
 
-    if (event.key === "Escape" || event.key === "Esc") {
+    if (event.code === "Escape") {
       inputElem.focus()
     }
   }

--- a/app/javascript/src/dropdown.js
+++ b/app/javascript/src/dropdown.js
@@ -33,5 +33,5 @@ function closeDropdown(event) {
 }
 
 function closeOnKeyDown(event) {
-  if (event.key === "Escape") closeDropdown(event)
+  if (event.code === "Escape") closeDropdown(event)
 }

--- a/app/javascript/src/modal.js
+++ b/app/javascript/src/modal.js
@@ -40,7 +40,7 @@ export function closeModal(event) {
 }
 
 function closeModalOnKeyDown(event) {
-  if (event.key === "Escape") closeModal()
+  if (event.code === "Escape") closeModal()
 }
 
 function getScrollbarWidth() {


### PR DESCRIPTION
Turns out `.key` returns the text the user would have typed on a text input.

For example, if the user was pressing Shift + S, then `.key` would be `"S"`. If the user wasn't pressing Shift, then `.key` would be `"s"`.

This makes the Compile keybind work again.