### PR TITLE
minor image Dropzone fixes/improvements

### DIFF
--- a/app/javascript/src/components/form/Dropzone.svelte
+++ b/app/javascript/src/components/form/Dropzone.svelte
@@ -139,7 +139,7 @@
 
   <small>{ help }</small>
 
-  <label for="" class="dropzone__button button button--secondary mt-1/4">
+  <label class="dropzone__button button button--secondary mt-1/4">
     { button }
 
     <input type="file" multiple="true" on:change={ changeInput } tabindex="-1" />

--- a/app/javascript/src/components/form/Dropzone.svelte
+++ b/app/javascript/src/components/form/Dropzone.svelte
@@ -142,7 +142,7 @@
   <label class="dropzone__button button button--secondary mt-1/4">
     { button }
 
-    <input type="file" multiple="true" accept="image/png, image/jpeg" on:change={ changeInput } tabindex="-1" />
+    <input type="file" multiple="true" accept="image/png, image/jpeg, image/jpg" on:change={ changeInput } tabindex="-1" />
   </label>
 </div>
 

--- a/app/javascript/src/components/form/Dropzone.svelte
+++ b/app/javascript/src/components/form/Dropzone.svelte
@@ -142,7 +142,7 @@
   <label class="dropzone__button button button--secondary mt-1/4">
     { button }
 
-    <input type="file" multiple="true" on:change={ changeInput } tabindex="-1" />
+    <input type="file" multiple="true" accept="image/png, image/jpeg" on:change={ changeInput } tabindex="-1" />
   </label>
 </div>
 


### PR DESCRIPTION
This PR fixes an issue which prevented the "Browse Files On Device" button from opening a prompt to select images to upload, while also adding metadata which specifies which file types can be selected.
