### PR TITLE
chore: Remove provider profile image

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,6 @@ class User < ApplicationRecord
     user.username = username
     user.username.gsub!(" ", "-")
     user.username.gsub!(".", "-")
-    user.provider_profile_image = auth_hash["info"]["image"]
     user.password = "no_password"
 
     # If a user logs in with Discord their discrimimator only gets added if

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="post-comment <%= "shadow-block" if comment.parent_id.nil? %>" data-comment="<%= comment.id %>" id="<%= comment.id %>">
   <div class="post-comment__layout">
-    <%= link_to user_profile_path(comment.user), class: "profile-image #{ "profile-image--empty" unless comment.user.profile_image.attached? || comment.user.provider_profile_image.present? }" do %>
+    <%= link_to user_profile_path(comment.user), class: "profile-image #{ "profile-image--empty" unless comment.user.profile_image.attached? }" do %>
       <%= render "profiles/image", user: comment.user, size: 40 %>
     <% end %>
 

--- a/app/views/filter/get_verified_users.html.erb
+++ b/app/views/filter/get_verified_users.html.erb
@@ -4,8 +4,6 @@
   <%= link_to build_filter_path(:author, user.username), class: "dropdown__item", data: { action: "add-filter", value: CGI.escape(user.username) } do %>
     <% if user.profile_image.attached? %>
       <%= image_tag rails_public_blob_url(user.profile_image.variant(quality: 95, resize_to_fill: [30, 30]).processed), width: 30, height: 30, loading: "lazy" %>
-    <% elsif user.provider_profile_image.present? %>
-      <%= image_tag user.provider_profile_image, width: 30, height: 30, loading: "lazy" %>
     <% else %>
       <span class="empty-image"></span>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
       <div class="item__header">
         <div>
           <%= link_to user_profile_path(@post.user), class: "item__author" do %>
-            <div class="item__avatar <%= "profile-image--empty" unless @post.user.profile_image.attached? || @post.user.provider_profile_image.present? %>">
+            <div class="item__avatar <%= "profile-image--empty" unless @post.user.profile_image.attached? %>">
               <%= render "profiles/image", user: @post.user, size: 32 %>
             </div>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -52,37 +52,28 @@
     <h2 class="mt-1/1 mb-0">Images</h2>
 
     <div class="well well--dark block mt-1/2">
-      <% if @user.provider_profile_image.present? %>
-        <%= form.label :profile_image, "Profile image", class: "form-label" %>
-        <%= image_tag @user.provider_profile_image, class: "profile-image" %>
+      <div class="form-group-max-width">
+        <%= form.label :profile_image, t("profile.form.image.label"), class: "form-label" %>
 
-        <p class="form-hint mt-1/4">
-          <%= t "profile.form.image.discord" %>
-        </p>
-      <% else %>
-        <div class="form-group-max-width">
-          <%= form.label :profile_image, t("profile.form.image.label"), class: "form-label" %>
-
-          <div class="profile-image">
-            <%= image_tag (@user.profile_image.attached? ? rails_public_blob_url(@user.profile_image.variant(quality: 95, resize_to_fill: [140, 140]).processed) : "//:0"),
-                          data: { image_preview: "profile-image" } %>
-          </div>
-
-
-          <%= form.file_field :profile_image,
-                              accept: "image/png, image/jpeg, image/jpg",
-                              data: { action: "image-preview", target: "profile-image" } %>
-
-          <p class="form-hint mt-1/4 mb-0">
-            <%= t "profile.form.image.help" %>
-          </p>
-
-          <%= hidden_field_tag :remove_profile_image, "", data: { clear_image_flag: "profile-image" } %>
-          <%= button_tag "Remove", type: "button", class: "mt-1/8 button button--small button--link text-red",
-                             data: { action: "clear-image", target: "profile-image" }  %>
-
+        <div class="profile-image">
+          <%= image_tag (@user.profile_image.attached? ? rails_public_blob_url(@user.profile_image.variant(quality: 95, resize_to_fill: [140, 140]).processed) : "//:0"),
+                        data: { image_preview: "profile-image" } %>
         </div>
-      <% end %>
+
+
+        <%= form.file_field :profile_image,
+                            accept: "image/png, image/jpeg, image/jpg",
+                            data: { action: "image-preview", target: "profile-image" } %>
+
+        <p class="form-hint mt-1/4 mb-0">
+          <%= t "profile.form.image.help" %>
+        </p>
+
+        <%= hidden_field_tag :remove_profile_image, "", data: { clear_image_flag: "profile-image" } %>
+        <%= button_tag "Remove", type: "button", class: "mt-1/8 button button--small button--link text-red",
+                            data: { action: "clear-image", target: "profile-image" }  %>
+
+      </div>
     </div>
 
     <div class="well well--dark block mt-1/2">

--- a/app/views/profiles/_image.html.erb
+++ b/app/views/profiles/_image.html.erb
@@ -3,6 +3,4 @@
     <%= image_tag rails_public_blob_url(user.profile_image.variant(quality: 95, resize_to_fill: [size, size]).processed), loading: "lazy", aria: { label: "Profile image of '#{ user.username }'" }, height: size, width: size %>
   <% rescue %>
   <% end %>
-<% elsif user.provider_profile_image.present? %>
-  <%= image_tag user.provider_profile_image, loading: "lazy", aria: { label: "Profile image of '#{ user.username }'" } %>
 <% end %>

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -2,7 +2,7 @@
 <% size = small ? 60 : 140 %>
 
 <div class="profile-banner <%= "profile-banner--small" if small %>">
-  <%= link_to user_profile_path(user), class: "profile-image #{ user.profile_image.attached? || user.provider_profile_image.present? ? '' : 'profile-image--empty' }", aria: { label: "Go to profile of '#{ user.username }'" } do %>
+  <%= link_to user_profile_path(user), class: "profile-image #{ "profile-image--empty" unless user.profile_image.attached? }", aria: { label: "Go to profile of '#{ user.username }'" } do %>
     <%= render "profiles/image", user: user, size: size %>
   <% end %>
 


### PR DESCRIPTION
Now that Discord images expire we can no longer store their avatar urls. Battle.net already didn't have avatars, so this PR simply removes provider profile images altogether.

An alternative would be to store the actual from from the moment someone logs in, but that would require us to store that image _every time_ they log in, as we have no way to tell if they changed their image with the provider.