### PR TITLE
feat: Replace category select

### DIFF
--- a/app/assets/stylesheets/elements/_well.scss
+++ b/app/assets/stylesheets/elements/_well.scss
@@ -20,6 +20,13 @@
     background: var(--bg-darker);
   }
 
+  &--scrollable {
+    max-height: 10rem;
+    overflow-y: auto;
+
+    @include styled-scrollbar;
+  }
+
   a {
     text-decoration: none;
   }

--- a/app/assets/stylesheets/utilities/_border_radius.scss
+++ b/app/assets/stylesheets/utilities/_border_radius.scss
@@ -1,3 +1,7 @@
 .br-1 {
   border-radius: $border-radius;
 }
+
+.br-1\/2 {
+  border-radius: $border-radius / 2;
+}

--- a/app/helpers/svelte_helper.rb
+++ b/app/helpers/svelte_helper.rb
@@ -1,0 +1,11 @@
+# This is a reimplementation of https://github.com/will-wow/webpacker-svelte so we can use do blocks as loading state
+
+module SvelteHelper
+  def svelte_component(name, props = {}, options = {}, &block)
+    tag = options.delete(:tag) || :div
+    data = { data: { "svelte-component": name, "svelte-props": props.to_json } }
+    content = capture(&block) if block_given?
+
+    content_tag(tag, content, options.deep_merge(data))
+  end
+end

--- a/app/javascript/packs/logged-in-user.js
+++ b/app/javascript/packs/logged-in-user.js
@@ -44,10 +44,10 @@ document.addEventListener("turbolinks:before-cache", function() {
   inscrybMde.destroy()
 
   const svelteComponents = document.querySelectorAll("[data-svelte-component]")
-  svelteComponents.forEach(element => element.innerHTML = null)
+  svelteComponents.forEach(element => element.dataset.initialized = null)
 })
 
 document.addEventListener("turbolinks:click", () => {
   const svelteComponents = document.querySelectorAll("[data-svelte-component]")
-  svelteComponents.forEach(element => element.innerHTML = null)
+  svelteComponents.forEach(element => element.dataset.initialized = null)
 })

--- a/app/javascript/packs/logged-in-user.js
+++ b/app/javascript/packs/logged-in-user.js
@@ -7,12 +7,13 @@ import Alerts from "../src/components/Alerts.svelte"
 import Dropzone from "../src/components/form/Dropzone.svelte"
 import ControlsForm from "../src/components/form/Controls.svelte"
 import SnippetForm from "../src/components/form/Snippet.svelte"
+import LimitedCheckboxes from "../src/components/form/LimitedCheckboxes.svelte"
 import TagsForm from "../src/components/form/Tags.svelte"
 import DerivativesForm from "../src/components/form/Derivatives.svelte"
 import Notifications from "../src/components/Notifications.svelte"
 import { LinkedChart, LinkedLabel } from "svelte-tiny-linked-charts"
 
-WebpackerSvelte.setup({ Alerts, Dropzone, ControlsForm, SnippetForm, TagsForm, DerivativesForm, Notifications, LinkedChart, LinkedLabel })
+WebpackerSvelte.setup({ Alerts, Dropzone, ControlsForm, SnippetForm, LimitedCheckboxes, TagsForm, DerivativesForm, Notifications, LinkedChart, LinkedLabel })
 
 import * as applyCustomCss from "../src/apply-custom-css"
 import * as blocks from "../src/blocks"

--- a/app/javascript/src/components/form/LimitedCheckboxes.svelte
+++ b/app/javascript/src/components/form/LimitedCheckboxes.svelte
@@ -1,0 +1,39 @@
+<script>
+  export let name = "checkboxes"
+  export let categories = []
+  export let selected = []
+  export let limit = 3
+
+  /**
+   * Add the selected option to the list of selected options.
+   * If you select more than the given limit the first item will be replaced with the new one.
+   * E.g if you selected 1,2,3 and now add 4, the next order will be 2,3,4
+   * @param {boolean} checked The state of event checkbox
+   * @param {string} value The given value to be added to the selected array
+   */
+  function bind(checked, value) {
+    if (!checked) {
+      selected = selected?.filter(o => o !== value)
+      return
+    }
+
+    if (selected.length >= limit) selected = [...selected.slice(1), value]
+    else selected = [...selected, value]
+  }
+</script>
+
+<div class="well well--scrollable block br-1/2">
+  {#each categories as [label, value]}
+    <div class="checkbox">
+      <input
+        type="checkbox"
+        {name}
+        {value}
+        id={name + value}
+        checked={selected?.some(o => o === value)}
+        on:change={({ target: { checked } }) => bind(checked, value)} />
+
+      <label for={name + value}>{label}</label>
+    </div>
+  {/each}
+</div>

--- a/app/javascript/src/components/form/LimitedCheckboxes.svelte
+++ b/app/javascript/src/components/form/LimitedCheckboxes.svelte
@@ -20,6 +20,21 @@
     if (selected.length >= limit) selected = [...selected.slice(1), value]
     else selected = [...selected, value]
   }
