### PR TITLE
Rename Flashbang Explosion Sound effect to match Overwatch's changes

### DIFF
--- a/config/arrays/wiki/constants.yml
+++ b/config/arrays/wiki/constants.yml
@@ -2178,8 +2178,8 @@ Explosion Sound:
     en-US: Hanzo Sonic Arrow Initial Pulse Sound
   Lúcio Sound Barrier Cast Sound:
     en-US: Lúcio Sound Barrier Cast Sound
-  McCree Flashbang Explosion Sound:
-    en-US: McCree Flashbang Explosion Sound
+  Cassidy Flashbang Explosion Sound:
+    en-US: Cassidy Flashbang Explosion Sound
   Moira Fade Disappear Sound:
     en-US: Moira Fade Disappear Sound
   Moira Fade Reappear Sound:


### PR DESCRIPTION
With this, he who shall not be named is no longer in named in the Workshop