### PR TITLE
feat(editor): Content slots

### DIFF
--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -45,7 +45,7 @@ export function extractAndInsertMixins(joinedItems) {
       content: mixin,
       full: joinedItems.slice(match.index, closing + 1),
       params: paramsDefaults,
-      hasContents: mixin.includes("@contents;")
+      hasContents: mixin.includes("@contents")
     }
   }
 
@@ -57,9 +57,7 @@ export function extractAndInsertMixins(joinedItems) {
     // Get arguments
     const index = joinedItems.indexOf("@include")
     let closing = getClosingBracket(joinedItems, "(", ")", index + 1)
-    if (closing < 0) {
-      closing = joinedItems.length
-    }
+    if (closing < 0) closing = joinedItems.length
     const full = joinedItems.slice(index, closing + 1)
     const name = full.match(/(?<=@include\s)(\w+)/)?.[0]
     const mixin = mixins[name]
@@ -80,20 +78,7 @@ export function extractAndInsertMixins(joinedItems) {
     // Get content for @contents
     let fullMixin
     let contents
-    if (mixin.hasContents) {
-      let contentsClosing = getClosingBracket(joinedItems, "{", "}", index)
-      if (contentsClosing == -1) contentsClosing = joinedItems.length
-      fullMixin = joinedItems.slice(index, contentsClosing + 1)
-
-      const contentsOpening = fullMixin.indexOf("{")
-
-      if (contentsOpening != -1) {
-        contents = fullMixin.slice(contentsOpening + 1, fullMixin.length - 1)
-        if (contents.includes(`@include\s${ name }`)) throw new Error("Can not include a mixin in itself")
-      }
-
-      replaceWith = replaceWith.replace("@contents;", contents || "")
-    }
+    if (mixin.hasContents) ({ replaceWith, fullMixin, contents } = replaceContents(mixin, joinedItems, index, replaceWith))
 
     mixin.params
       .map((param, index) => ({ ...param, index }))
@@ -108,4 +93,62 @@ export function extractAndInsertMixins(joinedItems) {
   }
 
   return joinedItems
+}
+
+/**
+ * Replace every contents occurance with their corresponding slot from the mixin include.
+ */
+function replaceContents(mixin, joinedItems, index, replaceWith) {
+  let contents = ""
+  let contentsClosing = getClosingBracket(joinedItems, "{", "}", index)
+  if (contentsClosing == -1) contentsClosing = joinedItems.length
+
+  const fullMixin = joinedItems.slice(index, contentsClosing + 1)
+  const contentsOpening = fullMixin.indexOf("{")
+
+  if (contentsOpening != -1) {
+    contents = fullMixin.slice(contentsOpening + 1, fullMixin.length - 1)
+    if (contents.includes(`@include\s${ name }`)) throw new Error("Can not include a mixin in itself")
+  }
+
+  const slotContents = getSlotContents(contents, mixin)
+
+  const contentsRegex = /@contents(?:\("(.+?)"\))?;?/g
+  let match
+  while ((match = contentsRegex.exec(replaceWith)) !== null) {
+    const slot = match[1] || "default"
+    const start = match.index
+    const end = match.index + match[0].length
+
+    if (!slot in slotContents) {
+      throw new Error(`Slot "${ slot }" not found in mixin "${ mixin.name }"`)
+    }
+
+    replaceWith = replaceBetween(replaceWith, slotContents[slot], start, end)
+  }
+
+  return { contents, fullMixin, replaceWith }
+}
+
+function getSlotContents(contents, mixin) {
+  const slotContents = {}
+  const defaultSlotContent = []
+
+  const slotsRegex = /@slot\("([^"]+)"\) {/g
+  let lastIndex = 0
+  let match
+
+  while ((match = slotsRegex.exec(contents)) !== null) {
+    const name = match[1] || ""
+    const slotClosing = getClosingBracket(contents, "{", "}", match.index)
+
+    defaultSlotContent.push(contents.slice(lastIndex, match.index))
+    slotContents[name] = contents.slice(match.index + match[0].length, slotClosing)
+    lastIndex = slotClosing + 1
+  }
+
+  // Add content after final slot to default slot
+  defaultSlotContent.push(contents.slice(lastIndex))
+
+  return { ...slotContents, default: defaultSlotContent.join("") }
 }

