### PR TITLE
Allow for pressing Enter across some inputs in the Editor to execute their primary action

### DIFF
--- a/app/javascript/src/components/actions/escapeable.js
+++ b/app/javascript/src/components/actions/escapeable.js
@@ -1,7 +1,7 @@
 
 export function escapeable(node) {
   function keydown(event) {
-    if (event.code != "Escape") return
+    if (event.code !== "Escape") return
 
     node.dispatchEvent(new CustomEvent("escape"))
   }

--- a/app/javascript/src/components/actions/submittable.js
+++ b/app/javascript/src/components/actions/submittable.js
@@ -1,0 +1,26 @@
+
+export function submittable(node) {
+  const nodeIsInput = node.tagName === "INPUT"
+  const nodeIsTextarea = node.tagName === "TEXTAREA"
+
+  if (!(nodeIsInput || nodeIsTextarea)) {
+    throw new Error("submittable action is only meant to be used on inputs")
+  }
+
+  function keydown(event) {
+    if (event.code !== "Enter") return
+    if (nodeIsTextarea && (event.metaKey || event.altKey || event.shiftKey || event.ctrlKey)) return
+
+    event.preventDefault()
+
+    node.dispatchEvent(new CustomEvent("submit"))
+  }
+
+  window.addEventListener("keydown", keydown)
+
+  return {
+    destroy() {
+      window.removeEventListener("keydown", keydown)
+    }
+  }
+}

--- a/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
+++ b/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
@@ -2,6 +2,8 @@
   import Modal from "./Modal.svelte"
   import { currentProject, isSignedIn, modal } from "../../../stores/editor"
   import { createProject, renameCurrentProject } from "../../../utils/project"
+  import { escapeable } from "../../actions/escapeable"
+  import { submittable } from "../../actions/submittable"
   import { createEventDispatcher } from "svelte"
   import { fade } from "svelte/transition"
 
@@ -59,7 +61,7 @@
     <div class="p-1/2">
       <h3 class="mb-0 mt-0">Create a new project</h3>
 
-      <input type="text" class="form-input mt-1/4" placeholder="Project title" bind:value />
+      <input type="text" class="form-input mt-1/4" placeholder="Project title" bind:value use:submittable on:submit={newProject} />
 
       <button class="button w-100 mt-1/4" on:click={newProject} disabled={!value || loading}>
         {#if loading}
@@ -73,7 +75,7 @@
     <div class="p-1/2">
       <h3 class="mb-0 mt-0">Rename {$currentProject?.title || "this project"}</h3>
 
-      <input type="text" class="form-input mt-1/4" placeholder="Project title" bind:value />
+      <input type="text" class="form-input mt-1/4" placeholder="Project title" bind:value use:submittable on:submit={renameProject} />
 
       <button class="button w-100 mt-1/4" on:click={renameProject} disabled={!value || loading}>
         {#if loading}

--- a/app/javascript/src/components/editor/ScriptImporter.svelte
+++ b/app/javascript/src/components/editor/ScriptImporter.svelte
@@ -2,14 +2,18 @@
   import { items } from "../../stores/editor"
   import { createNewItem } from "../../utils/editor"
   import { getSettings } from "../../utils/parse"
+  import { submittable } from "../actions/submittable"
   import { escapeable } from "../actions/escapeable"
   import { fade } from "svelte/transition"
 
   let active = false
   let replaceScript = false
   let value = ""
+  let disallowSubmit
 
   $: if (active) value = ""
+
+  $: disallowSubmit = !value
 
   function findSettings() {
     const [start, end] = getSettings(value)
@@ -45,6 +49,8 @@
   }
 
   function submit() {
+    if (disallowSubmit) return
+
     if (replaceScript) $items = []
 
     const settings = findSettings()
@@ -64,7 +70,12 @@
     <div class="modal__content">
       Copy your snippet from inside of Overwatch and paste it in here to convert your current snippet to this project.
 
-      <textarea class="form-input form-textarea form-textarea--extra-small mt-1/4" bind:value />
+      <textarea
+        class="form-input form-textarea form-textarea--extra-small mt-1/4"
+        bind:value
+        use:submittable
+        on:submit={submit}
+      />
 
       <div class="switch-checkbox mt-1/4">
         <input
@@ -72,7 +83,8 @@
           class="switch-checkbox__input"
           autocomplete="off"
           type="checkbox"
-          bind:checked={replaceScript}>
+          bind:checked={replaceScript}
+        >
 
         <label
           class="switch-checkbox__label"
@@ -81,7 +93,7 @@
         </label>
       </div>
 
-      <button class="button w-100 mt-1/4" on:click={submit} disabled={!value}>Import</button>
+      <button class="button w-100 mt-1/4" on:click={submit} disabled={disallowSubmit}>Import</button>
     </div>
 
     <div class="modal__backdrop" on:click={() => active = false} />

--- a/app/javascript/src/components/editor/TranslationKeys/TranslationKeys.svelte
+++ b/app/javascript/src/components/editor/TranslationKeys/TranslationKeys.svelte
@@ -3,6 +3,7 @@
   import TranslationKeysSelectLanguages from "./TranslationKeysSelectLanguages.svelte"
   import { translationKeys, orderedTranslationKeys, selectedLanguages } from "../../../stores/translationKeys"
   import { copyValueToClipboard } from "../../../copy"
+  import { submittable } from "../../actions/submittable"
   import { escapeable } from "../../actions/escapeable"
   import { fade } from "svelte/transition"
 
@@ -62,7 +63,14 @@
 
           <div class="well well--dark block p-1/4 mt-1/4">
             <label class="form-label text-small" for="">Create new key</label>
-            <input bind:this={newKeyInput} class="form-input" type="text" placeholder="Some Translation Key..." />
+            <input
+              bind:this={newKeyInput}
+              class="form-input"
+              type="text"
+              placeholder="Some Translation Key..."
+              use:submittable
+              on:submit={addKey}
+            />
 
             {#if error}
               <div class="text-red mt-1/8 text-small">{error}</div>

--- a/app/javascript/src/components/editor/TranslationKeys/TranslationKeysEditStrings.svelte
+++ b/app/javascript/src/components/editor/TranslationKeys/TranslationKeysEditStrings.svelte
@@ -1,6 +1,7 @@
 <script>
   import { translationKeys, selectedLanguages } from "../../../stores/translationKeys"
   import { languageOptions } from "../../../lib/languageOptions"
+  import { submittable } from "../../actions/submittable"
   import { createEventDispatcher } from "svelte"
 
   export let selectedKey
@@ -45,7 +46,7 @@
 
 <div class="well well--dark block p-1/4 mb-1/4">
   <div class="form-group-uneven">
-    <input class="form-input" value={selectedKey} bind:this={renameInput} />
+    <input class="form-input" value={selectedKey} bind:this={renameInput} use:submittable on:submit={renameKey} />
 
     <div class="flex justify-end">
       <button class="button button--secondary button--small button--square" on:click={renameKey}>Rename</button>


### PR DESCRIPTION
Introduces a `submittable` Svelte action which captures the Enter key on inputs and calls the `submit` event.
There is a special case for textareas, where using a modifier key + Enter will not trigger the event.

Also modifies some dialogs across the editor to `use:submittable`