### PR TITLE
feat: Autoplay video

### DIFF
--- a/app/assets/stylesheets/elements/_video.scss
+++ b/app/assets/stylesheets/elements/_video.scss
@@ -3,11 +3,6 @@
 	padding-bottom: 56.25%;
 	height: 0;
 	background: $bg-darker;
-
-	video {
-		width: 100%;
-		height: auto;
-	}
 }
 
 .video__iframe {
@@ -16,4 +11,9 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
+}
+
+video {
+	width: 100%;
+	height: auto;
 }

--- a/app/assets/stylesheets/elements/_video.scss
+++ b/app/assets/stylesheets/elements/_video.scss
@@ -14,6 +14,7 @@
 }
 
 video {
+	display: block;
 	width: 100%;
 	height: auto;
 }

--- a/app/assets/stylesheets/general/_form.scss
+++ b/app/assets/stylesheets/general/_form.scss
@@ -181,6 +181,7 @@
   input {
     -webkit-appearance: none;
     appearance: none;
+    flex: 0 0 1rem;
     width: 1rem;
     height: 1rem;
     margin: 1px 0 0;

--- a/app/assets/stylesheets/logged_in_user/_inscryb-mde.scss
+++ b/app/assets/stylesheets/logged_in_user/_inscryb-mde.scss
@@ -72,7 +72,7 @@
   right: 0;
   top: 2rem;
   max-height: 300px;
-  width: 150px;
+  width: 220px;
   background: $bg-dark;
   border: 1px solid $text-color-dark;
   border-radius: $border-radius;
@@ -84,6 +84,10 @@
   small {
     display: block;
     padding: .5rem;
+  }
+
+  .checkbox label {
+    padding-left: .5rem;
   }
 }
 

--- a/app/assets/stylesheets/logged_in_user/_switch.scss
+++ b/app/assets/stylesheets/logged_in_user/_switch.scss
@@ -103,7 +103,8 @@
     pointer-events: all;
     transition: left 100ms;
 
-    .switch-checkbox__input:checked + & {
+    .switch-checkbox__input:checked + &,
+    .switch-checkbox--active & {
       left: calc(1rem + 6px);
       background: $white;
     }
@@ -116,7 +117,8 @@
     pointer-events: all;
 
     .switch-checkbox__input:checked + &,
-    .switch-checkbox:focus-within & {
+    .switch-checkbox:focus-within &,
+    .switch-checkbox--active & {
       border-color: $white;
     }
   }

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -98,11 +98,10 @@ module ContentHelper
       autoplay = $2.blank? ? nil : true
 
       video_element = ActionController::Base.helpers.video_tag("",
-        data: { role: "lazy-video", src: video_url },
+        data: { role: "lazy-video", src: video_url, autoplay: autoplay },
         playsinline: true,
         controls: !autoplay,
         muted: autoplay,
-        autoplay: autoplay,
         loop: autoplay)
 
       "<div class='bg-darker'>#{video_element}</div>"
@@ -164,7 +163,7 @@ module ContentHelper
     ActionController::Base.helpers.sanitize(
       markdown(text, rendererOptions: rendererOptions),
       tags: %w(div span hr style mark dl dd dt img details summary a b iframe audio video source blockquote pre code br p table td tr th thead tbody ul ol li h1 h2 h3 h4 h5 h6 em i strong),
-      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-src data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls playsinline loop muted autoplay)
+      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-autoplay data-src data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls playsinline loop muted)
     )
   end
 

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -93,8 +93,18 @@ module ContentHelper
   end
 
   def markdown_video(text)
-    text.gsub /\[video\s(https?:\/\/\S+)\]/ do
-      "<div class='video'>#{ActionController::Base.helpers.video_tag($1, controls: true)}</div>"
+    text.gsub /\[video\s(https?:\/\/\S+)(?:\s(autoplay))?\]/ do
+      video_url = $1
+      autoplay = $2.blank? ? nil : true
+
+      video_element = ActionController::Base.helpers.video_tag(video_url,
+        playsinline: true,
+        controls: !autoplay,
+        muted: autoplay,
+        autoplay: autoplay,
+        loop: autoplay)
+
+      "<div class='video'>#{video_element}</div>"
     end
   end
 