--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -100,7 +100,6 @@ export function extractAndInsertMixins(joinedItems) {
 
 /**
  * Replace every `@contents` occurance with their corresponding slot from the mixin include.
- * @param {Object} mixin - The mixin
  * @param {string} joinedItems - The full given content
  * @param {number} index - The starting index of the mixin content
  * @param {string} replaceWith - String constructed to far to replace the starting value

--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -111,7 +111,7 @@ function replaceContents(mixin, joinedItems, index, replaceWith) {
     if (contents.includes(`@include\s${ name }`)) throw new Error("Can not include a mixin in itself")
   }
 
-  const slotContents = getSlotContents(contents, mixin)
+  const slotContents = getSlotContents(contents)
 
   const contentsRegex = /@contents(?:\("(.+?)"\))?;?/g
   let match
@@ -130,7 +130,7 @@ function replaceContents(mixin, joinedItems, index, replaceWith) {
   return { contents, fullMixin, replaceWith }
 }
 
-function getSlotContents(contents, mixin) {
+function getSlotContents(contents) {
   const slotContents = {}
   const defaultSlotContent = []
 
@@ -142,13 +142,13 @@ function getSlotContents(contents, mixin) {
     const name = match[1] || ""
     const slotClosing = getClosingBracket(contents, "{", "}", match.index)
 
-    defaultSlotContent.push(contents.slice(lastIndex, match.index))
-    slotContents[name] = contents.slice(match.index + match[0].length, slotClosing)
+    defaultSlotContent.push(contents.slice(lastIndex, match.index).trim())
+    slotContents[name] = contents.slice(match.index + match[0].length, slotClosing).trim()
     lastIndex = slotClosing + 1
   }
 
   // Add content after final slot to default slot
-  defaultSlotContent.push(contents.slice(lastIndex))
+  defaultSlotContent.push(contents.slice(lastIndex).trim())
 
-  return { ...slotContents, default: defaultSlotContent.join("") }
+  return { ...slotContents, default: defaultSlotContent.join("").trim() }
 }

--- a/app/javascript/src/utils/compiler/mixins.js
+++ b/app/javascript/src/utils/compiler/mixins.js
@@ -120,14 +120,13 @@ export function replaceContents(joinedItems, index, replaceWith) {
 
   const slotContents = getSlotContents(contents)
 
-  const contentsRegex = /@contents(?:\("(.+?)"\))?;?/g
-  let match
-  while ((match = contentsRegex.exec(replaceWith)) !== null) {
+  while (replaceWith.indexOf("@contents") != -1) {
+    const match = /@contents(?:\("(.+?)"\))?;?/.exec(replaceWith)
     const slot = match[1] || "default"
     const start = match.index
     const end = match.index + match[0].length
 
-    replaceWith = replaceBetween(replaceWith, slotContents[slot], start, end)
+    replaceWith = replaceBetween(replaceWith, slotContents[slot] || "", start, end)
   }
 
   return { contents, fullMixin, replaceWith }

--- a/spec/javascript/utils/compiler/mixins.test.js
+++ b/spec/javascript/utils/compiler/mixins.test.js
@@ -165,7 +165,7 @@ describe("mixins.js", () => {
     })
   })
 
-  describe("extractAndInsertMixins", () => {
+  describe("replaceContents", () => {
     it("Should replace @contents with default content", () => {
       const joinedItems = "@include testMixin() { Global.value = 1; }"
       const replaceWith = "@contents;"
@@ -206,7 +206,7 @@ describe("mixins.js", () => {
       expect(result.replaceWith).toEqual("Global.value = 1; Global.slot = 1; Action(Global.slot = 2;); Global.slot = 2;")
     })
 
-    it("Should @contents without matching @slot with nothing", () => {
+    it("Should replace @contents without matching @slot with nothing", () => {
       const joinedItems = `@include testMixin() {
         @slot("Slot 1") { Global.slot = 1; }
       }`


### PR DESCRIPTION
This PR adds content slots. Content slots allow you to define multiple different `@contents` properties. For example:
```swift
@mixin someSpecialRule() {
  rule("Global Rule") {
    event {
      Ongoing - Global;
    }

    conditions {
      @contents("conditions");
      Some Special Condition();
    }

    actions {
      @contents("actions");
      Some Special Action();
    }
  }
}

@include someSpecialRule() {
  @slot("conditions") {
    Some Slot Condition();
  }
  
  @slot("actions") {
    Some Slot Action();
  }
}
```

Which will result in

```swift
rule("Global Rule") {
  event {
    Ongoing - Global;
  }

  conditions {
    Some Slot Condition();
    Some Special Condition();
  }

  actions {
    Some Slot Action();
    Some Special Action();
  }
}
```

You can still use the default slot as before, it will take all non slot content and use that as the default.

```swift
@mixin someMixin() {
  @contents;

  @contents("Some Slot");
}

@include someMixin() {
  Before();
  
  @slot("Some Slot") {
    Some Slot Action();
  }

  After();
}
```

Which results in

```swift
  Before();
  After();

  Some Slot Action();
```