+
+  /**
+   * Generate an id for the given value.
+   * The id is based on the name and value value.
+   * The name might consist of brackets, the first bracket is replaced by an underscore,
+   * other brackets are ignored. Spaces are replaced with underscores.
+   * This results in an id like post_categories_some_value to match Rails ids.
+   * @param {string} value The given value to use for the id
+   */
+  function getId(value) {
+    return (name + "_" + value).toLowerCase()
+      .replace("[", "_")
+      .replace(/\[|\]/g, "")
+      .replace(" ", "_")
+  }
 </script>
 
 <div class="well well--scrollable block br-1/2">
@@ -29,11 +44,11 @@
         type="checkbox"
         {name}
         {value}
-        id={name + value}
+        id={getId(value)}
         checked={selected?.some(o => o === value)}
         on:change={({ target: { checked } }) => bind(checked, value)} />
 
-      <label for={name + value}>{label}</label>
+      <label for={getId(value)}>{label}</label>
     </div>
   {/each}
 </div>

--- a/app/javascript/src/components/form/LimitedCheckboxes.svelte
+++ b/app/javascript/src/components/form/LimitedCheckboxes.svelte
@@ -48,7 +48,7 @@
         checked={selected?.some(o => o === value)}
         on:change={({ target: { checked } }) => bind(checked, value)} />
 
-      <label for={getId(value)}>{label}</label>
+      <label class="w-100" for={getId(value)}>{label}</label>
     </div>
   {/each}
 </div>

--- a/app/javascript/src/components/form/LimitedCheckboxes.svelte
+++ b/app/javascript/src/components/form/LimitedCheckboxes.svelte
@@ -1,6 +1,6 @@
 <script>
   export let name = "checkboxes"
-  export let categories = []
+  export let options = []
   export let selected = []
   export let limit = 3
 
@@ -26,7 +26,7 @@
    * The id is based on the name and value value.
    * The name might consist of brackets, the first bracket is replaced by an underscore,
    * other brackets are ignored. Spaces are replaced with underscores.