@@ -153,7 +163,7 @@ module ContentHelper
     ActionController::Base.helpers.sanitize(
       markdown(text, rendererOptions: rendererOptions),
       tags: %w(div span hr style mark dl dd dt img details summary a b iframe audio video source blockquote pre code br p table td tr th thead tbody ul ol li h1 h2 h3 h4 h5 h6 em i strong),
-      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls)
+      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls playsinline loop muted autoplay)
     )
   end
 

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -97,14 +97,15 @@ module ContentHelper
       video_url = $1
       autoplay = $2.blank? ? nil : true
 
-      video_element = ActionController::Base.helpers.video_tag(video_url,
+      video_element = ActionController::Base.helpers.video_tag("",
+        data: { role: "lazy-video", src: video_url },
         playsinline: true,
         controls: !autoplay,
         muted: autoplay,
         autoplay: autoplay,
         loop: autoplay)
 
-      "<div class='video'>#{video_element}</div>"
+      "<div class='bg-darker'>#{video_element}</div>"
     end
   end
 
@@ -163,7 +164,7 @@ module ContentHelper
     ActionController::Base.helpers.sanitize(
       markdown(text, rendererOptions: rendererOptions),
       tags: %w(div span hr style mark dl dd dt img details summary a b iframe audio video source blockquote pre code br p table td tr th thead tbody ul ol li h1 h2 h3 h4 h5 h6 em i strong),
-      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls playsinline loop muted autoplay)
+      attributes: %w(style href id class src title width height frameborder allow allowfullscreen alt loading data-src data-action data-target data-tab data-hide-on-close data-toggle-content data-modal data-role data-url data-gallery controls playsinline loop muted autoplay)
     )
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,6 +25,7 @@ import * as getSnippet from "../src/get-snippet"
 import * as getVerifiedUsers from "../src/get-verified-users"
 import * as imagePreview from "../src/image-preview"
 import * as infiniteScroll from "../src/infinite-scroll"
+import * as lazyVideo from "../src/lazy-video"
 import * as microlight from "../src/microlight"
 import * as modal from "../src/modal"
 import * as navigation from "../src/navigation"
