### PR TITLE
feat: Use localStorage as fall back for saving projects

### DIFF
--- a/app/javascript/src/components/Bugsnag.svelte
+++ b/app/javascript/src/components/Bugsnag.svelte
@@ -1,0 +1,10 @@
+<script>
+  import Bugsnag from "@bugsnag/js"
+  import { onMount } from "svelte"
+
+  export let apiKey = ""
+
+  onMount(() => {
+    Bugsnag.start(apiKey)
+  })
+</script>

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -14,6 +14,7 @@
   import LineFinder from "./LineFinder.svelte"
   import Modals from "./Modals/Modals.svelte"
   import Logo from "../icon/Logo.svelte"
+  import Bugsnag from "../Bugsnag.svelte"
 
   export let events
   export let values
@@ -22,6 +23,7 @@
   export let defaults
   export let heroes
   export let maps
+  export let bugsnagApiKey = ""
   export let _projects
   export let _isSignedIn = false
 
@@ -180,3 +182,7 @@
 {/if}
 
 <Modals />
+
+{#if bugsnagApiKey}
+  <Bugsnag apiKey={bugsnagApiKey} />
+{/if}

--- a/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
+++ b/app/javascript/src/components/editor/Modals/CreateProjectModal.svelte
@@ -1,7 +1,7 @@
 <script>
   import Modal from "./Modal.svelte"
   import { currentProject, isSignedIn, modal } from "../../../stores/editor"
-  import { createProject, renameCurrentProject } from "../../../utils/project"
+  import { createProject, renameCurrentProject, setUrl } from "../../../utils/project"
   import { submittable } from "../../actions/submittable"
 
   let loading

--- a/app/javascript/src/components/editor/Save.svelte
+++ b/app/javascript/src/components/editor/Save.svelte
@@ -20,6 +20,8 @@
 
     const content = getSaveContent()
 
+    saveToLocalStorage(content)
+
     new FetchRails(`/projects/${ $currentProject.uuid }`, { project: { content } }).post({ method: "put" })
       .then(data => {
         if (!data) throw Error("Create failed")
@@ -34,6 +36,17 @@
         alert("Something went wrong while saving, please try again")
       })
       .finally(() => loading = false)
+  }
+
+  function saveToLocalStorage(content) {
+    const currentSaved = JSON.parse(localStorage.getItem("saved-projects") || "{}")
+    localStorage.setItem("saved-projects", JSON.stringify({
+      ...currentSaved,
+      [$currentProject.uuid]: {
+        updated_at: Date.now(),
+        content
+      }
+    }))
   }
 
   async function createBackup() {

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -58,6 +58,7 @@ export async function fetchProject(uuid) {
       // This is a fallback and should not be the norm.
       if (localProject && new Date(parsedData.updated_at) < new Date(localProject.updated_at)) {
         parsedData.content = localProject.content
+        addAlert("We recovered a version of your project that wasn't fully saved.")
       }
 
       updateProject(parsedData.uuid, {

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -1,3 +1,4 @@
+import Bugsnag from "@bugsnag/js"
 import FetchRails from "../fetch-rails"
 import { addAlert } from "../lib/alerts"
 import { projects, currentProjectUUID, currentProject, items, currentItem, isSignedIn } from "../stores/editor"
@@ -59,6 +60,7 @@ export async function fetchProject(uuid) {
       if (localProject && new Date(parsedData.updated_at) < new Date(localProject.updated_at)) {
         parsedData.content = localProject.content
         addAlert("We recovered a version of your project that wasn't fully saved.")
+        Bugsnag.notify(`Project with uuid "${ uuid }" was recovered from localStorage.`)
       }
 
       updateProject(parsedData.uuid, {

--- a/app/javascript/src/utils/project.js
+++ b/app/javascript/src/utils/project.js
@@ -44,11 +44,21 @@ export function createDemoProject(title) {
 export async function fetchProject(uuid) {
   const baseUrl = "/projects/"
 
+  const localProject = getProjectFromLocalStorage(uuid)
+
   return await new FetchRails(baseUrl + uuid).get()
     .then(data => {
       if (!data) throw Error("No results")
 
       const parsedData = JSON.parse(data)
+
+      // If the project in localStorage is newer than the project from the API
+      // something may have gone wrong when saving to the API, but the localStorage
+      // was still saved as expected. In this case we use the data from localStorage.
+      // This is a fallback and should not be the norm.
+      if (localProject && new Date(parsedData.updated_at) < new Date(localProject.updated_at)) {
+        parsedData.content = localProject.content
+      }
 
       updateProject(parsedData.uuid, {
         uuid: parsedData.uuid,
@@ -75,6 +85,11 @@ export async function fetchProject(uuid) {
       console.error(error)
       alert(`Something went wrong while loading, please try again. ${ error }`)
     })
+}
+
+function getProjectFromLocalStorage(uuid) {
+  const localContent = JSON.parse(localStorage.getItem("saved-projects") || "{}")
+  return localContent[uuid]
 }
 
 export function updateProject(uuid, params) {

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -17,6 +17,7 @@
     defaults: @defaults,
     heroes: heroes,
     maps: maps,
+    bugsnagApiKey: ENV["BUGSNAG_API_KEY"],
     _projects: @projects,
     _isSignedIn: current_user.present?
   } %>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@agilie/canvas-image-cover-position": "^1.1.1",
+    "@bugsnag/js": "^7.21.0",
     "@codemirror/autocomplete": "^6.3.0",
     "@codemirror/lang-javascript": "^6.1.0",
     "@codemirror/search": "^6.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,54 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bugsnag/browser@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/browser/-/browser-7.21.0.tgz#ee623ffa57c0fe2e2e4644a24bfc2008f18f83ef"
+  integrity sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==
+  dependencies:
+    "@bugsnag/core" "^7.19.0"
+
+"@bugsnag/core@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/core/-/core-7.19.0.tgz#7663a4addb1322e8315a4012dc9db2aad3fea53b"
+  integrity sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==
+  dependencies:
+    "@bugsnag/cuid" "^3.0.0"
+    "@bugsnag/safe-json-stringify" "^6.0.0"
+    error-stack-parser "^2.0.3"
+    iserror "0.0.2"
+    stack-generator "^2.0.3"
+
+"@bugsnag/cuid@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@bugsnag/cuid/-/cuid-3.0.2.tgz#544f8e6e7e3768c8cb618ca5c5fb1eea6aacbb7e"
+  integrity sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ==
+
+"@bugsnag/js@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/js/-/js-7.21.0.tgz#0a8a9a61a43cf9b552dc70341ed49ee9da46a8f3"
+  integrity sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==
+  dependencies:
+    "@bugsnag/browser" "^7.21.0"
+    "@bugsnag/node" "^7.19.0"
+
+"@bugsnag/node@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/node/-/node-7.19.0.tgz#6a8e5d0f5e73a1d0bad19537def1a7ff65e19787"
+  integrity sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==
+  dependencies:
+    "@bugsnag/core" "^7.19.0"
+    byline "^5.0.0"
+    error-stack-parser "^2.0.2"
+    iserror "^0.0.2"
+    pump "^3.0.0"
+    stack-generator "^2.0.3"
+
+"@bugsnag/safe-json-stringify@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz#22abdcd83e008c369902976730c34c150148a758"
+  integrity sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==
+
 "@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz#217e16bb6ce63374ec7b9d2a01d007ba53ff0aff"
@@ -2949,6 +2997,11 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==
+
+byline@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+  integrity sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==
 
 bytes@3.0.0:
   version "3.0.0"
@@ -4785,6 +4838,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^2.0.2, error-stack-parser@^2.0.3:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
+  integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
+  dependencies:
+    stackframe "^1.3.4"
 
 es-abstract@^1.17.2, es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5, es-abstract@^1.20.1:
   version "1.20.4"
@@ -6973,6 +7033,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
+iserror@0.0.2, iserror@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/iserror/-/iserror-0.0.2.tgz#bd53451fe2f668b9f2402c1966787aaa2c7c0bf5"
+  integrity sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -11158,12 +11223,24 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stack-generator@^2.0.3:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.10.tgz#8ae171e985ed62287d4f1ed55a1633b3fb53bb4d"
+  integrity sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==
+  dependencies:
+    stackframe "^1.3.4"
+
 stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+stackframe@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
+  integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
We've had some reports of projects seemingly not saving after coming back to the editor. This PR doesn't fix that necessarily, but it adds a fall back. The project will now also be saved to your local storage, along with a timestamp. When fetching a project your local storage is also fetched. If the timestamp of the local storage project is newer than that of the fetched project, something may have gone wrong previously. In this case we use the content of the local storage project instead.

I thought about adding some alert along the lines of "Your local save is newer than the save on the server, do you want to use this instead?", similar to steam back ups saves perhaps, but it felt like this was too convoluted and most people won't have a clue what that means. So I decided to keep it stealthy and assume that the latest save is always the desired save.

This PR also fixes a missing import, but that's unrelated.