### PR TITLE
Improve Editor variable excluding logic to better match what the game wants

### DIFF
--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -43,6 +43,25 @@ export function getDefaultVariableNameIndex(name) {
   return index - 1
 }
 
+/**
+ * Exclude variables that would already be defined by default.
+ *
+ * For example, the following would fail because Overwatch already declares "B" at index 1 by default:
+ * ```
+ *   global:
+ *     0: B
+ * ```
+ *
+ * On the other hand, the following would not fail because the variable name at index 1 was overwritten:
+ * ```
+ *   global:
+ *     0: B
+ *     1: someNameThatIsNotJustB
+ * ```
+ *
+ * @param {string[]} variables A list of variables
+ * @returns {string[]} The list of variables without
+ */
 export function excludeDefaultVariableNames(variables) {
   let removedCount = 0
   return variables.filter((name) => {

--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -50,7 +50,7 @@ export function excludeDefaultVariableNames(variables) {
     if (
       defaultIndex >= 0 &&
       defaultIndex < maxVariableCount &&
-      defaultIndex > (variables.length - removedCount)) {
+      defaultIndex >= (variables.length - removedCount)) {
       removedCount++
       return false
     }

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -261,30 +261,38 @@ describe("variables.js", () => {
 
     test("Should exclude default variables if their index is different from the default", () => {
       const input = `
-        Global.variable;
         Global.A;
+        Global.variable;
+        Global.B;
+        Global.Z;
+        Global.AA;
         Global.DX;
         Global.DY;
-        Global.ZZ;
 
-        Event Player.variable;
         Event Player.A;
+        Event Player.variable;
+        Event Player.B;
+        Event Player.Z;
+        Event Player.AA;
         Event Player.DX;
         Event Player.DY;
-        Event Player.ZZ;
       `
       const expectedOutput = `
         variables {
           global:
-            0: variable
-            1: A
-            2: DY
-            3: ZZ
+            0: A
+            1: variable
+            2: B
+            3: AA
+            4: DX
+            5: DY
           player:
-            0: variable
-            1: A
-            2: DY
-            3: ZZ
+            0: A
+            1: variable
+            2: B
+            3: AA
+            4: DX
+            5: DY
         }\n\n
       `
       expect(disregardWhitespace(compileVariables(input))).toBe(disregardWhitespace(expectedOutput))
@@ -351,20 +359,12 @@ describe("variables.js", () => {
       expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
     })
 
-    test("Should exclude double letter variables if their index is different from the default", () => {
+    test("Should not exclude AA as its default index (26) is past the max initial variable indices (up to 25)", () => {
       const input = [
-        ... (new Array(100).fill("ignore me")),
-        "DW",
-        "DX",
-        "DY",
-        "DZ",
-        "ZZ"
+        "AA"
       ]
       const expectedOutput = [
-        ... (new Array(100).fill("ignore me")),
-        "DY",
-        "DZ",
-        "ZZ"
+        "AA"
       ]
       expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
     })

--- a/spec/javascript/utils/compiler/variables.test.js
+++ b/spec/javascript/utils/compiler/variables.test.js
@@ -292,17 +292,61 @@ describe("variables.js", () => {
   })
 
   describe("excludeDefaultVariableNames", () => {
-    test("Should exclude single letter variables if their index is different from the default", () => {
+    test("Should not exclude A as it is at its default index (0)", () => {
       const input = [
-        "A",
-        "variable",
-        "Z",
+        "A"
+      ]
+      const expectedOutput = [
+        "A"
+      ]
+      expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
+    })
+
+    test("Should not exclude A as the variable at the default index of A (0) was already defined with another name", () => {
+      const input = [
+        "someNameThatIsNotA",
+        "A"
+      ]
+      const expectedOutput = [
+        "someNameThatIsNotA",
+        "A"
+      ]
+      expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
+    })
+
+    test("Should exclude B as there aren't enough variables to reach the default index of B (1)", () => {
+      const input = [
         "B"
       ]
       const expectedOutput = [
-        "A",
-        "variable",
-        "B"
+      ]
+      expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
+    })
+
+    test("Should exclude Z as there is no variable at the default index of Z (25)", () => {
+      const input = [
+        "someVar1",
+        "someVar2",
+        "Z",
+        "someVar3",
+        "someVar4"
+      ]
+      const expectedOutput = [
+        "someVar1",
+        "someVar2",
+        "someVar3",
+        "someVar4",
+      ]
+      expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
+    })
+
+    test("Should exclude C and D as there are no variable at their default indices", () => {
+      const input = [
+        "C",
+        "D"
+      ]
+      const expectedOutput = [
+        // None
       ]
       expect(excludeDefaultVariableNames(input)).toStrictEqual(expectedOutput)
     })


### PR DESCRIPTION
- Fixed an off-by-one bug that saved some variables from being excluded when they shouldn't
- Fixed an issue where variables past Z were being excluded

Also added JSDocs explaining how the logic should work, and improved tests by splitting them up into smaller testable chunks