@@ -54,6 +55,7 @@ document.addEventListener("turbolinks:load", function() {
   getVerifiedUsers.bind()
   imagePreview.bind()
   infiniteScroll.bind()
+  lazyVideo.bind()
   modal.bind()
   navigation.bind()
   revealByCheckbox.bind()

--- a/app/javascript/src/inscryb-mde.js
+++ b/app/javascript/src/inscryb-mde.js
@@ -277,7 +277,7 @@ class InitialiseInscrybeMDE {
     dropdownElement.classList.add("editor-dropdown")
 
     const textElement = document.createElement("small")
-    textElement.innerText = "Upload an image. Alternative, with an image on your clipboard simply paste it in the text area."
+    textElement.innerText = "Upload an image. Alternatively, with an image on your clipboard simply paste it in the text area."
 
     const randomId = Math.random().toString().substr(2, 8)
     const labelElement = document.createElement("label")

--- a/app/javascript/src/inscryb-mde.js
+++ b/app/javascript/src/inscryb-mde.js
@@ -268,37 +268,38 @@ class InitialiseInscrybeMDE {
 
     button.classList.toggle("dropdown-open")
 
-    if (button.classList.contains("dropdown-open")) {
-      const dropdownElement = document.createElement("div")
-      dropdownElement.classList.add("editor-dropdown")
-
-      const textElement = document.createElement("small")
-      textElement.innerText = "Upload an image. Alternative, with an image on your clipboard simply paste it in the text area."
-
-      const randomId = Math.random().toString().substr(2, 8)
-      const labelElement = document.createElement("label")
-      const labelClasslist = ["button", "button--small", "mt-1/4", "w-100"]
-      labelElement.for = randomId
-      labelElement.innerText = "Upload image"
-      labelElement.classList.add(...labelClasslist)
-
-      const inputElement = document.createElement("input")
-      inputElement.type = "file"
-      inputElement.id = randomId
-      inputElement.accept = "image/png, image/jpeg, image/jpg"
-      inputElement.classList.add("hidden-field")
-
-      inputElement.addEventListener("change", event => { new InscrybeInsertImage(event, this.codemirror).input() })
-      labelElement.addEventListener("click", () => { inputElement.click() })
-
-      document.body.append(inputElement)
-
-      textElement.append(labelElement)
-      dropdownElement.append(textElement)
-      button.append(dropdownElement)
-    } else {
+    if (!button.classList.contains("dropdown-open")) {
       button.querySelector(".editor-dropdown").remove()
+      return
     }
+
+    const dropdownElement = document.createElement("div")
+    dropdownElement.classList.add("editor-dropdown")
+
+    const textElement = document.createElement("small")
+    textElement.innerText = "Upload an image. Alternative, with an image on your clipboard simply paste it in the text area."
+
+    const randomId = Math.random().toString().substr(2, 8)
+    const labelElement = document.createElement("label")
+    const labelClasslist = ["button", "button--small", "mt-1/4", "w-100"]
+    labelElement.for = randomId
+    labelElement.innerText = "Upload image"
+    labelElement.classList.add(...labelClasslist)
+
+    const inputElement = document.createElement("input")
+    inputElement.type = "file"
+    inputElement.id = randomId
+    inputElement.accept = "image/png, image/jpeg, image/jpg"
+    inputElement.classList.add("hidden-field")
+
+    inputElement.addEventListener("change", event => { new InscrybeInsertImage(event, this.codemirror).input() })
+    labelElement.addEventListener("click", () => { inputElement.click() })
+
+    document.body.append(inputElement)
+
+    textElement.append(labelElement)
+    dropdownElement.append(textElement)
+    button.append(dropdownElement)
   }
 
   toggleVideoUploader() {
@@ -306,37 +307,65 @@ class InitialiseInscrybeMDE {
 
     button.classList.toggle("dropdown-open")
 
-    if (button.classList.contains("dropdown-open")) {
-      const dropdownElement = document.createElement("div")
-      dropdownElement.classList.add("editor-dropdown")
-
-      const textElement = document.createElement("small")
-      textElement.innerText = "Upload a video. Limited to mp4 filetype and 50mb filesize."
-
-      const randomId = Math.random().toString().substr(2, 8)
-      const labelElement = document.createElement("label")
-      const labelClasslist = ["button", "button--small", "mt-1/4", "w-100"]
-      labelElement.for = randomId
-      labelElement.innerText = "Upload video"
-      labelElement.classList.add(...labelClasslist)
-
-      const inputElement = document.createElement("input")
-      inputElement.type = "file"
-      inputElement.id = randomId
-      inputElement.accept = "video/mp4"
-      inputElement.classList.add("hidden-field")
-
-      inputElement.addEventListener("change", event => { new InscrybeInsertVideo(event, this.codemirror).input() })
-      labelElement.addEventListener("click", () => { inputElement.click() })
-
-      document.body.append(inputElement)
-
-      textElement.append(labelElement)
-      dropdownElement.append(textElement)
-      button.append(dropdownElement)
-    } else {
+    if (!button.classList.contains("dropdown-open")) {
       button.querySelector(".editor-dropdown").remove()
+      return
     }
+
+    const dropdownElement = document.createElement("div")
+    dropdownElement.classList.add("editor-dropdown")
+
+    const textElement = document.createElement("small")
+    textElement.innerText = "Upload a video. Limited to mp4 filetype and 50mb filesize."
+
+    const randomId = Math.random().toString().substr(2, 8)
+    const labelElement = document.createElement("label")
+    const labelClasslist = ["button", "button--small", "mt-1/8", "w-100"]
+    labelElement.for = randomId
+    labelElement.innerText = "Upload video"
+    labelElement.classList.add(...labelClasslist)
+
+    const inputElement = document.createElement("input")
+    inputElement.type = "file"
+    inputElement.id = randomId
+    inputElement.accept = "video/mp4"
+    inputElement.classList.add("hidden-field")
+
+    inputElement.addEventListener("change", event => new InscrybeInsertVideo(event, this.codemirror).input())
+    labelElement.addEventListener("click", () => inputElement.click())
+
+    const autoplayCheckboxElement = document.createElement("div")
+    autoplayCheckboxElement.classList.add("switch-checkbox", "mt-1/8", "mb-1/8")
+    autoplayCheckboxElement.addEventListener("click", event => {
+      event.preventDefault()
+      event.stopPropagation()
+
+      const checkbox = event.target.closest(".switch-checkbox")
+      if (!checkbox) return
+      const input = document.querySelector("#autoplay" + randomId)
+      if (input) input.checked = !input.checked
+      checkbox.classList.toggle("switch-checkbox--active", input.checked)
+    })
+
+    const autoplayLabelElement = document.createElement("label")
+    autoplayLabelElement.classList.add("switch-checkbox__label")
+    autoplayLabelElement.innerText = "Loop and autoplay on mute"
+    autoplayLabelElement.for = "autoplay" + randomId
+
+    const autoplayInputElement = document.createElement("input")
+    autoplayInputElement.classList.add("switch-checkbox__input")
+    autoplayInputElement.type = "checkbox"
+    autoplayInputElement.id = "autoplay" + randomId
+
+    autoplayCheckboxElement.append(autoplayLabelElement)
+
+    document.body.append(autoplayInputElement)
+    document.body.append(inputElement)
+
+    textElement.append(autoplayCheckboxElement)
+    textElement.append(labelElement)
+    dropdownElement.append(textElement)
+    button.append(dropdownElement)
   }
 
   toggleWikiSearch() {
@@ -344,65 +373,65 @@ class InitialiseInscrybeMDE {
 
     button.classList.toggle("dropdown-open")
 
-    if (button.classList.contains("dropdown-open")) {
-      const dropdownElement = document.createElement("div")
-      dropdownElement.classList.add("editor-dropdown")
-
-      dropdownElement.innerHTML = `
-        <small>Search the Wiki and insert a link to an article.</small>
-        <input type="text" class="form-input bg-darker" placeholder="Search the Wiki" />
-        <div data-role="results"></div>
-      `
-
-      button.append(dropdownElement)
-
-      const input = button.querySelector("input")
-      input.focus()
-
-      input.addEventListener("click", event => {
-        event.stopPropagation()
-        event.preventDefault()
-
-        input.focus()
-      })
-
-      const getSearchResults = debounce(event => {
-        if (!event.target.value) return
-
-        const resultsElement = button.querySelector("[data-role='results']")
-        resultsElement.innerHTML = "<small>Searching...</small>"
-
-        new FetchRails(`/wiki/search/${ event.target.value }.json`).get()
-          .then(data => {
-            data = JSON.parse(data)
-            resultsElement.innerHTML = ""
-
-            if (!data.length) {
-              resultsElement.innerHTML = "<small>No results found</small>"
-              return
-            }
-
-            data.forEach(item => {
-              const itemElement = document.createElement("a")
-              itemElement.classList.add("editor-dropdown__item")
-              itemElement.innerText = item.title
-              itemElement.addEventListener("click", () => { this.insertLink(`/wiki/articles/${ decodeURIComponent(item.slug) }`) })
-
-              const categoryElement = document.createElement("span")
-              categoryElement.style = "opacity: .5; font-size: .8em"
-              categoryElement.innerText = " " + item.category.title
-
-
-              itemElement.append(categoryElement)
-              resultsElement.append(itemElement)
-            })
-          })
-      }, 500)
-
-      input.addEventListener("input", getSearchResults)
-    } else {
+    if (!button.classList.contains("dropdown-open")) {
       button.querySelector(".editor-dropdown").remove()
+      return
     }
+    const dropdownElement = document.createElement("div")
+    dropdownElement.classList.add("editor-dropdown")
+
+    dropdownElement.innerHTML = `
+      <small>Search the Wiki and insert a link to an article.</small>
+      <input type="text" class="form-input bg-darker" placeholder="Search the Wiki" />
+      <div data-role="results"></div>
+    `
+
+    button.append(dropdownElement)
+
+    const input = button.querySelector("input")
+    input.focus()
+
+    input.addEventListener("click", event => {
+      event.stopPropagation()
+      event.preventDefault()
+
+      input.focus()
+    })
+
+    const getSearchResults = debounce(event => {
+      if (!event.target.value) return
+
+      const resultsElement = button.querySelector("[data-role='results']")
+      resultsElement.innerHTML = "<small>Searching...</small>"
+
+      new FetchRails(`/wiki/search/${ event.target.value }.json`).get()
+        .then(data => {
+          data = JSON.parse(data)
+          resultsElement.innerHTML = ""
+
+          if (!data.length) {
+            resultsElement.innerHTML = "<small>No results found</small>"
+            return
+          }
+
+          data.forEach(item => {
+            const itemElement = document.createElement("a")
+            itemElement.classList.add("editor-dropdown__item")
+            itemElement.innerText = item.title
+            itemElement.addEventListener("click", () => { this.insertLink(`/wiki/articles/${ decodeURIComponent(item.slug) }`) })
+
+            const categoryElement = document.createElement("span")
+            categoryElement.style = "opacity: .5; font-size: .8em"
+            categoryElement.innerText = " " + item.category.title
+
+
+            itemElement.append(categoryElement)
+            resultsElement.append(itemElement)
+          })
+        })
+    }, 500)
+
+    input.addEventListener("input", getSearchResults)
   }
 
   insertLink(link = "") {

--- a/app/javascript/src/inscryb-mde.js
+++ b/app/javascript/src/inscryb-mde.js
@@ -4,6 +4,7 @@ import InscrybeInsertVideo from "./inscrybe-mde-insert-video"
 import FetchRails from "./fetch-rails"
 import { buildInputSortable, insertBlockTemplate, removeBlockTemplate } from "./blocks"
 import debounce from "./debounce"
+import * as lazyVideo from "../src/lazy-video"
 
 let editors = []
 
@@ -135,6 +136,7 @@ class InitialiseInscrybeMDE {
         new FetchRails("/parse-markdown", { post: { description: plainText } })
           .post().then(data => {
             preview.innerHTML = data
+            lazyVideo.bind()
           })
 
         return "<div class=`p-1/2`><div class=`spinner`></div></div>"

--- a/app/javascript/src/inscrybe-mde-insert-video.js
+++ b/app/javascript/src/inscrybe-mde-insert-video.js
@@ -7,11 +7,13 @@ export default class InscrybeInsertVideo {
     this.event = event,
     this.editor = editor,
     this.file = ""
+    this.id = ""
   }
 
   input() {
     const items = this.event.target.files
     this.file = items[0]
+    this.id = this.event.target.id
 
     this.isFileVideo()
   }
@@ -90,10 +92,12 @@ export default class InscrybeInsertVideo {
   replaceMarkerWithVideo(randomId, url) {
     const marker = this.editor.getAllMarks().find(m => m.randomId == randomId)
 
+    const autoplay = document.querySelector("#autoplay" + this.id)?.checked
+
     const cursorPosition = this.editor.getCursor()
     const position = marker.find()
     this.editor.setSelection(position, position)
-    this.editor.replaceSelection(`[video ${ url }]`)
+    this.editor.replaceSelection(`[video ${ url }${ autoplay ? " autoplay" : "" }]`)
 
     this.editor.setSelection(cursorPosition, cursorPosition)
 

--- a/app/javascript/src/lazy-video.js
+++ b/app/javascript/src/lazy-video.js
@@ -1,0 +1,16 @@
+export function bind() {
+  const elements = document.querySelectorAll("[data-role~='lazy-video']")
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (!entry.isIntersecting) return
+
+      const element = entry.target
+
+      element.src = element.dataset.src
+      observer.unobserve(element)
+    })
+  })
+
+  elements.forEach(element => observer.observe(element))
+}

--- a/app/javascript/src/lazy-video.js
+++ b/app/javascript/src/lazy-video.js
@@ -8,6 +8,7 @@ export function bind() {
       const element = entry.target
 
       element.src = element.dataset.src
+      if (element.dataset.autoplay === "true") element.play()
       observer.unobserve(element)
     })
   })


### PR DESCRIPTION
This PR adds an optional toggle to autoplay videos. When videos are marked as autoplay they have no controls, are muted, and loop.
To accommodate this all videos will now lazy load, which is done through an intersection observer.

Set set a video as autoplay you can use the toggle in the video uploader or add "autoplay" to the end of the video tag like `[video http://some_url autoplay]`

## Toggle in video uploader
![toggle](https://github.com/Mitcheljager/workshop.codes/assets/12848235/49f196af-015e-43e1-8238-a9e79dd662aa)

## Proof of lazy loading
https://github.com/Mitcheljager/workshop.codes/assets/12848235/d33e724a-b389-4a49-a26b-c902a8ac9c5d


