### PR TITLE
Improve editor detection of variables in the context of numbers

### DIFF
--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -13,7 +13,7 @@ const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
  */
 const possiblePlayerVariablesRegex = /(?<![^\w.]Global)\.(?<variableName>[A-Za-z0-9_]+)/g
 
-const invalidVariablePrefixRegex = /[^\w.](?:\d+|D)$/
+const invalidVariablePrefixRegex = /(?:(?:[^\w.])(?:\d+|D)|[^A-Za-z0-9_\]])$/
 
 const maxVariableCount = 128
 const maxVariableNameLength = 32

--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -1,5 +1,7 @@
 import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "../parse"
 
+// NOTE: The fact variable names can start with a decimal is intention.
+// We leave it to Overwatch to warn the user that this is not allowed.
 const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
 
 /**
@@ -10,10 +12,12 @@ const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
  *   "Global.myGlobalVar.myPlayerVar" => ".myPlayerVar"
  *   "Global.myGlobalVar.myPlayerVar.otherPlayerVar" => ".myPlayerVar", ".otherPlayerVar"
  *   "Global.Global.Global.myPlayerVar.otherPlayerVar" => "Global" (the second one), ".myPlayerVar", ".otherPlayerVar"
+ *
+ * NOTE: The fact variable names can start with a
  */
 const possiblePlayerVariablesRegex = /(?<![^\w.]Global)\.(?<variableName>[A-Za-z0-9_]+)/g
 
-const invalidVariablePrefixRegex = /(?:(?:[^\w.])(?:\d+|D)|[^A-Za-z0-9_\]])$/
+const invalidVariablePrefixRegex = /(?:^|(?:^|[^\w.])(?:\d+|D)|[^A-Za-z0-9_\]])$/
 
 const maxVariableCount = 128
 const maxVariableNameLength = 32

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -145,6 +145,8 @@ describe("variables.js", () => {
       const input = `
         1.234;
         1.abc;
+        .1234;
+        Wait(.1234);
       `
       const expectedOutput = {
         globalVariables: [],
@@ -184,6 +186,15 @@ describe("variables.js", () => {
 
     test("Should ignore variable-likes inside strings", () => {
       const input = "Custom String(\"Hello.World I8.5.3\")"
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: []
+      }
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
+
+    test("Should ignore variable-likes when there is a symbol behind them", () => {
+      const input = "Wait(.15)"
       const expectedOutput = {
         globalVariables: [],
         playerVariables: []

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -142,17 +142,24 @@ describe("variables.js", () => {
     })
 
     test("Should ignore decimals of a number", () => {
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: []
+      }
+
       const input = `
         1.234;
         1.abc;
         .1234;
         Wait(.1234);
       `
-      const expectedOutput = {
-        globalVariables: [],
-        playerVariables: []
-      }
       expect(getVariables(input)).toEqual(expectedOutput)
+
+      const specialCaseBeginningOfText1Input = `.1234`
+      expect(getVariables(specialCaseBeginningOfText1Input)).toEqual(expectedOutput)
+
+      const specialCaseBeginningOfText2Input = `.abcd`
+      expect(getVariables(specialCaseBeginningOfText2Input)).toEqual(expectedOutput)
     })
 
     test("Should not ignore nested variables ending in a number", () => {


### PR DESCRIPTION
- Avoid detecting variables from numbers without
 a whole number part (e.g. ".1234")
- Handle beginning of text in the regex (e.g. don't detect variables when the input is literally "0.abc" or "D.abc")
