### PR TITLE
feat(editor): Remember scroll state between different items

### DIFF
--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onDestroy, onMount, createEventDispatcher } from "svelte"
+  import { onDestroy, onMount, createEventDispatcher, tick } from "svelte"
   import { basicSetup } from "codemirror"
   import { EditorView, keymap } from "@codemirror/view"
   import { EditorState, EditorSelection } from "@codemirror/state"
@@ -12,7 +12,7 @@
   import { OWLanguageLinter } from "../../lib/OWLanguageLinter"
   import { parameterTooltip } from "../../lib/parameterTooltip"
   import { extraCompletions } from "../../lib/extraCompletions"
-  import { currentItem, editorStates, items, currentProjectUUID, completionsMap, variablesMap, subroutinesMap, mixinsMap, settings } from "../../stores/editor"
+  import { currentItem, editorStates, editorScrollPositions, items, currentProjectUUID, completionsMap, variablesMap, subroutinesMap, mixinsMap, settings } from "../../stores/editor"
   import { translationsMap } from "../../stores/translationKeys"
   import { getPhraseFromPosition } from "../../utils/parse"
   import debounce from "../../debounce"
@@ -22,6 +22,7 @@
   let element
   let view
   let currentId
+  let updatingState = false
 
   $: if ($currentProjectUUID) $editorStates = {}
   $: if ($currentItem.id != currentId && view) updateEditorState()
@@ -36,13 +37,15 @@
   onDestroy(() => $editorStates = {})
 
   function updateEditorState() {
+    updatingState = true
+
     if (currentId && !$currentItem.forceUpdate) $editorStates[currentId] = view.state
     if ($currentItem.forceUpdate) $currentItem = { ...$currentItem, forceUpdate: false }
 
     currentId = $currentItem.id
 
     if ($editorStates[currentId]) {
-      view.setState($editorStates[currentId])
+      onStateUpdateEnd()
       return
     }
 
@@ -52,7 +55,17 @@
     })
 
     $editorStates[currentId] = createEditorState($currentItem.content)
+
+    onStateUpdateEnd()
+  }
+
+  function onStateUpdateEnd() {
     view.setState($editorStates[currentId])
+
+    setTimeout(() => {
+      updatingState = false
+      setScrollPosition()
+    })
   }
 
   function createEditorState(content) {
@@ -83,6 +96,7 @@
         basicSetup,
         parameterTooltip(),
         indentationMarkers(),
+        rememberScrollPosition(),
         ...($settings["word-wrap"] ? [EditorView.lineWrapping] : [])
       ]
     })
@@ -237,9 +251,34 @@
       ])
     })
   }
+
+  /**
+   * Returns a plguin that updates a store of scroll positions when the view is scrolled.
+   * The view is also scrolled when updating the view, but we don't want to store that position.
+   * For this we use the updatingState flag to determine if it was a user scroll or a update scroll.
+   */
+  function rememberScrollPosition(event) {
+    return EditorView.domEventHandlers({
+      scroll(event, view) {
+        if (updatingState) return
+
+        $editorScrollPositions = {
+          ...$editorScrollPositions,
+          [currentId]: view.scrollDOM.scrollTop
+        }
+      }
+    })
+  }
+
+  async function setScrollPosition() {
+    view.scrollDOM.scrollTo({ top: $editorScrollPositions[currentId] || 0 })
+  }
+
 </script>
 
-<svelte:window on:keydown={keydown} on:create-selection={({ detail }) => createSelection(detail)} />
+<svelte:window
+  on:keydown={keydown}
+  on:create-selection={({ detail }) => createSelection(detail)} />
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div bind:this={element} on:click={click}></div>

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -59,6 +59,10 @@
     onStateUpdateEnd()
   }
 
+  /**
+   * This is fired after updateEditorState, after all required bits are set.
+   * Part of this is wrapped in an empty setTimeout to wait for the view state to update.
+   */
   function onStateUpdateEnd() {
     view.setState($editorStates[currentId])
 

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -66,7 +66,7 @@
   function onStateUpdateEnd() {
     view.setState($editorStates[currentId])
 
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       updatingState = false
       setScrollPosition()
     })

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -27,6 +27,7 @@ export const modal = (() => {
 })()
 
 export const editorStates = writable({})
+export const editorScrollPositions = writable({})
 
 export const projects = writable(null)
 export const currentProjectUUID = writable(null)


### PR DESCRIPTION
With this PR your scroll state will be remembered when navigating between different items. So if you scroll 100 pixels on file A, go to file B, and back to file A, file A will still be scroll 100 pixels.

The event is bound using a codemirror plugin. Unfortunately this event is also fired when the state updates, so when changing between items. This messes with the scroll position, as it would set it to a seemingly random scroll position. To prevent this from happening I added a variable that is toggled when changing between two items. If this variable is true the scroll position isn't saved. This is wrapped in a `setTimeout` with no time set to wait for the next render tick, so as to wait for the view update to complete.

![scroll-state](https://github.com/Mitcheljager/workshop.codes/assets/12848235/ec569a38-3461-455b-a816-ef5c7277ca69)