-   * This results in an id like post_categories_some_value to match Rails ids.
+   * This results in an id like post_options_some_value to match Rails ids.
    * @param {string} value The given value to use for the id
    */
   function getId(value) {
@@ -38,7 +38,7 @@
 </script>
 
 <div class="well well--scrollable block br-1/2">
-  {#each categories as [label, value]}
+  {#each options as [label, value]}
     <div class="checkbox">
       <input
         type="checkbox"

--- a/app/views/posts/form/tabs/_settings.html.erb
+++ b/app/views/posts/form/tabs/_settings.html.erb
@@ -151,7 +151,9 @@
     <%= svelte_component "LimitedCheckboxes", {
                          name: "post[categories][]",
                          categories: categories.map { |category| [category[current_locale], category["en"]] },
-                         selected: @post.categories || [] } %>
+                         selected: @post.categories || [] } do %>
+      <%= form.check_box :categories, { multiple: true, checked: false }, "Team Deathmatch" %>
+    <% end %>
   </div>
 
   <div class="form-group">

--- a/app/views/posts/form/tabs/_settings.html.erb
+++ b/app/views/posts/form/tabs/_settings.html.erb
@@ -150,7 +150,7 @@
 
     <%= svelte_component "LimitedCheckboxes", {
                          name: "post[categories][]",
-                         categories: categories.map { |category| [category[current_locale], category["en"]] },
+                         options: categories.map { |category| [category[current_locale], category["en"]] },
                          selected: @post.categories || [] } do %>
       <%= form.check_box :categories, { multiple: true, checked: false, include_hidden: false }, "Team Deathmatch" %>
     <% end %>

--- a/app/views/posts/form/tabs/_settings.html.erb
+++ b/app/views/posts/form/tabs/_settings.html.erb
@@ -148,11 +148,10 @@
       <%= t("posts.form.categories.help") %>
     </div>
 
-    <%= form.select :categories, options_for_select(
-                                  categories.map { |category| [category[current_locale], category["en"]] },
-                                  (@post.categories if @post.categories)),
-                                { include_hidden: false },
-                                { multiple: true, size: 5, class: "form-select" } %>
+    <%= svelte_component "LimitedCheckboxes", {
+                         name: "post[categories][]",
+                         categories: categories.map { |category| [category[current_locale], category["en"]] },
+                         selected: @post.categories || [] } %>
   </div>
 
   <div class="form-group">

--- a/app/views/posts/form/tabs/_settings.html.erb
+++ b/app/views/posts/form/tabs/_settings.html.erb
@@ -152,7 +152,7 @@
                          name: "post[categories][]",
                          categories: categories.map { |category| [category[current_locale], category["en"]] },
                          selected: @post.categories || [] } do %>
-      <%= form.check_box :categories, { multiple: true, checked: false }, "Team Deathmatch" %>
+      <%= form.check_box :categories, { multiple: true, checked: false, include_hidden: false }, "Team Deathmatch" %>
     <% end %>
   </div>
 

--- a/features/step_definitions/post_stepdefs.rb
+++ b/features/step_definitions/post_stepdefs.rb
@@ -90,9 +90,10 @@ def fill_in_post_form
 
   # Settings
   click_on "Settings"
-  post_attrs[:categories].each do |category|
-    select(category, from: "post_categories")
+  post_attrs[:categories].first(3).each do |category|
+    check(category)
   end
+
   # Simulating actualy clicking/pressing/dragging is a pain with Capybara
   slider = page.evaluate_script "slider=document.querySelector('[data-role=\"num-player-slider\"][data-type=\"post\"]');"
   page.execute_script "const slider = arguments[0]; slider.noUiSlider.set([#{ post_attrs[:min_players] }, #{ post_attrs[:max_players] }]);", slider

--- a/patches/webpacker-svelte+1.0.0.patch
+++ b/patches/webpacker-svelte+1.0.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/webpacker-svelte/dist/webpacker-svelte.js b/node_modules/webpacker-svelte/dist/webpacker-svelte.js
+index b92f3ab..c4b9c0e 100644
+--- a/node_modules/webpacker-svelte/dist/webpacker-svelte.js
++++ b/node_modules/webpacker-svelte/dist/webpacker-svelte.js
+@@ -130,6 +130,7 @@ const WebpackerSvelte = {
+       const component = registeredComponents[className];
+ 
+       if (component) {
++        node.innerHTML = ""
+         if (node.innerHTML.length === 0) this.render(node, component);
+       } else {
+         console.error(

--- a/patches/webpacker-svelte+1.0.0.patch
+++ b/patches/webpacker-svelte+1.0.0.patch
@@ -1,12 +1,17 @@
 diff --git a/node_modules/webpacker-svelte/dist/webpacker-svelte.js b/node_modules/webpacker-svelte/dist/webpacker-svelte.js
-index b92f3ab..c4b9c0e 100644
+index b92f3ab..59628cb 100644
 --- a/node_modules/webpacker-svelte/dist/webpacker-svelte.js
 +++ b/node_modules/webpacker-svelte/dist/webpacker-svelte.js
-@@ -130,6 +130,7 @@ const WebpackerSvelte = {
+@@ -130,7 +130,11 @@ const WebpackerSvelte = {
        const component = registeredComponents[className];
  
        if (component) {
+-        if (node.innerHTML.length === 0) this.render(node, component);
++        if (node.dataset.initialized === "true" && node.dataset.innerHTML) continue
 +        node.innerHTML = ""
-         if (node.innerHTML.length === 0) this.render(node, component);
++        node.dataset.initialized = true
++
++        this.render(node, component);
        } else {
          console.error(
+           `webpacker-svelte: can not render a component that has not been registered: ${className}`

--- a/spec/support/post_helpers.rb
+++ b/spec/support/post_helpers.rb
@@ -13,7 +13,7 @@ module Helpers
       # Settings
       click_on "Settings"
       post_attrs[:categories].each do |category|
-        select(category, from: "post_categories")
+        check(category)
       end
       # Simulating actualy clicking/pressing/dragging is a pain with Capybara
       slider = page.evaluate_script "slider=document.querySelector('[data-role=\"num-player-slider\"][data-type=\"post\"]');"

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -137,7 +137,7 @@ def fill_in_post_details
   fill_in "post_tags", with: @post.tags
   fill_in "post_version", with: @post.version
 
-  find("#post_categories").find("option[value='Team Deathmatch']").select_option
+  find("#post[categories][]Team Deathmatch").set(true)
   find("#post_heroes_reinhardt").set(true)
   find("#post_maps_hanamura").set(true)
   find("#post_min_players", visible: false).set(1)

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -137,7 +137,7 @@ def fill_in_post_details
   fill_in "post_tags", with: @post.tags
   fill_in "post_version", with: @post.version
 
-  find("#post[categories][]Team Deathmatch").set(true)
+  find("#post_categories_team_deathmatch").set(true)
   find("#post_heroes_reinhardt").set(true)
   find("#post_maps_hanamura").set(true)
   find("#post_min_players", visible: false).set(1)


### PR DESCRIPTION
This PR replaces the multi select box for categories with a svelte component. The multi select is unpredictable and annoying to use. By using regular checkboxes we make the whole UX make clear, as you don't need to hold an additional button to select more categories. The checkboxes automatically limit themselves to 3 items, making the validation much simpler as well. Even if you didn't read can you only select 3, you will be forced to. The old validation is still in place in case someone tries to game the system.

![category-select](https://github.com/Mitcheljager/workshop.codes/assets/12848235/8d3a4e75-b247-4ad7-a88a-6edaca857c0d)
