### PR TITLE
Fix some issues related to variable extraction and compilation

### DIFF
--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -1,5 +1,7 @@
 import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "../parse"
 
+const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
+
 /**
  * This regex tries to capture:
  *   "Event Player.playerVar" => ".playerVar"
@@ -9,7 +11,7 @@ import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArg
  *   "Global.myGlobalVar.myPlayerVar.otherPlayerVar" => ".myPlayerVar", ".otherPlayerVar"
  *   "Global.Global.Global.myPlayerVar.otherPlayerVar" => "Global" (the second one), ".myPlayerVar", ".otherPlayerVar"
  */
-const possiblePlayerVariablesRegex = /(?<![^\w.]Global)\.(?<variableName>[^\s,.[\]));"]+)/g
+const possiblePlayerVariablesRegex = /(?<![^\w.]Global)\.(?<variableName>[A-Za-z0-9_]+)/g
 
 const invalidVariablePrefixRegex = /[^\w.](?:\d+|D)$/
 
@@ -67,7 +69,7 @@ export function getVariables(joinedItems) {
     }
   }
 
-  const literalGlobalVariables = matchAllOutsideRanges(stringRanges, joinedItems, /(?<=Global\.)[^\s,.[\]);]+/g).map((match) => match[0])
+  const literalGlobalVariables = matchAllOutsideRanges(stringRanges, joinedItems, globalVariablesRegex).map((match) => match[0])
   const literalPlayerVariables = getLiteralPlayerVariables(joinedItems, stringRanges)
 
   const playerVariables = [...new Set([...literalPlayerVariables, ...playerVariablesFromActions])]

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -23,6 +23,35 @@ describe("variables.js", () => {
       expect(getVariables(input)).toEqual(expectedOutput)
     })
 
+    test("Global variables should only contain letters, numbers, or an underscore", () => {
+      // caughtByTheGame means the variable is technically an error in-game,
+      // but we leave informing users of that fact to our Linter
+      const input = `
+        Global.variable1;
+        Global.vArIaBlE;
+        Global.variable_1;
+        Global.1caughtByTheGame;
+        Global.variable2+5;
+        Global.$notAValidVariable;
+        Global.TorbTurret+Up*2;
+
+        Set Global Variable($caughtByTheGame, whatever);
+      `
+      const expectedOutput = {
+        globalVariables: [
+          "variable1",
+          "vArIaBlE",
+          "variable_1",
+          "1caughtByTheGame",
+          "variable2",
+          "TorbTurret",
+          "$caughtByTheGame"
+        ],
+        playerVariables: []
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
+
     test("Should extract simple player variables", () => {
       const input = `
         Event Player.variable1 = Test;
@@ -45,6 +74,35 @@ describe("variables.js", () => {
       const expectedOutput = {
         globalVariables: [],
         playerVariables: ["variable1", "variable2", "variable3", "variable4", "variable5", "variable6", "variable7", "variable8", "variable9", "variable10", "variable11", "variable12", "variable13", "variable14"]
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
+
+    test("Player variables should only contain letters, numbers, or an underscore", () => {
+      // caughtByTheGame means the variable is technically an error in-game,
+      // but we leave informing users of that fact to our Linter
+      const input = `
+        Event Player.variable1;
+        Event Player.vArIaBlE;
+        Event Player.variable_1;
+        Event Player.1caughtByTheGame;
+        Event Player.variable2+5;
+        Event Player.$notAValidVariable;
+        Event Player.TorbTurret+Up*2
+
+        Set Player Variable(Event Player, $caughtByTheGame, whatever);
+      `
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: [
+          "variable1",
+          "vArIaBlE",
+          "variable_1",
+          "1caughtByTheGame",
+          "variable2",
+          "TorbTurret",
+          "$caughtByTheGame"
+        ]
       }
       expect(getVariables(input)).toEqual(expectedOutput)
     })


### PR DESCRIPTION
- Restrict variable regex to only letters, numbers, or underscore
- Avoid giving default variable names a new index, causing an error on import (details in d31c8e6d1c4e361a76719b2e44ffcea2bcf26c45)

Both changes include tests.