### PR TITLE
Remove any [linemarkers] in @each array items

### DIFF
--- a/app/javascript/src/utils/compiler/each.js
+++ b/app/javascript/src/utils/compiler/each.js
@@ -97,4 +97,7 @@ export function parseArrayValues(input) {
   }
 
   return result
+    // HACK: line finder inserts [linemarker]s on the input, which may confuse @each
+    // into thinking they are nested arrays.
+    .map((item) => item.replace(/\s*\[linemarker\].*?\[\/linemarker\]\s*/g, ""))
 }

--- a/spec/javascript/utils/compiler/each.test.js
+++ b/spec/javascript/utils/compiler/each.test.js
@@ -136,5 +136,11 @@ describe("for.js", () => {
       const expected = ["1", "(2, [3, 4])", "5"]
       expect(parseArrayValues(input)).toEqual(expected)
     })
+
+    it("Should ignore [linemarker]s", () => {
+      const input = "\n[linemarker]itemID|2[/linemarker]\t\t1, 2, 3\n[linemarker]itemID|3[/linemarker]\t\t"
+      const expected = ["1", "2", "3"]
+      expect(parseArrayValues(input)).toEqual(expected)
+    })
   })
 })


### PR DESCRIPTION
Fixes an issue where an array iterable spanning multiple lines could confuse the compiler when run with linemarkers inserted.

I'm not very happy with having to account for the linemarkers in the compiler directly, I'd much rather change the line finder and compiler so this metadata isn't mixed with the actual code. But for now this will do.

##### Example problematic snippet

```
[linemarker]d3ae10|1[/linemarker]@each (pair, i in [
[linemarker]d3ae10|2[/linemarker]	// Name, Value
[linemarker]d3ae10|3[/linemarker]	["True", True]
[linemarker]d3ae10|4[/linemarker]]) {
[linemarker]d3ae10|5[/linemarker]	@each (thing, j in Each.pair) {
[linemarker]d3ae10|6[/linemarker]		Each.thing (Each.i);
[linemarker]d3ae10|7[/linemarker]	}
[linemarker]d3ae10|8[/linemarker]}
[linemarker]d3ae10|9[/linemarker]
```

this would've previously compiled to

```
  ["True", True]
[linemarker]d3ae10|4[/linemarker (0);
```

but now it correctly compiles to

```
  "True" (0);

  True (0);
```