### PR TITLE
Add "Mixin.whatever" as a valid iterable for `findEachLoopsWithInvalidIterables` the Editor linter rule

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -502,7 +502,7 @@ function findEachLoopsWithInvalidIterables(content) {
   const constants = get(workshopConstants)
 
   const regex = /@each\s*\(.+in\s+(.+)\s*\)\s*\{/g
-  const variableIterableRegex = /(Constant|For|Each)\.([\w\s]*)/
+  const variableIterableRegex = /(Constant|Mixin|For|Each)\.([\w\s]*)/
 
   let match
   while ((match = regex.exec(content)) != null) {


### PR DESCRIPTION
Fixes diagnostic errors in the following code, because "Mixin.Buttons" would not have been a valid variable iterable
```haskell
@mixin TempAllowAndPressButtons(Player, Buttons) {
	@each (button in Mixin.Buttons) {
		Allow Button(Mixin.Player, Mixin.Button);
		Press Button(Mixin.Player, Mixin.Button);    
		Disallow Button(Mixin.Player, Mixin.Button);            
	}
}

@include TempAllowAndPressButtons(Event Player, [Button(Primary Fire), Button(Jump)])
```