### PR TITLE
chore: Clean up wiki data

### DIFF
--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -4,11 +4,6 @@ return:
   args:
   return: Void
   en-US: Abort
-  es-MX: Abortar
-  fr-FR: Interrompre
-  ja-JP: 中止
-  pt-BR: Anular
-  zh-CN: 中止
 __abortIf__:
   description: Stops execution of the action list if this action's condition evaluates to true. If it does not, execution continues with the next action.
   args:
@@ -18,31 +13,16 @@ __abortIf__:
     default: Compare
   return: Void
   en-US: Abort If
-  es-MX: Abortar si
-  fr-FR: Interrompre si
-  ja-JP: 中止する条件
-  pt-BR: Anular se
-  zh-CN: 根据条件中止
 __abortIfConditionIsFalse__:
   description: Stops execution of the action list if at least one condition in the condition list is false. If all conditions are true, execution continues with the next action.
   args: []
   return: Void
   en-US: Abort If Condition Is False
-  es-MX: Abortar si la condición es falsa
-  fr-FR: Interrompre si la condition est fausse
-  ja-JP: 条件が「FALSE」の場合中止
-  pt-BR: Anular se a Condição for Falsa
-  zh-CN: 如条件为“假”则中止
 __abortIfConditionIsTrue__:
   description: Stops execution of the action list if all conditions in the condition list are true. If any are false, execution continues with the next action.
   args: []
   return: Void
   en-US: Abort If Condition Is True
-  es-MX: Abortar si la condición es verdadera
-  fr-FR: Interrompre si la condition est vraie
-  ja-JP: 条件が「True」の場合中止
-  pt-BR: Anular se a Condição for Verdadeira
-  zh-CN: 如条件为”真“则中止
 _&allowButton:
   description: Undoes the effect of the disallow button action for one or more players.
   args:
@@ -58,11 +38,6 @@ _&allowButton:
     default: Primary Fire
   return: Void
   en-US: Allow Button
-  es-MX: Habilitar botón
-  fr-FR: Autoriser un bouton
-  ja-JP: ボタンを有効化
-  pt-BR: Permitir Botão
-  zh-CN: 可用按钮
 _&applyImpulse:
   description: Applies an instantaneous change in velocity to the movement of one or more players.
   args:
@@ -90,11 +65,6 @@ _&applyImpulse:
     default: Cancel Contrary Motion
   return: Void
   en-US: Apply Impulse
-  es-MX: Aplicar impulso
-  fr-FR: Appliquer une impulsion
-  ja-JP: 推進力を適用
-  pt-BR: Aplicar Impulso
-  zh-CN: 施加推力
 _&attachTo:
   description: Attaches the player (the 'child') to another player (the 'parent'). Once attached, the child will be unable to move freely until detached or teleported away. Multiple children may be attached to the same parent, but not vice versa.
   args:
@@ -112,11 +82,6 @@ _&attachTo:
     default: Vector
   return: Void
   en-US: Attach Players
-  es-MX: Anexar jugadores
-  fr-FR: Attacher les joueurs
-  ja-JP: プレイヤーをくっつける
-  pt-BR: Unir Jogadores
-  zh-CN: 绑定玩家
 bigMessage:
   description: Displays a large message above the reticle that is visible to specific players.
   args:
@@ -132,20 +97,11 @@ bigMessage:
     default: String
   return: Void
   en-US: Big Message
-  es-MX: Mensaje grande
-  fr-FR: Message en grand
-  ja-JP: 大きなメッセージ
-  pt-BR: Mensagem Grande
-  zh-CN: 大字体信息
 break:
   description: Goes to the end of the innermost `switch` statement, or `do/while`, `while` or `for` loop.
   args:
   return: Void
   en-US: Break
-  fr-FR: Arrêter
-  ja-JP: BREAK
-  pt-BR: Interromper
-  zh-CN: 中断
 __callSubroutine__:
   description: Pauses execution of the current rule and begins executing a subroutine rule (which is a rule with a subroutine event type). When the subroutine rule finishes, the original rule resumes execution. The subroutine will have access to the same contextual values (such as Event Player) as the original rule.
   args:
@@ -155,11 +111,6 @@ __callSubroutine__:
     default: Sub0
   return: Void
   en-US: Call Subroutine
-  es-MX: Llamada a subrutina
-  fr-FR: Sous-programme à appeler
-  ja-JP: サブルーチンの呼び出し
-  pt-BR: Chamar sub-rotina
-  zh-CN: 调用子程序
 _&cancelPrimaryAction:
   description: Cancels the active abilities for one or more players. Equivalent to a short stun.
   args:
@@ -171,11 +122,6 @@ _&cancelPrimaryAction:
     default: Event Player
   return: Void
   en-US: Cancel Primary Action
-  es-MX: Cancelar acción primaria
-  fr-FR: Annuler l’action principale
-  ja-JP: メインアクションをキャンセル
-  pt-BR: Cancelar Ação Primária
-  zh-CN: 取消主要动作
 __chaseGlobalVariableAtRate__:
   description: Gradually modifies the value of a global variable at a specific rate. (A global variable is a variable that belongs to the game itself.)
   args:
@@ -199,11 +145,6 @@ __chaseGlobalVariableAtRate__:
     default: Destination And Rate
   return: Void
   en-US: Chase Global Variable At Rate
-  es-MX: Seguir variable global según la tasa
-  fr-FR: Modifier une variable globale selon une cadence
-  ja-JP: グローバル変数を特定のレートで追跡
-  pt-BR: Acompanhar Variável Global na Medida
-  zh-CN: 追踪全局变量频率
 __chaseGlobalVariableOverTime__:
   description: Gradually modifies the value of a global variable over time. (A global variable is a variable that belongs to the game itself.)
   args:
@@ -227,11 +168,6 @@ __chaseGlobalVariableOverTime__:
     default: Destination And Duration
   return: Void
   en-US: Chase Global Variable Over Time
-  es-MX: Seguir variable global con el tiempo
-  fr-FR: Modifier une variable globale sur la durée
-  ja-JP: グローバル変数を継続的に追跡
-  pt-BR: Acompanhar Variável Global ao Longo do Tempo
-  zh-CN: 持续追踪全局变量
 __chasePlayerVariableAtRate__:
   description: Gradually modifies the value of a player variable at a specific rate. (A player variable is a variable that belongs to a specific player.)
   args:
@@ -261,11 +197,6 @@ __chasePlayerVariableAtRate__:
     default: Destination And Rate
   return: Void
   en-US: Chase Player Variable At Rate
-  es-MX: Seguir variable de jugador según la tasa
-  fr-FR: Modifier une variable de joueur selon une cadence
-  ja-JP: プレイヤー変数を特定のレートで追跡
-  pt-BR: Acompanhar Variável de Jogador na Medida
-  zh-CN: 追踪玩家变量频率
 __chasePlayerVariableOverTime__:
   description: Gradually modifies the value of a player variable over time. (A player variable is a variable that belongs to a specific player.)
   args:
@@ -295,11 +226,6 @@ __chasePlayerVariableOverTime__:
     default: Destination And Duration
   return: Void
   en-US: Chase Player Variable Over Time
-  es-MX: Seguir variable del jugador con el tiempo
-  fr-FR: Modifier une variable de joueur sur la durée
-  ja-JP: プレイヤー変数を継続的に追跡
-  pt-BR: Acompanhar Variável de Jogador ao Longo do Tempo
-  zh-CN: 持续追踪玩家变量
 _&clearStatusEffect:
   description: Clears a status that was applied from a set status action from one or more players.
   args:
@@ -315,11 +241,6 @@ _&clearStatusEffect:
     default: Hacked
   return: Void
   en-US: Clear Status
-  es-MX: Eliminar estado
-  fr-FR: Effacer le statut
-  ja-JP: ステータスをクリア
-  pt-BR: Apagar Status
-  zh-CN: 清除状态
 _&communicate:
   description: Causes one or more players to use an emote, voice line, or other equipped communication.
   args:
@@ -335,21 +256,11 @@ _&communicate:
     default: Voice Line Up
   return: Void
   en-US: Communicate
-  es-MX: Comunicar
-  fr-FR: Communiquer
-  ja-JP: コミュニケーション
-  pt-BR: Comunicar
-  zh-CN: 交流
 continue:
   description: Goes back to the start of the innermost loop.
   args:
   return: Void
   en-US: Continue
-  es-MX: Continuar
-  fr-FR: Continuer
-  ja-JP: CONTINUE
-  pt-BR: Continuar
-  zh-CN: 继续
 createBeam:
   description: Creates an in-world beam effect entity. This effect entity will persist until destroyed. To obtain a reference to this entity, use the last created entity value. This action will fail if too many entities have been created.
   args:
@@ -381,11 +292,6 @@ createBeam:
     default: Visible To, Position, And Radius
   return: Void
   en-US: Create Beam Effect
-  es-MX: Crear efecto de rayo
-  fr-FR: Créer un effet de rayon
-  ja-JP: ビーム・エフェクトを作成
-  pt-BR: Criar Efeito de Feixe
-  zh-CN: 创建光束效果
 createDummy:
   description: Adds a new bot to the specified slot on the specified team so long as the slot is available. This bot will only move, fire, or use abilities if executing workshop actions.
   args:
@@ -411,11 +317,6 @@ createDummy:
     default: Vector
   return: Void
   en-US: Create Dummy Bot
-  es-MX: Crear robot de entrenamiento
-  fr-FR: Créer une I.A.
-  ja-JP: ダミーボットを作成
-  pt-BR: Criar Bot
-  zh-CN: 生成机器人
 createEffect:
   description: Creates an in-world effect entity. This effect entity will persist
     until destroyed. To obtain a reference to this entity, use the last created entity
@@ -449,11 +350,6 @@ createEffect:
     default: Visible To, Position, And Radius
   return: Void
   en-US: Create Effect
-  es-MX: Crear efecto
-  fr-FR: Créer un effet
-  ja-JP: エフェクトを作成
-  pt-BR: Criar Efeito
-  zh-CN: 创建效果
 __hudText__:
   description: Creates hud text visible to specific players at a specific location
     on the screen. This text will persist until destroyed. To obtain a reference to
@@ -508,11 +404,6 @@ __hudText__:
     default: Default Visibility
   return: Void
   en-US: Create HUD Text
-  es-MX: Crear texto del HUD
-  fr-FR: Créer du texte d’interface
-  ja-JP: HUDテキストを作成
-  pt-BR: Criar Texto de HUD
-  zh-CN: 创建HUD文本
 createIcon:
   description: Creates an in-world icon entity. This icon entity will persist until
     destroyed. To obtain a reference to this entity, use the last created entity value.
@@ -546,11 +437,6 @@ createIcon:
     default: 'True'
   return: Void
   en-US: Create Icon
-  es-MX: Crear ícono
-  fr-FR: Créer une icône
-  ja-JP: アイコンを作成
-  pt-BR: Criar Ícone
-  zh-CN: 创建图标
 createInWorldText:
   description: Creates in-world text visible to specific players at a specific position
     in the world. This text will persist until destroyed. To obtain a reference to
@@ -593,11 +479,6 @@ createInWorldText:
     default: Default Visibility
   return: Void
   en-US: Create In-World Text
-  es-MX: Crear texto dentro del mundo
-  fr-FR: Créer du texte en jeu
-  ja-JP: ワールド内テキストを作成
-  pt-BR: Criar Texto no Mundo
-  zh-CN: 创建地图文本
 damage:
   description: Applies instantaneous damage to one or more players, possibly killing
     the players.
@@ -618,22 +499,12 @@ damage:
     default: Number
   return: Void
   en-US: Damage
-  es-MX: Infligir daño
-  fr-FR: Infliger des dégâts
-  ja-JP: ダメージ
-  pt-BR: Dano
-  zh-CN: 伤害
 declareDraw:
   description: Instantly ends the match in a draw. This action has no effect in free-for-all
     modes.
   args: []
   return: Void
   en-US: Declare Match Draw
-  es-MX: Declarar empate de la partida
-  fr-FR: Déclarer le match nul
-  ja-JP: マッチの引き分けを宣言
-  pt-BR: Declarar Empate na Partida
-  zh-CN: 宣布比赛为平局
 declarePlayerVictory:
   description: Instantly ends the match with the specific player as the winner. This
     action only has an effect in free-for-all modes.
@@ -644,22 +515,12 @@ declarePlayerVictory:
     default: Event Player
   return: Void
   en-US: Declare Player Victory
-  es-MX: Declarar victoria del jugador
-  fr-FR: Déclarer la victoire d’un joueur
-  ja-JP: チームの勝利を宣言
-  pt-BR: Declarar Vitória do Jogador
-  zh-CN: 宣告玩家胜利
 declareRoundDraw:
   description: Declare a draw for the current round. This only works in the elimination
     game mode.
   args: []
   return: Void
   en-US: Declare Round Draw
-  es-MX: Declarar ronda empatada
-  fr-FR: Déclarer la manche nulle
-  ja-JP: ラウンドの引き分けを宣言
-  pt-BR: Declarar Empate na Rodada
-  zh-CN: 宣布回合为平局
 declareRoundVictory:
   description: Declare a team as the current round winner. This only works in the
     control and elimination game modes.
@@ -670,11 +531,6 @@ declareRoundVictory:
     default: Team
   return: Void
   en-US: Declare Round Victory
-  es-MX: Declarar victoria de la ronda
-  fr-FR: Déclarer la victoire de la manche
-  ja-JP: ラウンドの勝利を宣言
-  pt-BR: Declarar Vitória na Rodada
-  zh-CN: 宣告回合胜利
 declareTeamVictory:
   description: Instantly ends the match with the specified team as the winner. This
     action has no effect in free-for-all modes.
@@ -685,61 +541,31 @@ declareTeamVictory:
     default: Team
   return: Void
   en-US: Declare Team Victory
-  es-MX: Declarar la victoria del equipo
-  fr-FR: Déclarer la victoire d’une équipe
-  ja-JP: チームの勝利を宣言
-  pt-BR: Declarar Vitória da Equipe
-  zh-CN: 宣告队伍胜利
 destroyAllDummies:
   description: Removes all dummy bots from the match.
   args: []
   return: Void
   en-US: Destroy All Dummy Bots
-  es-MX: Destruir todos los robots de entrenamiento
-  fr-FR: Détruire toutes les I.A.
-  ja-JP: すべてのダミーボットを破棄
-  pt-BR: Destruir Todos os Bots
-  zh-CN: 移除所有机器人
 destroyAllEffects:
   description: Destroys all effect entities created by create effect.
   args: []
   return: Void
   en-US: Destroy All Effects
-  es-MX: Destruir todos los efectos
-  fr-FR: Détruire tous les effets
-  ja-JP: すべてのエフェクトを破棄
-  pt-BR: Destruir Todos os Efeitos
-  zh-CN: 消除所有效果
 destroyAllHudTexts:
   description: Destroys all hud text that was created by the create hud text action.
   args: []
   return: Void
   en-US: Destroy All HUD Text
-  es-MX: Destruir todo el texto del HUD
-  fr-FR: Détruire tous les textes d’interface
-  ja-JP: すべてのHUDテキストを破棄
-  pt-BR: Destruir Todo o Texto de HUD
-  zh-CN: 消除所有HUD文本
 destroyAllIcons:
   description: Destroys all icon entities created by create icon.
   args: []
   return: Void
   en-US: Destroy All Icons
-  es-MX: Destruir todos los íconos
-  fr-FR: Détruire toutes les icônes
-  ja-JP: すべてのアイコンを破棄
-  pt-BR: Destruir Todos os Ícones
-  zh-CN: 消除所有图标
 destroyAllInWorldText:
   description: Destroys all in-world text created by create in-world text.
   args: []
   return: Void
   en-US: Destroy All In-World Text
-  es-MX: Destruir todo el texto dentro del mundo
-  fr-FR: Détruire tous les textes en jeu
-  ja-JP: すべてのワールド内テキストを破棄
-  pt-BR: Destruir Todo o Texto no Mundo
-  zh-CN: 消除所有地图文本
 destroyDummy:
   description: Removes the specified dummy bot from the match.
   args:
@@ -753,11 +579,6 @@ destroyDummy:
     default: Number
   return: Void
   en-US: Destroy Dummy Bot
-  es-MX: Destruir robot de entrenamiento
-  fr-FR: Détruire une I.A.
-  ja-JP: ダミーボットを破壊する
-  pt-BR: Destruir Bot
-  zh-CN: 移除机器人
 destroyEffect:
   description: Destroys an effect entity that was created by create effect.
   args:
@@ -767,11 +588,6 @@ destroyEffect:
     default: Last Created Entity Entity
   return: Void
   en-US: Destroy Effect
-  es-MX: Destruir efecto
-  fr-FR: Détruire un effet
-  ja-JP: エフェクトを破棄
-  pt-BR: Destruir Efeito
-  zh-CN: 消除效果
 destroyHudText:
   description: Destroys hud text that was created by create hud text.
   args:
@@ -781,11 +597,6 @@ destroyHudText:
     default: Last Text ID
   return: Void
   en-US: Destroy HUD Text
-  es-MX: Destruir texto del HUD
-  fr-FR: Détruire du texte d’interface
-  ja-JP: HUDテキストを破棄
-  pt-BR: Destruir Texto de HUD
-  zh-CN: 消除HUD文本
 destroyIcon:
   description: Destroys an icon entity that was created by create icon.
   args:
@@ -795,11 +606,6 @@ destroyIcon:
     default: Last Created Entity Entity
   return: Void
   en-US: Destroy Icon
-  es-MX: Destruir ícono
-  fr-FR: Détruire une icône
-  ja-JP: アイコンを破棄
-  pt-BR: Destruir Ícone
-  zh-CN: 消除图标
 destroyInWorldText:
   description: Destroys in-world text that was created by create in-world text.
   args:
@@ -809,11 +615,6 @@ destroyInWorldText:
     default: Last Text ID
   return: Void
   en-US: Destroy In-World Text
-  es-MX: Destruir texto dentro del mundo
-  fr-FR: Détruire du texte en jeu
-  ja-JP: ワールド内テキストを破棄
-  pt-BR: Destruir Texto no Mundo
-  zh-CN: 消除地图文本
 _&detach:
   description: Undoes the attachment caused by the 'attachTo' action for one or more
     players. These players will resume normal movement from their current position.
@@ -826,43 +627,23 @@ _&detach:
     default: Event Player
   return: Void
   en-US: Detach Players
-  es-MX: Separar jugadores
-  fr-FR: Détacher les joueurs
-  ja-JP: プレイヤーを離れさせる
-  pt-BR: Separar Jogadores
-  zh-CN: 解除绑定
 disableAnnouncer:
   description: Disables game mode announcements from the announcer until reenabled
     or the match ends.
   args: []
   return: Void
   en-US: Disable Built-In Game Mode Announcer
-  es-MX: Deshabilitar el presentador integrado del modo de juego
-  fr-FR: Désactiver l’annonceur prédéfini par le mode de jeu
-  ja-JP: ゲーム・モードの通知を無効化
-  pt-BR: Desativar Narração Integrada ao Modo de Jogo
-  zh-CN: 关闭游戏预设通告模式
 disableGamemodeCompletion:
   description: Disables completion of the match from the game mode itself, only allowing
     the match to be completed by scripting commands.
   args: []
   return: Void
   en-US: Disable Built-In Game Mode Completion
-  es-MX: Deshabilitar la finalización integrada del modo de juego
-  fr-FR: Désactiver l’accomplissement prédéfini par le mode de jeu
-  ja-JP: ゲーム・モードの標準完了を無効化
-  pt-BR: Desativar Conclusão Integrada ao Modo de Jogo
-  zh-CN: 关闭游戏预设完成条件
 disableMusic:
   description: Disables all game mode music until reenabled or the match ends.
   args: []
   return: Void
   en-US: Disable Built-In Game Mode Music
-  es-MX: Deshabilitar la música integrada del modo de juego
-  fr-FR: Désactiver la musique prédéfinie par le mode de jeu
-  ja-JP: ゲーム・モードのBGMを無効化
-  pt-BR: Desativar Música Integrada ao Modo de Jogo
-  zh-CN: 关闭游戏预设音乐模式
 _&disableRespawn:
   description: Disables automatic respawning for one or more players, only allowing
     respawning by scripting commands.
@@ -875,22 +656,12 @@ _&disableRespawn:
     default: Event Player
   return: Void
   en-US: Disable Built-In Game Mode Respawning
-  es-MX: Deshabilitar la reaparición integrada del modo de juego
-  fr-FR: Désactiver la réapparition prédéfinie par le mode de jeu
-  ja-JP: ゲーム・モードの標準リスポーンを無効化
-  pt-BR: Desativar Ressurgimento Integrado ao Modo de Jogo
-  zh-CN: 关闭游戏预设重生模式
 disableScoring:
   description: Disables changes to player and team scores from the game mode itself,
     only allowing scores to be changed by scripting commands.
   args: []
   return: Void
   en-US: Disable Built-In Game Mode Scoring
-  es-MX: Deshabilitar el sistema de puntuación integrado del modo de juego
-  fr-FR: Désactiver le calcul des points prédéfini par le mode de jeu
-  ja-JP: ゲーム・モードの標準スコアリングを無効化
-  pt-BR: Desativar Pontuação Integrada ao Modo de Jogo
-  zh-CN: 关闭游戏预设计分模式
 _&disableDeathSpectateAllPlayers:
   description: Undoes the effect of the enable death spectate all players action for
     or more players.
@@ -903,11 +674,6 @@ _&disableDeathSpectateAllPlayers:
     default: Event Player
   return: Void
   en-US: Disable Death Spectate All Players
-  es-MX: Deshabilitar la observación de todos los jugadores como espectador muerto
-  fr-FR: Empêcher d’observer n’importe qui après la mort
-  ja-JP: 観戦時に全プレイヤー選択可能を無効化
-  pt-BR: Desativar Visualização de Todos os Jogadores na Morte
-  zh-CN: 对所有玩家禁用死亡回放
 _&disableDeathSpectateTargetHud:
   description: Undoes the effect of the enable death spectate target hud action for
     or more players.
@@ -920,11 +686,6 @@ _&disableDeathSpectateTargetHud:
     default: Event Player
   return: Void
   en-US: Disable Death Spectate Target HUD
-  es-MX: Deshabilitar la observación del HUD objetivo como espectador muerto
-  fr-FR: Empêcher de voir l’interface de la cible après la mort
-  ja-JP: 観戦中のターゲットHUD表示を無効化
-  pt-BR: Desativar HUD do Alvo de Visualização na Morte
-  zh-CN: 禁用死亡回放时目标的HUD
 disableInspector:
   description: Causes the workshop inspector to stop recording new entries. This has
     the benefit of reducing your script's server load, particularly when modifying
@@ -932,11 +693,6 @@ disableInspector:
   args: []
   return: Void
   en-US: Disable Inspector Recording
-  es-MX: Desactivar registro de Inspector
-  fr-FR: Désactiver l’enregistrement du contrôleur
-  ja-JP: インスペクターでの記録を無効化
-  pt-BR: Desativar gravação do Inspetor
-  zh-CN: 禁用查看器录制
 _&disallowButton:
   description: Disables a logical button for one or more players such that pressing
     it has no effect.
@@ -953,20 +709,12 @@ _&disallowButton:
     default: Primary Fire
   return: Void
   en-US: Disallow Button
-  es-MX: Deshabilitar botón
-  fr-FR: Interdire le bouton
-  ja-JP: ボタンを無効化
-  pt-BR: Proibir Botão
-  zh-CN: 禁用按钮
 __else__:
   description: Denotes the beginning of a series of actions that will only execute
     if the previous If or Else If action's condition was false.
   args: []
   return: Void
   en-US: Else
-  es-MX: Si no
-  fr-FR: Sinon
-  ja-JP: Else
 __elif__:
   description: Denotes the beginning of a series of actions that will only execute
     if the specified condition is true and the previous If or Else If action's condition
@@ -978,39 +726,21 @@ __elif__:
     default: Compare
   return: Void
   en-US: Else If
-  es-MX: Si no si
-  fr-FR: Sinon Si
-  ja-JP: Else If
 enableAnnouncer:
   description: Undoes the effect of the disable built-in game mode announcer action.
   args: []
   return: Void
   en-US: Enable Built-In Game Mode Announcer
-  es-MX: Habilitar presentador integrado del modo de juego
-  fr-FR: Activer l’annonceur prédéfini par le mode de jeu
-  ja-JP: ゲーム・モードの通知を有効化
-  pt-BR: Ativar Narração Integrada ao Modo de Jogo
-  zh-CN: 开启游戏预设通告模式
 enableGamemodeCompletion:
   description: Undoes the effect of the disable built-in game mode completion action.
   args: []
   return: Void
   en-US: Enable Built-In Game Mode Completion
-  es-MX: Habilitar la finalización integrada del modo de juego
-  fr-FR: Activer l’accomplissement prédéfini par le mode de jeu
-  ja-JP: ゲーム・モードの標準完了を有効化
-  pt-BR: Ativar Conclusão Integrada ao Modo de Jogo
-  zh-CN: 开启游戏预设完成条件
 enableMusic:
   description: Undoes the effect of the disable built-in game mode music action.
   args: []
   return: Void
   en-US: Enable Built-In Game Mode Music
-  es-MX: Habilitar la música integrada del modo de juego
-  fr-FR: Activer la musique prédéfinie par le mode de jeu
-  ja-JP: ゲーム・モードのBGMを有効化
-  pt-BR: Ativar Música Integrada ao Modo de Jogo
-  zh-CN: 开启游戏预设音乐模式
 _&enableRespawn:
   description: Undoes the effect of the disable built-in game mode respawning action
     for one or more players.
@@ -1023,21 +753,11 @@ _&enableRespawn:
     default: Event Player
   return: Void
   en-US: Enable Built-In Game Mode Respawning
-  es-MX: Habilitar la reaparición integrada del modo de juego
-  fr-FR: Activer la réapparition prédéfinie par le mode de jeu
-  ja-JP: ゲーム・モードの標準リスポーンを有効化
-  pt-BR: Ativar Ressurgimento Integrado ao Modo de Jogo
-  zh-CN: 开启游戏预设重生模式
 enableScoring:
   description: Undoes the effect of the disable built-in game mode scoring action.
   args: []
   return: Void
   en-US: Enable Built-In Game Mode Scoring
-  es-MX: Habilitar el sistema de puntuación integrado del modo de juego
-  fr-FR: Activer le calcul des points prédéfini par le mode de jeu
-  ja-JP: ゲーム・モードの標準スコアリングを有効化
-  pt-BR: Ativar Pontuação Integrada ao Modo de Jogo
-  zh-CN: 开启游戏预设计分模式
 _&enableDeathSpectateAllPlayers:
   description: Allows one or more players to spectate all players when dead, as opposed
     to only allies.
@@ -1050,11 +770,6 @@ _&enableDeathSpectateAllPlayers:
     default: Event Player
   return: Void
   en-US: Enable Death Spectate All Players
-  es-MX: Habilitar la observación de todos los jugadores como espectador muerto
-  fr-FR: Permettre d’observer n’importe qui après la mort
-  ja-JP: 観戦時に全プレイヤー選択可能を有効化
-  pt-BR: Ativar Visualização de Todos os Jogadores na Morte
-  zh-CN: 对所有玩家启用死亡回放
 _&enableDeathSpectateTargetHud:
   description: Causes one or more players to see their spectate target's hud instead
     of their own while death spectating.
@@ -1067,11 +782,6 @@ _&enableDeathSpectateTargetHud:
     default: Event Player
   return: Void
   en-US: Enable Death Spectate Target HUD
-  es-MX: Habilitar la observación del HUD objetivo como espectador muerto
-  fr-FR: Permettre de voir l’interface de la cible après la mort
-  ja-JP: 観戦中のターゲットHUD表示を有効化
-  pt-BR: Ativar HUD do Alvo de Visualização na Morte
-  zh-CN: 启用死亡回放时目标的HUD
 enableInspector:
   description: Causes the workshop inspector to resume recording new entries (in case
     it had been disabled earlier). Enabling recording at specific times may make it
@@ -1079,21 +789,12 @@ enableInspector:
   args: []
   return: Void
   en-US: Enable Inspector Recording
-  es-MX: Activar registro de Inspector
-  fr-FR: Activer l’enregistrement du contrôleur
-  ja-JP: インスペクターでの記録を有効化
-  pt-BR: Ativar gravação do Inspetor
-  zh-CN: 启用查看器录制
 __end__:
   description: Denotes the end of a series of actions started by an if, else if, else,
     while, or for action.
   args: []
   return: Void
   en-US: End
-  es-MX: Fin
-  fr-FR: Fin
-  ja-JP: End
-  pt-BR: Término
 __forGlobalVariable__:
   description: Denotes the beginning of a series of actions that will execute in a
     loop, modifying the control variable on each loop. The corresponding end action
@@ -1119,11 +820,6 @@ __forGlobalVariable__:
     default: Number (1)
   return: Void
   en-US: For Global Variable
-  es-MX: Para variable global
-  fr-FR: Pour variable globale
-  ja-JP: グローバル変数
-  pt-BR: For variável global
-  zh-CN: For 全局变量
 __forPlayerVariable__:
   description: Denotes the beginning of a series of actions that will execute in a
     loop, modifying the control variable on each loop. The corresponding end action
@@ -1153,22 +849,12 @@ __forPlayerVariable__:
     default: Number (1)
   return: Void
   en-US: For Player Variable
-  es-MX: Para variable de jugador
-  fr-FR: Pour variable de joueur
-  ja-JP: プレイヤー変数
-  pt-BR: For variável de jogador
-  zh-CN: For 玩家变量
 goToAssembleHeroes:
   description: Returns the match to the assemble heroes phase of the game mode. Only
     works if the game is in progress.
   args: []
   return: Void
   en-US: Go To Assemble Heroes
-  es-MX: Ir a Forma tu equipo
-  fr-FR: Aller à Choisissez vos héros
-  ja-JP: "「ヒーローを編成しよう」に移行"
-  pt-BR: Ir para Escolher Heróis
-  zh-CN: 前往集结英雄
 heal:
   description: Provides an instantaneous heal to one or more players. This heal will
     not resurrect dead players.
@@ -1189,11 +875,6 @@ heal:
     default: Number
   return: Void
   en-US: Heal
-  es-MX: Sanar
-  fr-FR: Soigner
-  ja-JP: 回復
-  pt-BR: Cura
-  zh-CN: 治疗
 __if__:
   description: Denotes the beginning of a series of actions that will only execute
     if the specified condition is true.
@@ -1204,9 +885,6 @@ __if__:
     default: Compare
   return: Void
   en-US: If
-  es-MX: Si
-  fr-FR: Si
-  ja-JP: If
 kill:
   description: Instantly kills one or more players.
   args:
@@ -1222,11 +900,6 @@ kill:
     default: 'Null'
   return: Void
   en-US: Kill
-  es-MX: Matar
-  fr-FR: Tuer
-  ja-JP: キル
-  pt-BR: Abater
-  zh-CN: 击杀
 __loop__:
   description: Restarts the action list from the beginning. To prevent an infinite
     loop, a wait action must execute between the start of the action list and this
@@ -1234,11 +907,6 @@ __loop__:
   args: []
   return: Void
   en-US: Loop
-  es-MX: Bucle
-  fr-FR: Boucle
-  ja-JP: ループ
-  pt-BR: Gerar Loop
-  zh-CN: 循环
 __loopIf__:
   description: Restarts the action list from the beginning if this action's condition
     evaluates to true. If it does not, execution continues with the next action. To
@@ -1251,11 +919,6 @@ __loopIf__:
     default: Compare
   return: Void
   en-US: Loop If
-  es-MX: Repetir si
-  fr-FR: Boucle si
-  ja-JP: ループする条件
-  pt-BR: Gerar Loop se
-  zh-CN: 根据条件循环
 __loopIfConditionIsFalse__:
   description: Restarts the action list from the beginning if at least one condition
     in the condition list is false. If all conditions are true, execution continues
@@ -1264,11 +927,6 @@ __loopIfConditionIsFalse__:
   args: []
   return: Void
   en-US: Loop If Condition Is False
-  es-MX: Repetir si la condición es falsa
-  fr-FR: Boucle si la condition est fausse
-  ja-JP: 条件が「FALSE」の場合ループ
-  pt-BR: Gerar Loop se a Condição for Falsa
-  zh-CN: 如条件为“假”则循环
 __loopIfConditionIsTrue__:
   description: Restarts the action list from the beginning if every condition in the
     condition list is true. If any are false, execution continues with the next action.
@@ -1277,11 +935,6 @@ __loopIfConditionIsTrue__:
   args: []
   return: Void
   en-US: Loop If Condition Is True
-  es-MX: Repetir si la condición es verdadera
-  fr-FR: Boucle si la condition est vraie
-  ja-JP: 条件が「True」の場合ループ
-  pt-BR: Gerar Loop se a Condição for Verdadeira
-  zh-CN: 如条件为”真“则循环
 __modifyGlobalVariable__:
   description: Modifies the value of a global variable, which is a variable that belongs
     to the game itself.
@@ -1302,11 +955,6 @@ __modifyGlobalVariable__:
     default: Number
   return: Void
   en-US: Modify Global Variable
-  es-MX: Modificar variable global
-  fr-FR: Modifier une variable globale
-  ja-JP: グローバル変数を変更
-  pt-BR: Modificar Variável Global
-  zh-CN: 修改全局变量
 __modifyGlobalVariableAtIndex__:
   description: Modifies the value of a global variable at an index, which is a variable
     that belongs to the game itself.
@@ -1331,11 +979,6 @@ __modifyGlobalVariableAtIndex__:
     default: Number
   return: Void
   en-US: Modify Global Variable At Index
-  es-MX: Modificar variable global según el índice
-  fr-FR: Modifier une variable globale à l’index
-  ja-JP: インデックスのグローバル変数を変更
-  pt-BR: Modificar Variável Global no Índice
-  zh-CN: 在索引处修改全局变量
 _&addToScore:
   description: Modifies the score (kill count) of one or more players. This action
     only has an effect in free-for-all modes.
@@ -1352,11 +995,6 @@ _&addToScore:
     default: Number
   return: Void
   en-US: Modify Player Score
-  es-MX: Modificar puntuación del jugador
-  fr-FR: Modifier le score d’un joueur
-  ja-JP: プレイヤー・スコアを変更
-  pt-BR: Modificar Pontuação do Jogador
-  zh-CN: 修改玩家分数
 __modifyPlayerVariable__:
   description: Modifies the value of a player variable, which is a variable that belongs
     to a specific player.
@@ -1383,11 +1021,6 @@ __modifyPlayerVariable__:
     default: Number
   return: Void
   en-US: Modify Player Variable
-  es-MX: Modificar variable de jugador
-  fr-FR: Modifier une variable de joueur
-  ja-JP: プレイヤー変数を変更
-  pt-BR: Modificar Variável de Jogador
-  zh-CN: 修改玩家变量
 __modifyPlayerVariableAtIndex__:
   description: Modifies the value of a player variable at an index, which is a variable
     that belongs to a specific player.
@@ -1418,11 +1051,6 @@ __modifyPlayerVariableAtIndex__:
     default: Number
   return: Void
   en-US: Modify Player Variable At Index
-  es-MX: Modificar variable de jugador según el índice
-  fr-FR: Modifier une variable de joueur à l’index
-  ja-JP: インデックスのプレイヤー変数を変更
-  pt-BR: Modificar Variável de Jogador no Índice
-  zh-CN: 在索引处修改玩家变量
 addToTeamScore:
   description: Modifies the score of one or both teams. This action has no effect
     in free-for-all modes or modes without a team score.
@@ -1437,22 +1065,12 @@ addToTeamScore:
     default: Number
   return: Void
   en-US: Modify Team Score
-  es-MX: Modificar puntuación del equipo
-  fr-FR: Modifier le score de l’équipe
-  ja-JP: チーム・スコアを変更
-  pt-BR: Modificar Pontuação da Equipe
-  zh-CN: 修改队伍分数
 pauseMatchTime:
   description: Pauses the match time. Players, objective logic, and game mode advancement
     criteria are unaffected by the pause.
   args: []
   return: Void
   en-US: Pause Match Time
-  es-MX: Pausar tiempo de la partida
-  fr-FR: Mettre en pause le temps de jeu
-  ja-JP: マッチ時間をポーズする
-  pt-BR: Pausar Tempo da Partida
-  zh-CN: 比赛时间暂停
 playEffect:
   description: Plays an effect at a position in the world. The lifetime of this effect
     is short, so it does not need to be updated or destroyed.
@@ -1481,11 +1099,6 @@ playEffect:
     default: Number (1)
   return: Void
   en-US: Play Effect
-  es-MX: Reproducir efecto
-  fr-FR: Jouer un effet
-  ja-JP: エフェクトを再生
-  pt-BR: Reproduzir Efeito
-  zh-CN: 播放效果
 _&preloadHero:
   description: Preemptively loads the specified hero or heroes into memory using the
     skins of the specified player or players, available memory permitting. Useful
@@ -1505,11 +1118,6 @@ _&preloadHero:
     default: Hero
   return: Void
   en-US: Preload Hero
-  es-MX: Precargar héroe
-  fr-FR: Précharger un héros
-  ja-JP: ヒーローをプリロード
-  pt-BR: Pré-carregar Herói
-  zh-CN: 预加载英雄
 _&forceButtonPress:
   description: Forces one or more players to press a button virtually for a single
     frame.
@@ -1526,11 +1134,6 @@ _&forceButtonPress:
     default: Primary Fire
   return: Void
   en-US: Press Button
-  es-MX: Presionar botón
-  fr-FR: Appuyer sur un bouton
-  ja-JP: ボタンを押してください
-  pt-BR: Pressionar Botão
-  zh-CN: 按下按键
 _&resetHeroAvailability:
   description: Restores the list of heroes available to one or more players to the
     list specified by the game settings. If a player's current hero becomes unavailable,
@@ -1545,11 +1148,6 @@ _&resetHeroAvailability:
     default: Event Player
   return: Void
   en-US: Reset Player Hero Availability
-  es-MX: Restablecer disponibilidad de héroes de los jugadores
-  fr-FR: Réinitialiser la disponibilité du héros pour un joueur
-  ja-JP: プレイヤーが使用できるヒーローをリセット
-  pt-BR: Redefinir Disponibilidade de Heróis para o Jogador
-  zh-CN: 重置玩家英雄可选状态
 _&respawn:
   description: Respawns one or more players at an appropriate spawn location with
     full health, even if they were already alive.
@@ -1562,11 +1160,6 @@ _&respawn:
     default: Event Player
   return: Void
   en-US: Respawn
-  es-MX: Reaparecer
-  fr-FR: Réapparaître
-  ja-JP: リスポーン
-  pt-BR: Ressurgir
-  zh-CN: 重生
 _&resurrect:
   description: Instantly resurrects one or more players at the location they died
     with no transition.
@@ -1579,11 +1172,6 @@ _&resurrect:
     default: Event Player
   return: Void
   en-US: Resurrect
-  es-MX: Resucitar
-  fr-FR: Ressusciter
-  ja-JP: 蘇生
-  pt-BR: Ressuscitar
-  zh-CN: 重生
 _&setAbility1Enabled:
   description: Enables or disables ability 1 for one or more players.
   args:
@@ -1599,11 +1187,6 @@ _&setAbility1Enabled:
     default: 'True'
   return: Void
   en-US: Set Ability 1 Enabled
-  es-MX: Establecer habilidad 1 habilitada
-  fr-FR: Définir l’activation de la capacité 1
-  ja-JP: アビリティ1を有効化
-  pt-BR: Definir Habilidade 1 como Ativada
-  zh-CN: 设置启用技能 1
 _&setAbility2Enabled:
   description: Enables or disables ability 2 for one or more players.
   args:
@@ -1619,11 +1202,6 @@ _&setAbility2Enabled:
     default: 'True'
   return: Void
   en-US: Set Ability 2 Enabled
-  es-MX: Establecer habilidad 2 habilitada
-  fr-FR: Définir l’activation de la capacité 2
-  ja-JP: アビリティ2を有効化
-  pt-BR: Definir Habilidade 2 como Ativada
-  zh-CN: 设置启用技能 2
 _&setAbilityCooldown:
   description: Set the ability cooldown time for one or more players.
   args:
@@ -1643,11 +1221,6 @@ _&setAbilityCooldown:
     default: Number
   return: Void
   en-US: Set Ability Cooldown
-  es-MX: Establecer Reutilización de habilidad
-  fr-FR: Définir le temps de recharge de la capacité
-  ja-JP: アビリティのクールダウンを設定
-  pt-BR: Definir Tempo de Recarga da Habilidade
-  zh-CN: 设置技能冷却
 _&setAimSpeed:
   description: Sets the aim speed of one or more players to a percentage of their
     normal aim speed.
@@ -1664,11 +1237,6 @@ _&setAimSpeed:
     default: Number
   return: Void
   en-US: Set Aim Speed
-  es-MX: Establecer velocidad al apuntar
-  fr-FR: Définir la vitesse de visée
-  ja-JP: 照準速度を設定
-  pt-BR: Definir Velocidade de Mira
-  zh-CN: 设置瞄准速度
 _&setCrouchEnabled:
   description: Enables or disables crouch for one or more players.
   args:
@@ -1684,11 +1252,6 @@ _&setCrouchEnabled:
     default: 'True'
   return: Void
   en-US: Set Crouch Enabled
-  es-MX: Establecer acción de agacharse activado
-  fr-FR: Définir l’activation de S’accroupir
-  ja-JP: しゃがみを有効化
-  pt-BR: Definir Agachar Ativado
-  zh-CN: 设置启用蹲下
 _&setDamageDealt:
   description: Sets the damage dealt of one or more players to a percentage of their
     raw damage dealt.
@@ -1705,11 +1268,6 @@ _&setDamageDealt:
     default: Number
   return: Void
   en-US: Set Damage Dealt
-  es-MX: Establecer daño infligido
-  fr-FR: Définir les dégâts infligés
-  ja-JP: 与えるダメージを設定
-  pt-BR: Definir Dano Causado
-  zh-CN: 设置造成伤害
 _&setDamageReceived:
   description: Sets the damage received of one or more players to a percentage of
     their raw damage received.
@@ -1726,11 +1284,6 @@ _&setDamageReceived:
     default: Number
   return: Void
   en-US: Set Damage Received
-  es-MX: Establecer daño recibido
-  fr-FR: Définir les dégâts subis
-  ja-JP: 受けるダメージを設定
-  pt-BR: Definir Dano Recebido
-  zh-CN: 设置受到伤害
 _&setFacing:
   description: Sets the facing of one or more players to the specified direction.
   args:
@@ -1750,11 +1303,6 @@ _&setFacing:
     default: To World
   return: Void
   en-US: Set Facing
-  es-MX: Establecer orientación
-  fr-FR: Définir la direction du regard
-  ja-JP: 向き変更を設定
-  pt-BR: Definir Encarar
-  zh-CN: 设置朝向
 __setGlobalVariable__:
   description: Stores a value into a global variable, which is a variable that belongs
     to the game itself.
@@ -1771,11 +1319,6 @@ __setGlobalVariable__:
     default: Number
   return: Void
   en-US: Set Global Variable
-  es-MX: Establecer variable global
-  fr-FR: Définir une variable globale
-  ja-JP: グローバル変数を設定
-  pt-BR: Definir Variável Global
-  zh-CN: 设置全局变量
 __setGlobalVariableAtIndex__:
   description: Finds or creates an array on a global variable, which is a variable
     that belongs to the game itself, then stores a value in the array at the specified
@@ -1797,11 +1340,6 @@ __setGlobalVariableAtIndex__:
     default: Number
   return: Void
   en-US: Set Global Variable At Index
-  es-MX: Establecer variable global según el índice
-  fr-FR: Définir une variable globale à l’index
-  ja-JP: インデックスのグローバル変数を設定
-  pt-BR: Definir Variável Global no Índice
-  zh-CN: 在索引处设置全局变量
 _&setGravity:
   description: Sets the movement gravity for one or more players to a percentage regular
     movement gravity.
@@ -1818,11 +1356,6 @@ _&setGravity:
     default: Number
   return: Void
   en-US: Set Gravity
-  es-MX: Establecer gravedad
-  fr-FR: Définir la gravité
-  ja-JP: 重力を設定
-  pt-BR: Definir Gravidade
-  zh-CN: 设置引力
 _&setHealingDealt:
   description: Sets the healing dealt of one or more players to a percentage of their
     raw healing dealt.
@@ -1839,11 +1372,6 @@ _&setHealingDealt:
     default: Number
   return: Void
   en-US: Set Healing Dealt
-  es-MX: Establecer sanación realizada
-  fr-FR: Définir les soins prodigués
-  ja-JP: 与える回復を設定
-  pt-BR: Definir Cura Realizada
-  zh-CN: 设置造成治疗
 _&setHealingReceived:
   description: Sets the healing received of one or more players to a percentage of
     their raw healing received.
@@ -1860,11 +1388,6 @@ _&setHealingReceived:
     default: Number
   return: Void
   en-US: Set Healing Received
-  es-MX: Establecer sanación recibida
-  fr-FR: Définir les soins reçus
-  ja-JP: 受ける回復量を設定
-  pt-BR: Definir Cura Recebida
-  zh-CN: 设置受到治疗
 _&setInvisibility:
   description: Causes one or more players to become invisible to either all other
     players or just enemies.
@@ -1881,11 +1404,6 @@ _&setInvisibility:
     default: ALL
   return: Void
   en-US: Set Invisible
-  es-MX: Establecer invisibilidad
-  fr-FR: Définir l’invisibilité
-  ja-JP: 目視可否を設定
-  pt-BR: Definir como Invisível
-  zh-CN: 设置不可见
 _&setJumpEnabled:
   description: Enables or disables jump for one or more players.
   args:
@@ -1901,11 +1419,6 @@ _&setJumpEnabled:
     default: 'True'
   return: Void
   en-US: Set Jump Enabled
-  es-MX: Establecer salto activado
-  fr-FR: Définir l’activation de Sauter
-  ja-JP: ジャンプを有効化
-  pt-BR: Definir Pular Ativado
-  zh-CN: 设置启用跳跃
 setMatchTime:
   description: Sets the current match time (which is visible at the top of the screen).
     This can be used to shorten or extend the duration of a match or to change the
@@ -1917,11 +1430,6 @@ setMatchTime:
     default: Number
   return: Void
   en-US: Set Match Time
-  es-MX: Establecer tiempo de la partida
-  fr-FR: Définir le temps de jeu
-  ja-JP: マッチ時間を設定
-  pt-BR: Definir Tempo da Partida
-  zh-CN: 设置比赛时间
 _&setMaxHealth:
   description: Sets the max health of one or more players as a percentage of their
     max health. This action will ensure that a player's current health will not exceed
@@ -1939,11 +1447,6 @@ _&setMaxHealth:
     default: Number
   return: Void
   en-US: Set Max Health
-  es-MX: Establecer salud máxima
-  fr-FR: Définir les points de vie maximum
-  ja-JP: 最大ライフを設定
-  pt-BR: Definir Vida Máxima
-  zh-CN: 设置最大生命值
 _&setMeleeEnabled:
   description: Enables or disables melee for one or more players.
   args:
@@ -1959,11 +1462,6 @@ _&setMeleeEnabled:
     default: 'True'
   return: Void
   en-US: Set Melee Enabled
-  es-MX: Establecer ataques melé activado
-  fr-FR: Définir l’activation de Mêlée
-  ja-JP: 近接攻撃を有効化
-  pt-BR: Definir Corpo a Corpo Ativado
-  zh-CN: 设置启用近战攻击
 _&setMoveSpeed:
   description: Sets the move speed of one or more players to a percentage of their
     raw move speed.
@@ -1980,11 +1478,6 @@ _&setMoveSpeed:
     default: Number
   return: Void
   en-US: Set Move Speed
-  es-MX: Establecer velocidad de movimiento
-  fr-FR: Définir la vitesse de déplacement
-  ja-JP: 移動速度を設定
-  pt-BR: Definir Velocidade de Movimento
-  zh-CN: 设置移动速度
 setObjectiveDescription:
   description: Sets the text at the top center of the screen that normally describes
     the objective to a message visible to specific players.
@@ -2005,11 +1498,6 @@ setObjectiveDescription:
     default: Visible To And String
   return: Void
   en-US: Set Objective Description
-  es-MX: Establecer descripción de objetivo
-  fr-FR: Définir la description d’objectif
-  ja-JP: 目標の説明を設定
-  pt-BR: Definir Descrição do Objetivo
-  zh-CN: 设置目标点描述
 _&setAllowedHeroes:
   description: Sets the list of heroes available to one or more players. If a player's
     current hero becomes unavailable, the player is forced to choose a different hero
@@ -2029,11 +1517,6 @@ _&setAllowedHeroes:
     default: Hero
   return: Void
   en-US: Set Player Allowed Heroes
-  es-MX: Establecer héroes permitidos para los jugadores
-  fr-FR: Définir les héros autorisés pour un joueur
-  ja-JP: プレイヤーが使用できるヒーローを設定
-  pt-BR: Definir Heróis Permitidos para o Jogador
-  zh-CN: 设置玩家可选的英雄
 _&setScore:
   description: Sets the score (kill count) of one or more players. This action only
     has an effect in free-for-all modes.
@@ -2050,11 +1533,6 @@ _&setScore:
     default: Number
   return: Void
   en-US: Set Player Score
-  es-MX: Establecer puntuación del jugador
-  fr-FR: Définir le score d’un joueur
-  ja-JP: プレイヤー・スコアを設定する
-  pt-BR: Definir Pontuação do Jogador
-  zh-CN: 设置玩家分数
 __setPlayerVariable__:
   description: Stores a value into a player variable, which is a variable that belongs
     to a specific player.
@@ -2077,11 +1555,6 @@ __setPlayerVariable__:
     default: Number
   return: Void
   en-US: Set Player Variable
-  es-MX: Establecer variable de jugador
-  fr-FR: Définir une variable de joueur
-  ja-JP: プレイヤー変数を設定
-  pt-BR: Definir Variável de Jogador
-  zh-CN: 设置玩家变量
 __setPlayerVariableAtIndex__:
   description: Finds or creates an array on a player variable, which is a variable
     that belongs to a specific player, then stores a value in the array at the specified
@@ -2109,11 +1582,6 @@ __setPlayerVariableAtIndex__:
     default: Number
   return: Void
   en-US: Set Player Variable At Index
-  es-MX: Establecer variable de jugador según el índice
-  fr-FR: Définir une variable de joueur à l’index
-  ja-JP: インデックスのプレイヤー変数を設定
-  pt-BR: Definir Variável de Jogador no Índice
-  zh-CN: 在索引处设置玩家变量
 _&setPrimaryFireEnabled:
   description: Enables or disables primary fire for one or more players.
   args:
@@ -2129,11 +1597,6 @@ _&setPrimaryFireEnabled:
     default: 'True'
   return: Void
   en-US: Set Primary Fire Enabled
-  es-MX: Establecer disparo principal habilitado
-  fr-FR: Définir l’activation du tir principal
-  ja-JP: メイン攻撃を許可
-  pt-BR: Definir Disparo Primário Ativado
-  zh-CN: 设置主要攻击模式启用
 _&setProjectileGravity:
   description: Sets the projectile gravity for one or more players to a percentage
     of regular projectile gravity.
@@ -2150,11 +1613,6 @@ _&setProjectileGravity:
     default: Number
   return: Void
   en-US: Set Projectile Gravity
-  es-MX: Establecer gravedad del proyectil
-  fr-FR: Définir la gravité des projectiles
-  ja-JP: 弾の重力を設定
-  pt-BR: Definir Gravidade de Projétil
-  zh-CN: 设置弹道引力
 _&setProjectileSpeed:
   description: Sets the projectile speed for one or more players to a percentage of
     projectile speed.
@@ -2171,11 +1629,6 @@ _&setProjectileSpeed:
     default: Number
   return: Void
   en-US: Set Projectile Speed
-  es-MX: Establecer velocidad del proyectil
-  fr-FR: Définir la vitesse des projectiles
-  ja-JP: 弾速を設定
-  pt-BR: Definir Velocidade de Projétil
-  zh-CN: 设置弹道速度
 _&setRespawnTime:
   description: Sets the duration between death and respawn for one or more players.
     For players that are already dead when this action is executed, the change takes
@@ -2193,11 +1646,6 @@ _&setRespawnTime:
     default: Number
   return: Void
   en-US: Set Respawn Max Time
-  es-MX: Establecer tiempo máximo de reaparición
-  fr-FR: Définir la durée maximum avant réapparition
-  ja-JP: 最大リスポーン時間を設定
-  pt-BR: Definir Tempo Máximo de Ressurgimento
-  zh-CN: 设置最大重生时间
 _&setSecondaryFireEnabled:
   description: Enables or disables secondary fire for one or more players.
   args:
@@ -2213,11 +1661,6 @@ _&setSecondaryFireEnabled:
     default: 'True'
   return: Void
   en-US: Set Secondary Fire Enabled
-  es-MX: Establecer disparo secundario habilitado
-  fr-FR: Définir l’activation du tir secondaire
-  ja-JP: サブ攻撃を許可
-  pt-BR: Definir Disparo Secundário Ativado
-  zh-CN: 设置辅助攻击模式启用
 setSlowMotion:
   description: Sets the simulation rate for the entire game, including all players,
     projectiles, effects, and game mode logic.
@@ -2228,11 +1671,6 @@ setSlowMotion:
     default: Number
   return: Void
   en-US: Set Slow Motion
-  es-MX: Establecer cámara lenta
-  fr-FR: Définir un ralenti
-  ja-JP: スローモーションを設定
-  pt-BR: Definir Câmera Lenta
-  zh-CN: 设置慢动作
 _&setStatusEffect:
   description: Applies a status to one or more players. This status will remain in
     effect for the specified duration or until it is cleared by the clear status action.
@@ -2257,11 +1695,6 @@ _&setStatusEffect:
     default: Number
   return: Void
   en-US: Set Status
-  es-MX: Establecer estado
-  fr-FR: Définir un statut
-  ja-JP: ステータスを設定
-  pt-BR: Definir Status
-  zh-CN: 设置状态
 setTeamScore:
   description: Sets the score for one or both teams. This action has no effect in
     free-for-all modes or modes without a team score.
@@ -2276,11 +1709,6 @@ setTeamScore:
     default: Number
   return: Void
   en-US: Set Team Score
-  es-MX: Establecer puntuación del equipo
-  fr-FR: Définir le score d’une équipe
-  ja-JP: チーム・スコアを設定
-  pt-BR: Definir Pontuação da Equipe
-  zh-CN: 设置队伍分数
 _&setUltEnabled:
   description: Enables or disables the ultimate ability of one or more players.
   args:
@@ -2296,11 +1724,6 @@ _&setUltEnabled:
     default: 'True'
   return: Void
   en-US: Set Ultimate Ability Enabled
-  es-MX: Establecer habilidad máxima habilitada
-  fr-FR: Définir l’activation de la capacité ultime
-  ja-JP: アルティメット・アビリティを有効化
-  pt-BR: Definir Habilidade Suprema como Ativada
-  zh-CN: 设置启用终极技能
 _&setUltCharge:
   description: Sets the ultimate charge for one or more players as a percentage of
     maximum charge.
@@ -2317,11 +1740,6 @@ _&setUltCharge:
     default: Number
   return: Void
   en-US: Set Ultimate Charge
-  es-MX: Establecer carga de habilidad máxima
-  fr-FR: Définir la charge de la capacité ultime
-  ja-JP: アルティメット・チャージを設定
-  pt-BR: Definir Carga da Suprema
-  zh-CN: 设置终极技能充能
 __skip__:
   description: Skips execution of a certain number of actions in the action list.
   args:
@@ -2331,11 +1749,6 @@ __skip__:
     default: Number
   return: Void
   en-US: Skip
-  es-MX: Omitir
-  fr-FR: Passer
-  ja-JP: スキップ
-  pt-BR: Ignorar
-  zh-CN: 跳过
 __skipIf__:
   description: Skips execution of a certain number of actions in the action list if
     this action's condition evaluates to true. If it does not, execution continues
@@ -2351,11 +1764,6 @@ __skipIf__:
     default: Number
   return: Void
   en-US: Skip If
-  es-MX: Omitir si
-  fr-FR: Passer si
-  ja-JP: スキップする条件
-  pt-BR: Ignorar se
-  zh-CN: 根据条件跳过
 smallMessage:
   description: Displays a small message beneath the reticle that is visible to specific
     players.
@@ -2372,11 +1780,6 @@ smallMessage:
     default: String
   return: Void
   en-US: Small Message
-  es-MX: Mensaje pequeño
-  fr-FR: Message en petit
-  ja-JP: 小さなメッセージ
-  pt-BR: Mensagem Pequena
-  zh-CN: 小字体信息
 _&startAcceleration:
   description: Starts accelerating one or more players in a specified direction.
   args:
@@ -2408,11 +1811,6 @@ _&startAcceleration:
     default: Direction, Rate, And Max Speed
   return: Void
   en-US: Start Accelerating
-  es-MX: Comenzar la aceleración
-  fr-FR: Accélérer
-  ja-JP: 加速の開始
-  pt-BR: Começar a Acelerar
-  zh-CN: 开始加速
 _&setCamera:
   description: Places your camera at a location, facing a direction.
   args:
@@ -2436,11 +1834,6 @@ _&setCamera:
     default: Number
   return: Void
   en-US: Start Camera
-  es-MX: Comenzar cámara
-  fr-FR: Lancer la caméra
-  ja-JP: カメラの始動
-  pt-BR: Iniciar Câmera
-  zh-CN: 开始镜头
 startDamageModification:
   description: Starts modifying how much damage one or more receivers will receive
     from one or more damagers. A reference to this damage modification can be obtained
@@ -2469,11 +1862,6 @@ startDamageModification:
     default: Receivers, Damagers, And Damage Percent
   return: Void
   en-US: Start Damage Modification
-  es-MX: Comenzar modificación de daño
-  fr-FR: Lancer la modification des dégâts
-  ja-JP: ダメージ変更を開始
-  pt-BR: Começar Modificação de Dano
-  zh-CN: 开始伤害调整
 _&startDoT:
   description: Starts an instance of damage over time. This dot will persist for the
     specified duration or until stopped by script. To obtain a reference to this dot,
@@ -2499,11 +1887,6 @@ _&startDoT:
     default: Number
   return: Void
   en-US: Start Damage Over Time
-  es-MX: Comenzar daño con el tiempo
-  fr-FR: Infliger des dégâts sur la durée
-  ja-JP: 継続ダメージを開始
-  pt-BR: Começar Dano ao Longo do Tempo
-  zh-CN: 开始持续伤害
 _&startFacing:
   description: Starts turning one or more players to face the specified direction.
   args:
@@ -2531,11 +1914,6 @@ _&startFacing:
     default: Direction And Turn Rate
   return: Void
   en-US: Start Facing
-  es-MX: Comenzar orientación
-  fr-FR: Regarder vers
-  ja-JP: 向き変更を開始
-  pt-BR: Começar a Encarar
-  zh-CN: 开始朝向
 _&startForcingHero:
   description: Starts forcing one or more players to be a specific hero and, if necessary,
     respawns them immediately in their current location. This will be the only hero
@@ -2554,11 +1932,6 @@ _&startForcingHero:
     default: Hero
   return: Void
   en-US: Start Forcing Player To Be Hero
-  es-MX: Comenzar a forzar a un jugador a usar un héroe
-  fr-FR: Forcer un héros
-  ja-JP: プレイヤーへのヒーロー強制を開始
-  pt-BR: Começar a Forçar Jogador a Ser o Herói
-  zh-CN: 开始强制玩家选择英雄
 _&startForcingPosition:
   description: Starts forcing a player to be in a given position. If reevaluation
     is enabled, then the position is evaluated every frame, allowing the player to
@@ -2578,11 +1951,6 @@ _&startForcingPosition:
     default: 'True'
   return: Void
   en-US: Start Forcing Player Position
-  es-MX: Comenzar a forzar la posición del jugador
-  fr-FR: Forcer la position du joueur
-  ja-JP: プレイヤーの位置強制を開始
-  pt-BR: Começar a Forçar Posição do Jogador
-  zh-CN: 开始强制设置玩家位置
 startForcingSpawn:
   description: Forces a team to spawn in a particular spawn room, regardless of the
     spawn room normally used by the game mode. This action only has an effect in assault,
@@ -2598,11 +1966,6 @@ startForcingSpawn:
     default: Number
   return: Void
   en-US: Start Forcing Spawn Room
-  es-MX: Comenzar a forzar cuarto de reaparición
-  fr-FR: Forcer une salle d’apparition
-  ja-JP: リスポーンエリアの強制を開始
-  pt-BR: Começar a Forçar Sala de Ressurgimento
-  zh-CN: 开始强制重生室
 _&startForcingThrottle:
   description: Defines minimum and maximum movement input values for one or more players,
     possibly forcing or preventing movement.
@@ -2639,11 +2002,6 @@ _&startForcingThrottle:
     default: Number
   return: Void
   en-US: Start Forcing Throttle
-  es-MX: Comenzar a forzar la aceleración
-  fr-FR: Forcer l’accélération
-  ja-JP: 強制スロットル開始
-  pt-BR: Começar a Forçar Aceleração
-  zh-CN: 开始限制阈值
 _&startHoT:
   description: Starts an instance of heal over time. This hot will persist for the
     specified duration or until stopped by script. To obtain a reference to this hot,
@@ -2669,11 +2027,6 @@ _&startHoT:
     default: Number
   return: Void
   en-US: Start Heal Over Time
-  es-MX: Comenzar sanación con el tiempo
-  fr-FR: Prodiguer des soins sur la durée
-  ja-JP: 継続回復を開始
-  pt-BR: Começar Cura ao Longo do Tempo
-  zh-CN: 开始持续治疗
 startHealingModification:
   description: Starts modifying how much healing one or more receivers will receive
     from one or more healers. A reference to this healing modification can be obtained
@@ -2702,11 +2055,6 @@ startHealingModification:
     default: Receivers, Healers, And Healing Percent
   return: Void
   en-US: Start Healing Modification
-  es-MX: Comenzar modificación de sanación
-  fr-FR: Lancer la modification des soins
-  ja-JP: 回復変更を開始
-  pt-BR: Começar modificação de cura
-  zh-CN: 开始治疗调整
 _&startForcingButton:
   description: Forces one or more players to hold a button virtually until stopped
     by the stop holding button action.
@@ -2723,11 +2071,6 @@ _&startForcingButton:
     default: Primary Fire
   return: Void
   en-US: Start Holding Button
-  es-MX: Comenzar a mantener el botón presionado
-  fr-FR: Maintenir un bouton enfoncé
-  ja-JP: ボタン長押し開始
-  pt-BR: Começar a Segurar Botão
-  zh-CN: 开始按下按钮
 __startRule__:
   description: Begins simultaneous execution of a subroutine rule (which is a rule
     with a Subroutine event type). Execution of the original rule continues uninterrupted.
@@ -2744,11 +2087,6 @@ __startRule__:
     default: RESTART RULE
   return: Void
   en-US: Start Rule
-  es-MX: Comenzar regla
-  fr-FR: Lancer la règle
-  ja-JP: ルールを開始
-  pt-BR: Regra de início
-  zh-CN: 开始规则
 _&startThrottleInDirection:
   description: Sets or adds to the throttle (directional input control) of a player
     or players such that they begin moving in a particular direction. Any previous
@@ -2782,11 +2120,6 @@ _&startThrottleInDirection:
     default: Direction And Magnitude
   return: Void
   en-US: Start Throttle In Direction
-  es-MX: Comenzar aceleración en dirección
-  fr-FR: Commencer l’accélération directionnelle
-  ja-JP: 指定方向にスロットル開始
-  pt-BR: Iniciar Aceleração na Direção
-  zh-CN: 开始定向阈值
 _&startTransformingThrottle:
   description: Starts transforming (scaling and rotating) the throttle (directional
     input control) of a player or players. Cancels any existing start transforming
@@ -2812,11 +2145,6 @@ _&startTransformingThrottle:
     default: Vector
   return: Void
   en-US: Start Transforming Throttle
-  es-MX: Comenzar a transformar la aceleración
-  fr-FR: Début de modification de l’accélération
-  ja-JP: スロットルの変化を開始
-  pt-BR: Iniciar Transformação de Aceleração
-  zh-CN: 开始转换阈值
 _&stopAcceleration:
   description: Stops the acceleration started by the start accelerating action for
     one or more players.
@@ -2829,33 +2157,18 @@ _&stopAcceleration:
     default: Event Player
   return: Void
   en-US: Stop Accelerating
-  es-MX: Detener la aceleración
-  fr-FR: Arrêter l’accélération
-  ja-JP: 加速の中止
-  pt-BR: Parar de Acelerar
-  zh-CN: 停止加速
 stopAllDamageModifications:
   description: Stops all damage modifications that were started using the start damage
     modification action.
   args: []
   return: Void
   en-US: Stop All Damage Modifications
-  es-MX: Detener todas las modificaciones de daño
-  fr-FR: Arrêter toutes les modifications de dégâts
-  ja-JP: すべてのダメージ変更を停止
-  pt-BR: Parar Todas as Modificações de Dano
-  zh-CN: 停止所有伤害调整
 stopAllHealingModifications:
   description: Stops all healing modifications that were started using the start healing
     modification action.
   args: []
   return: Void
   en-US: Stop All Healing Modifications
-  es-MX: Detener todas las modificaciones de sanación
-  fr-FR: Terminer toutes les modifications de soins
-  ja-JP: すべての回復変更を停止
-  pt-BR: Parar todas as modificações de cura
-  zh-CN: 停止所有治疗调整
 _&stopAllDoT:
   description: Stops all damage over time started by start damage over time for one
     or more players.
@@ -2868,11 +2181,6 @@ _&stopAllDoT:
     default: Event Player
   return: Void
   en-US: Stop All Damage Over Time
-  es-MX: Detener todo el daño con el tiempo
-  fr-FR: Arrêter tous les dégâts sur la durée
-  ja-JP: すべての継続ダメージを停止
-  pt-BR: Parar Todo o Dano ao Longo do Tempo
-  zh-CN: 停止所有持续伤害
 _&stopAllHoT:
   description: Stops all heal over time started by start heal over time for one or
     more players.
@@ -2885,11 +2193,6 @@ _&stopAllHoT:
     default: Event Player
   return: Void
   en-US: Stop All Heal Over Time
-  es-MX: Detener toda la sanación con el tiempo
-  fr-FR: Arrêter tous les soins sur la durée
-  ja-JP: すべての継続回復を停止
-  pt-BR: Parar Toda a Cura ao Longo do Tempo
-  zh-CN: 停止所有持续治疗
 _&stopCamera:
   description: Restores the camera to the default view.
   args:
@@ -2901,11 +2204,6 @@ _&stopCamera:
     default: Event Player
   return: Void
   en-US: Stop Camera
-  es-MX: Detener cámara
-  fr-FR: Arrêter la caméra
-  ja-JP: カメラの停止
-  pt-BR: Parar Câmera
-  zh-CN: 停止镜头
 __stopChasingGlobalVariable__:
   description: Stops an in-progress chase of a global variable, leaving it at its
     current value.
@@ -2916,11 +2214,6 @@ __stopChasingGlobalVariable__:
     default: A
   return: Void
   en-US: Stop Chasing Global Variable
-  es-MX: Detener seguimiento de variable global
-  fr-FR: Arrêter de modifier une variable globale
-  ja-JP: グローバル変数の追跡を中止
-  pt-BR: Parar de Acompanhar Variável Global
-  zh-CN: 停止追踪全局变量
 __stopChasingPlayerVariable__:
   description: Stops an in-progress chase of a player variable, leaving it at its
     current value.
@@ -2937,11 +2230,6 @@ __stopChasingPlayerVariable__:
     default: A
   return: Void
   en-US: Stop Chasing Player Variable
-  es-MX: Detener seguimiento de variable de jugador
-  fr-FR: Arrêter de modifier une variable de joueur
-  ja-JP: プレイヤー変数の追跡を中止
-  pt-BR: Parar de Acompanhar Variável de Jogador
-  zh-CN: 停止追踪玩家变量
 stopDamageModification:
   description: Stops a damage modification that was started by the start damage modification
     action.
@@ -2952,11 +2240,6 @@ stopDamageModification:
     default: Last Damage Modification ID
   return: Void
   en-US: Stop Damage Modification
-  es-MX: Detener modificación de daño
-  fr-FR: Arrêter la modification des dégâts
-  ja-JP: ダメージ変更を停止
-  pt-BR: Parar Modificação de Dano
-  zh-CN: 停止伤害调整
 stopDoT:
   description: Stops an instance of damage over time started by the start damage over
     time action.
@@ -2967,11 +2250,6 @@ stopDoT:
     default: Last Damage Over Time ID
   return: Void
   en-US: Stop Damage Over Time
-  es-MX: Detener daño con el tiempo
-  fr-FR: Arrêter des dégâts sur la durée
-  ja-JP: 継続ダメージを停止
-  pt-BR: Parar Dano ao Longo do Tempo
-  zh-CN: 停止持续伤害
 _&stopFacing:
   description: Stops the turning started by the start facing action for one or more
     players.
@@ -2984,11 +2262,6 @@ _&stopFacing:
     default: Event Player
   return: Void
   en-US: Stop Facing
-  es-MX: Detener orientación
-  fr-FR: Arrêter de regarder vers
-  ja-JP: 向き変更を停止
-  pt-BR: Parar de Encarar
-  zh-CN: 停止朝向
 _&stopForcingCurrentHero:
   description: Stops forcing one or more players to be a specific hero. This will
     not respawn the player or players, but it will restore their hero availability
@@ -3002,11 +2275,6 @@ _&stopForcingCurrentHero:
     default: Event Player
   return: Void
   en-US: Stop Forcing Player To Be Hero
-  es-MX: Dejar de forzar a un jugador a usar un héroe
-  fr-FR: Arrêter de forcer un héros
-  ja-JP: プレイヤーへのヒーロー強制を停止
-  pt-BR: Parar de Forçar Jogador a Ser o Herói
-  zh-CN: 停止强制玩家选择英雄
 _&stopForcingPosition:
   description: Cancels the behavior of `startForcingPosition()` for the specified
     player or players. Regular movement will resume from the last forced position(s).
@@ -3019,11 +2287,6 @@ _&stopForcingPosition:
     default: Event Player
   return: Void
   en-US: Stop Forcing Player Position
-  es-MX: Dejar de forzar la posición del jugador
-  fr-FR: Arrêter de forcer la position du joueur
-  ja-JP: プレイヤーの位置強制を停止
-  pt-BR: Parar de Forçar Posição do Jogador
-  zh-CN: 停止强制设置玩家位置
 stopForcingSpawn:
   description: Undoes the effect of the start forcing spawn room action for the specified
     team.
@@ -3034,11 +2297,6 @@ stopForcingSpawn:
     default: Team
   return: Void
   en-US: Stop Forcing Spawn Room
-  es-MX: Dejar de forzar cuarto de reaparición
-  fr-FR: Arrêter de forcer une salle d’apparition
-  ja-JP: リスポーンエリアの強制を停止
-  pt-BR: Parar de Forçar Sala de Ressurgimento
-  zh-CN: 停止强制重生室
 _&stopForcingThrottle:
   description: Undoes the effect of the start forcing throttle action for one or more
     players.
@@ -3051,11 +2309,6 @@ _&stopForcingThrottle:
     default: Event Player
   return: Void
   en-US: Stop Forcing Throttle
-  es-MX: Dejar de forzar la aceleración
-  fr-FR: Arrêter de forcer l’accélération
-  ja-JP: 強制スロットル中止
-  pt-BR: Parar de Forçar Aceleração
-  zh-CN: 停止限制阈值
 stopHoT:
   description: Stops an instance of heal over time started by the start heal over
     time action.
@@ -3066,11 +2319,6 @@ stopHoT:
     default: Player Variable
   return: Void
   en-US: Stop Heal Over Time
-  es-MX: Detener sanación con el tiempo
-  fr-FR: Arrêter des soins sur la durée
-  ja-JP: 継続回復を停止
-  pt-BR: Parar Cura ao Longo do Tempo
-  zh-CN: 停止持续治疗
 stopHealingModification:
   description: Stops a healing modification that was started by the start healing
     modification action.
@@ -3081,11 +2329,6 @@ stopHealingModification:
     default: Last Healing Modification ID
   return: Void
   en-US: Stop Healing Modification
-  es-MX: Detener modificación de sanación
-  fr-FR: Terminer la modification de soins
-  ja-JP: 回復変更を停止
-  pt-BR: Parar modificação de cura
-  zh-CN: 停止治疗调整
 _&stopForcingButton:
   description: Undoes the effect of the start holding button action for one or more
     players.
@@ -3102,11 +2345,6 @@ _&stopForcingButton:
     default: Primary Fire
   return: Void
   en-US: Stop Holding Button
-  es-MX: Dejar de mantener el botón presionado
-  fr-FR: Arrêter de maintenir un bouton enfoncé
-  ja-JP: ボタン長押し解除
-  pt-BR: Parar de Segurar Botão
-  zh-CN: 停止按下按钮
 _&stopThrottleInDirection:
   description: Cancels the behavior caused by start throttle in direction.
   args:
@@ -3118,11 +2356,6 @@ _&stopThrottleInDirection:
     default: Event Player
   return: Void
   en-US: Stop Throttle In Direction
-  es-MX: Detener aceleración en dirección
-  fr-FR: Arrêter l’accélération directionnelle
-  ja-JP: 指定方向にスロットル終了
-  pt-BR: Parar Aceleração na Direção
-  zh-CN: 停止定向阈值
 _&stopTransformingThrottle:
   description: Stops the throttle transform started by start transforming throttle
     for one or more players.
@@ -3135,11 +2368,6 @@ _&stopTransformingThrottle:
     default: Event Player
   return: Void
   en-US: Stop Transforming Throttle
-  es-MX: Dejar de transformar la aceleración
-  fr-FR: Arrêt de modification de l’accélération
-  ja-JP: スロットルの変化を停止
-  pt-BR: Parar Transformação de Aceleração
-  zh-CN: 停止转换阈值
 _&teleport:
   description: Teleports one or more players to the specified position.
   args:
@@ -3155,21 +2383,11 @@ _&teleport:
     default: Vector
   return: Void
   en-US: Teleport
-  es-MX: Transportar
-  fr-FR: Téléportation
-  ja-JP: テレポート
-  pt-BR: Teletransportar
-  zh-CN: 传送
 unpauseMatchTime:
   description: Unpauses the match time.
   args: []
   return: Void
   en-US: Unpause Match Time
-  es-MX: Despausar tiempo de la partida
-  fr-FR: Reprendre le temps de jeu
-  ja-JP: マッチ時間のポーズを解除
-  pt-BR: Retomar Tempo da Partida
-  zh-CN: 比赛时间继续
 __wait__:
   description: Pauses the execution of the action list. Unless the wait is interrupted,
     the remainder of the actions will execute after the pause.
@@ -3184,11 +2402,6 @@ __wait__:
     default: Ignore Condition
   return: Void
   en-US: Wait
-  es-MX: Esperar
-  fr-FR: Attente
-  ja-JP: 待機
-  pt-BR: Esperar
-  zh-CN: 等待
 __while__:
   description: Denotes the beginning of a series of actions that will execute in a
     loop as long as the specified condition is true. The next end action at the current
@@ -3202,9 +2415,6 @@ __while__:
     default: Compare
   return: Void
   en-US: While
-  es-MX: Mientras
-  fr-FR: Tant que
-  ja-JP: While
 setAmmo:
   description: Set the ammo of one or more Players.
   args:

--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -461,7 +461,7 @@ createEffect:
     default: Vector
   - name: Radius
     description: The radius of this effect.
-    type: unsigned float
+    type: Float
     default: Number (1)
   - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated.
@@ -1555,7 +1555,7 @@ playEffect:
     default: Vector
   - name: Radius
     description: The effect's radius in meters.
-    type: unsigned float
+    type: Float
     default: Number (1)
   guid: 00000000BB27
   return: Void
@@ -1725,7 +1725,7 @@ _&setAbilityCooldown:
     default: Primary Fire
   - name: COOLDOWN
     description: The cooldown time that will be set in seconds. Max of 1000.
-    type: unsigned float
+    type: Float
     default: Number
   return: Void
   guid: 0000000109CA
@@ -1747,7 +1747,7 @@ _&setAimSpeed:
     default: Event Player
   - name: Turn Speed Percent
     description: The percentage of normal aim speed to which the player or players will set their aim speed.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000C364
   return: Void
@@ -1790,7 +1790,7 @@ _&setDamageDealt:
     default: Event Player
   - name: Damage Dealt Percent
     description: The percentage of raw damage dealt to which the player or players will set their damage dealt.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B995
   return: Void
@@ -1812,7 +1812,7 @@ _&setDamageReceived:
     default: Event Player
   - name: Damage Received Percent
     description: The percentage of raw damage received to which the player or players will set their damage received.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B997
   return: Void
@@ -1908,7 +1908,7 @@ _&setGravity:
     default: Event Player
   - name: Gravity Percent
     description: The percentage of regular movement gravity to which the player or players will set their personal movement gravity.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B999
   return: Void
@@ -1930,7 +1930,7 @@ _&setHealingDealt:
     default: Event Player
   - name: Healing Dealt Percent
     description: ''
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B991
   return: Void
@@ -1952,7 +1952,7 @@ _&setHealingReceived:
     default: Event Player
   - name: Healing Received Percent
     description: The percentage of raw healing received to which the player or players will set their healing received.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B993
   return: Void
@@ -2035,7 +2035,7 @@ _&setMaxHealth:
     default: Event Player
   - name: Health Percent
     description: The percentage of raw max health to which the player or players will set their max health.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 0000000078FA
   return: Void
@@ -2078,7 +2078,7 @@ _&setMoveSpeed:
     default: Event Player
   - name: Move Speed Percent
     description: The percentage of raw move speed to which the player or players will set their move speed.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B998
   return: Void
@@ -2255,7 +2255,7 @@ _&setProjectileGravity:
     default: Event Player
   - name: Projectile Gravity Percent
     description: The percentage of regular projectile gravity to which the player or players will set their personal projectile gravity.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B99B
   return: Void
@@ -2277,7 +2277,7 @@ _&setProjectileSpeed:
     default: Event Player
   - name: Projectile Speed Percent
     description: The percentage of regular projectile speed to which the player or players will set their personal projectile speed.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B99D
   return: Void
@@ -2337,7 +2337,7 @@ setSlowMotion:
   args:
   - name: Speed Percent
     description: The simulation rate as a percentage of normal speed. Only rates up to 100% are allowed.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B9F2
   return: Void
@@ -2367,7 +2367,7 @@ _&setStatusEffect:
     default: Hacked
   - name: Duration
     description: The duration of the status in seconds. To have a status that lasts until a clear status action is executed, provide an arbitrarily long duration such as 9999.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B588
   return: Void
@@ -2430,7 +2430,7 @@ _&setUltCharge:
     default: Event Player
   - name: Charge Percent
     description: The percentage of maximum charge.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000BB1C
   return: Void
@@ -2513,11 +2513,11 @@ _&startAcceleration:
     default: Vector
   - name: Rate
     description: The rate of acceleration in meters per second squared. This value may need to be quite high in order to overcome gravity and/or surface friction.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Max Speed
     description: The speed at which acceleration will stop for the player or players. It may not be possible to reach this speed due to gravity and/or surface friction.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
@@ -2554,7 +2554,7 @@ _&setCamera:
     default: Vector
   - name: Blend Speed
     description: How fast to blend the camera speed as positions change. 0 means do not blend at all, and just change positions instantly.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000C393
   return: Void
@@ -2584,7 +2584,7 @@ startDamageModification:
     default: All Players
   - name: Damage Percent
     description: The percentage of damage that will apply to receivers when attacked by damagers.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
@@ -2615,11 +2615,11 @@ _&startDoT:
     default: 'Null'
   - name: Duration
     description: The duration of the damage over time in seconds. To have a dot that lasts until stopped by script, provide an arbitrarily long duration such as 9999.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Damage Per Second
     description: The damage per second for the damage over time.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B9C5
   return: Void
@@ -2644,7 +2644,7 @@ _&startFacing:
     default: Vector
   - name: Turn Rate
     description: The turn rate in degrees per second.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
@@ -2744,27 +2744,27 @@ _&startForcingThrottle:
     default: Event Player
   - name: Min Forward
     description: Sets the minimum run forward amount. 0 allows the player or players to stop while 1 forces full forward movement.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Max Forward
     description: Sets the maximum run forward amount. 0 prevents the player or players from moving forward while 1 allows full forward movement.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Min Backward
     description: Sets the minimum run backward amount. 0 allows the player or players to stop while 1 forces full backward movement.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Max Backward
     description: Sets the maximum run backward amount. 0 prevents the player or players from moving backward while 1 allows full backward movement.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Min Sideways
     description: Sets the minimum run sideways amount. 0 allows the player or players to stop while 1 forces full sideways movement.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Max Sideways
     description: Sets the maximum run sideways amount. 0 prevents the player or players from moving Sideways while 1 allows full sideways movement.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000BB0F
   return: Void
@@ -2791,11 +2791,11 @@ _&startHoT:
     default: 'Null'
   - name: Duration
     description: The duration of the heal over time in seconds. To have a hot that lasts until stopped by script, provide an arbitrarily long duration such as 9999.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Healing Per Second
     description: The healing per second for the heal over time.
-    type: unsigned float
+    type: Float
     default: Number
   guid: 00000000B9C2
   return: Void
@@ -2825,7 +2825,7 @@ startHealingModification:
     default: All Players
   - name: Healing Percent
     description: The percentage of healing that will apply to receivers when healed by healers.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
@@ -2900,7 +2900,7 @@ _&startThrottleInDirection:
     default: Vector
   - name: Magnitude
     description: The amount of throttle (or change to throttle). A value of 1 denotes full throttle.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
@@ -2935,11 +2935,11 @@ _&startTransformingThrottle:
     default: Event Player
   - name: X Axis Scalar
     description: The player or players will have their throttle X axis (left to right) multiplied by this value before the throttle is rotated to its new relative direction. This value is evaluated continuously (meaning it updates every frame).
-    type: unsigned float
+    type: Float
     default: Number
   - name: Y Axis Scalar
     description: The player or players will have their throttle Y axis (front to back) multiplied by this value before the throttle is rotated to its new relative direction. This value is evaluated continuously (meaning it updates every frame).
-    type: unsigned float
+    type: Float
     default: Number
   - name: Relative Direction
     description: After the axis scalars are applied, the player or players will have their throttle transformed so that it is relative to this unit direction vector. For example, to make the throttle camera relative, provide the direction that the camera is facing. This value is evaluated continuously (meaning it updates every frame) and normalized internally.
@@ -3335,7 +3335,7 @@ __wait__:
   args:
   - name: Time
     description: The duration of the pause.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Wait Behavior
     description: Specifies if and how the wait can be interrupted. If the condition list is ignored, the wait will not be interrupted. Otherwise, the condition list will determine if and when the action list will abort or restart.

--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -2,7 +2,6 @@
 return:
   description: Stops execution of the action list.
   args:
-  guid: 00000000BB09
   return: Void
   en-US: Abort
   es-MX: Abortar
@@ -17,7 +16,6 @@ __abortIf__:
     description: Specifies whether the execution is stopped.
     type: bool
     default: Compare
-  guid: 00000000BB04
   return: Void
   en-US: Abort If
   es-MX: Abortar si
@@ -28,7 +26,6 @@ __abortIf__:
 __abortIfConditionIsFalse__:
   description: Stops execution of the action list if at least one condition in the condition list is false. If all conditions are true, execution continues with the next action.
   args: []
-  guid: 00000000BB02
   return: Void
   en-US: Abort If Condition Is False
   es-MX: Abortar si la condición es falsa
@@ -39,7 +36,6 @@ __abortIfConditionIsFalse__:
 __abortIfConditionIsTrue__:
   description: Stops execution of the action list if all conditions in the condition list are true. If any are false, execution continues with the next action.
   args: []
-  guid: 00000000BB03
   return: Void
   en-US: Abort If Condition Is True
   es-MX: Abortar si la condición es verdadera
@@ -60,7 +56,6 @@ _&allowButton:
     description: The logical button that is being reenabled.
     type: ButtonLiteral
     default: Primary Fire
-  guid: 00000000B9D0
   return: Void
   en-US: Allow Button
   es-MX: Habilitar botón
@@ -93,7 +88,6 @@ _&applyImpulse:
     description: Specifies whether existing velocity that is counter to direction should first be cancelled out before applying the impulse.
     type: Impulse
     default: Cancel Contrary Motion
-  guid: 0000000078F6
   return: Void
   en-US: Apply Impulse
   es-MX: Aplicar impulso
@@ -117,7 +111,6 @@ _&attachTo:
     type: Position
     default: Vector
   return: Void
-  guid: 000000010E4F
   en-US: Attach Players
   es-MX: Anexar jugadores
   fr-FR: Attacher les joueurs
@@ -137,7 +130,6 @@ bigMessage:
     description: The message to be displayed.
     type: Object
     default: String
-  guid: 00000000BA88
   return: Void
   en-US: Big Message
   es-MX: Mensaje grande
@@ -149,7 +141,6 @@ break:
   description: Goes to the end of the innermost `switch` statement, or `do/while`, `while` or `for` loop.
   args:
   return: Void
-  guid: 0000000105B6
   en-US: Break
   fr-FR: Arrêter
   ja-JP: BREAK
@@ -162,7 +153,6 @@ __callSubroutine__:
     description: Specifies which subroutine to call. If a rule with a subroutine event type specifies the same subroutine, then it will execute. Otherwise, this action is ignored.
     type: Subroutine
     default: Sub0
-  guid: 00000001001E
   return: Void
   en-US: Call Subroutine
   es-MX: Llamada a subrutina
@@ -180,7 +170,6 @@ _&cancelPrimaryAction:
     - Array: Player
     default: Event Player
   return: Void
-  guid: 0000000109CB
   en-US: Cancel Primary Action
   es-MX: Cancelar acción primaria
   fr-FR: Annuler l’action principale
@@ -208,7 +197,6 @@ __chaseGlobalVariableAtRate__:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseRateReeval__
     default: Destination And Rate
-  guid: 00000000B840
   return: Void
   en-US: Chase Global Variable At Rate
   es-MX: Seguir variable global según la tasa
@@ -237,7 +225,6 @@ __chaseGlobalVariableOverTime__:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseTimeReeval__
     default: Destination And Duration
-  guid: 00000000B842
   return: Void
   en-US: Chase Global Variable Over Time
   es-MX: Seguir variable global con el tiempo
@@ -272,7 +259,6 @@ __chasePlayerVariableAtRate__:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseRateReeval__
     default: Destination And Rate
-  guid: 00000000B83F
   return: Void
   en-US: Chase Player Variable At Rate
   es-MX: Seguir variable de jugador según la tasa
@@ -307,7 +293,6 @@ __chasePlayerVariableOverTime__:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseTimeReeval__
     default: Destination And Duration
-  guid: 00000000B841
   return: Void
   en-US: Chase Player Variable Over Time
   es-MX: Seguir variable del jugador con el tiempo
@@ -328,7 +313,6 @@ _&clearStatusEffect:
     description: The status to be removed from the player or players.
     type: Status
     default: Hacked
-  guid: 00000000B595
   return: Void
   en-US: Clear Status
   es-MX: Eliminar estado
@@ -349,7 +333,6 @@ _&communicate:
     description: The type of communication.
     type: Comms
     default: Voice Line Up
-  guid: 00000000B9E3
   return: Void
   en-US: Communicate
   es-MX: Comunicar
@@ -360,7 +343,6 @@ _&communicate:
 continue:
   description: Goes back to the start of the innermost loop.
   args:
-  guid: 0000000105B7
   return: Void
   en-US: Continue
   es-MX: Continuar
@@ -397,7 +379,6 @@ createBeam:
     description: Specifies which of this action's inputs will be continuously reevaluated. The effect will keep asking for and using new values from reevaluated inputs.
     type: EffectReeval
     default: Visible To, Position, And Radius
-  guid: 00000000CE80
   return: Void
   en-US: Create Beam Effect
   es-MX: Crear efecto de rayo
@@ -428,7 +409,6 @@ createDummy:
     description: The initial direction that the bot will face.
     type: Direction
     default: Vector
-  guid: 00000000CA6A
   return: Void
   en-US: Create Dummy Bot
   es-MX: Crear robot de entrenamiento
@@ -467,7 +447,6 @@ createEffect:
     description: Specifies which of this action's inputs will be continuously reevaluated.
     type: EffectReeval
     default: Visible To, Position, And Radius
-  guid: 00000000B8AF
   return: Void
   en-US: Create Effect
   es-MX: Crear efecto
@@ -527,7 +506,6 @@ __hudText__:
     description: Whether spectators can see the text or not.
     type: SpecVisibility
     default: Default Visibility
-  guid: 00000000BAD3
   return: Void
   en-US: Create HUD Text
   es-MX: Crear texto del HUD
@@ -566,7 +544,6 @@ createIcon:
     description: Should this icon appear even when it is behind you?
     type: bool
     default: 'True'
-  guid: 00000000ACFA
   return: Void
   en-US: Create Icon
   es-MX: Crear ícono
@@ -614,7 +591,6 @@ createInWorldText:
     description: Whether spectators can see the text or not.
     type: SpecVisibility
     default: Default Visibility
-  guid: 00000000BAD0
   return: Void
   en-US: Create In-World Text
   es-MX: Crear texto dentro del mundo
@@ -623,7 +599,6 @@ createInWorldText:
   pt-BR: Criar Texto no Mundo
   zh-CN: 创建地图文本
 damage:
-  guid: 000000007876
   description: Applies instantaneous damage to one or more players, possibly killing
     the players.
   args:
@@ -652,7 +627,6 @@ declareDraw:
   description: Instantly ends the match in a draw. This action has no effect in free-for-all
     modes.
   args: []
-  guid: 00000000B9F1
   return: Void
   en-US: Declare Match Draw
   es-MX: Declarar empate de la partida
@@ -668,7 +642,6 @@ declarePlayerVictory:
     description: The winning player.
     type: Player
     default: Event Player
-  guid: 00000000AD30
   return: Void
   en-US: Declare Player Victory
   es-MX: Declarar victoria del jugador
@@ -681,7 +654,6 @@ declareRoundDraw:
     game mode.
   args: []
   return: Void
-  guid: 00000001098F
   en-US: Declare Round Draw
   es-MX: Declarar ronda empatada
   fr-FR: Déclarer la manche nulle
@@ -696,7 +668,6 @@ declareRoundVictory:
     description: Round winning team
     type: Team
     default: Team
-  guid: 00000000BF93
   return: Void
   en-US: Declare Round Victory
   es-MX: Declarar victoria de la ronda
@@ -712,7 +683,6 @@ declareTeamVictory:
     description: The winning team.
     type: Team
     default: Team
-  guid: 0000000078FD
   return: Void
   en-US: Declare Team Victory
   es-MX: Declarar la victoria del equipo
@@ -723,7 +693,6 @@ declareTeamVictory:
 destroyAllDummies:
   description: Removes all dummy bots from the match.
   args: []
-  guid: 00000000D1D4
   return: Void
   en-US: Destroy All Dummy Bots
   es-MX: Destruir todos los robots de entrenamiento
@@ -734,7 +703,6 @@ destroyAllDummies:
 destroyAllEffects:
   description: Destroys all effect entities created by create effect.
   args: []
-  guid: 00000000B8AD
   return: Void
   en-US: Destroy All Effects
   es-MX: Destruir todos los efectos
@@ -745,7 +713,6 @@ destroyAllEffects:
 destroyAllHudTexts:
   description: Destroys all hud text that was created by the create hud text action.
   args: []
-  guid: 00000000BAD1
   return: Void
   en-US: Destroy All HUD Text
   es-MX: Destruir todo el texto del HUD
@@ -756,7 +723,6 @@ destroyAllHudTexts:
 destroyAllIcons:
   description: Destroys all icon entities created by create icon.
   args: []
-  guid: 00000000B8AC
   return: Void
   en-US: Destroy All Icons
   es-MX: Destruir todos los íconos
@@ -767,7 +733,6 @@ destroyAllIcons:
 destroyAllInWorldText:
   description: Destroys all in-world text created by create in-world text.
   args: []
-  guid: 00000000B8AB
   return: Void
   en-US: Destroy All In-World Text
   es-MX: Destruir todo el texto dentro del mundo
@@ -786,7 +751,6 @@ destroyDummy:
     description: The slot to remove the dummy bot from.
     type: Integer
     default: Number
-  guid: 00000000CC21
   return: Void
   en-US: Destroy Dummy Bot
   es-MX: Destruir robot de entrenamiento
@@ -801,7 +765,6 @@ destroyEffect:
     description: Specifies which effect entity to destroy. This entity may be last created entity or a variable into which last created entity was earlier stored.
     type: EntityId
     default: Last Created Entity Entity
-  guid: 00000000B8AE
   return: Void
   en-US: Destroy Effect
   es-MX: Destruir efecto
@@ -816,7 +779,6 @@ destroyHudText:
     description: Specifies which hud text to destroy. This id may be last text id or a variable into which last text id was earlier stored.
     type: TextId
     default: Last Text ID
-  guid: 00000000BAD2
   return: Void
   en-US: Destroy HUD Text
   es-MX: Destruir texto del HUD
@@ -831,7 +793,6 @@ destroyIcon:
     description: Specifies which icon entity to destroy. This entity may be last created entity or a variable into which last created entity was earlier stored.
     type: EntityId
     default: Last Created Entity Entity
-  guid: 00000000B4E7
   return: Void
   en-US: Destroy Icon
   es-MX: Destruir ícono
@@ -846,7 +807,6 @@ destroyInWorldText:
     description: Specifies which in-world text to destroy. This id may be last text id or a variable into which last text id was earlier stored.
     type: TextId
     default: Last Text ID
-  guid: 00000000BACF
   return: Void
   en-US: Destroy In-World Text
   es-MX: Destruir texto dentro del mundo
@@ -865,7 +825,6 @@ _&detach:
     - Array: Player
     default: Event Player
   return: Void
-  guid: 000000010E52
   en-US: Detach Players
   es-MX: Separar jugadores
   fr-FR: Détacher les joueurs
@@ -876,7 +835,6 @@ disableAnnouncer:
   description: Disables game mode announcements from the announcer until reenabled
     or the match ends.
   args: []
-  guid: 00000000C3F8
   return: Void
   en-US: Disable Built-In Game Mode Announcer
   es-MX: Deshabilitar el presentador integrado del modo de juego
@@ -888,7 +846,6 @@ disableGamemodeCompletion:
   description: Disables completion of the match from the game mode itself, only allowing
     the match to be completed by scripting commands.
   args: []
-  guid: 00000000AD2D
   return: Void
   en-US: Disable Built-In Game Mode Completion
   es-MX: Deshabilitar la finalización integrada del modo de juego
@@ -899,7 +856,6 @@ disableGamemodeCompletion:
 disableMusic:
   description: Disables all game mode music until reenabled or the match ends.
   args: []
-  guid: 00000000C3F4
   return: Void
   en-US: Disable Built-In Game Mode Music
   es-MX: Deshabilitar la música integrada del modo de juego
@@ -917,7 +873,6 @@ _&disableRespawn:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B87A
   return: Void
   en-US: Disable Built-In Game Mode Respawning
   es-MX: Deshabilitar la reaparición integrada del modo de juego
@@ -929,7 +884,6 @@ disableScoring:
   description: Disables changes to player and team scores from the game mode itself,
     only allowing scores to be changed by scripting commands.
   args: []
-  guid: 00000000ABFA
   return: Void
   en-US: Disable Built-In Game Mode Scoring
   es-MX: Deshabilitar el sistema de puntuación integrado del modo de juego
@@ -947,7 +901,6 @@ _&disableDeathSpectateAllPlayers:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B9B5
   return: Void
   en-US: Disable Death Spectate All Players
   es-MX: Deshabilitar la observación de todos los jugadores como espectador muerto
@@ -965,7 +918,6 @@ _&disableDeathSpectateTargetHud:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B9B3
   return: Void
   en-US: Disable Death Spectate Target HUD
   es-MX: Deshabilitar la observación del HUD objetivo como espectador muerto
@@ -978,7 +930,6 @@ disableInspector:
     the benefit of reducing your script's server load, particularly when modifying
     arrays.
   args: []
-  guid: 00000000FB2F
   return: Void
   en-US: Disable Inspector Recording
   es-MX: Desactivar registro de Inspector
@@ -1000,7 +951,6 @@ _&disallowButton:
     description: The logical button that is being disabled.
     type: ButtonLiteral
     default: Primary Fire
-  guid: 00000000B9CF
   return: Void
   en-US: Disallow Button
   es-MX: Deshabilitar botón
@@ -1012,7 +962,6 @@ __else__:
   description: Denotes the beginning of a series of actions that will only execute
     if the previous If or Else If action's condition was false.
   args: []
-  guid: 00000000FB34
   return: Void
   en-US: Else
   es-MX: Si no
@@ -1027,7 +976,6 @@ __elif__:
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next else if, else, or end action at the current level.
     type: bool
     default: Compare
-  guid: 00000000FB33
   return: Void
   en-US: Else If
   es-MX: Si no si
@@ -1036,7 +984,6 @@ __elif__:
 enableAnnouncer:
   description: Undoes the effect of the disable built-in game mode announcer action.
   args: []
-  guid: 00000000C3FA
   return: Void
   en-US: Enable Built-In Game Mode Announcer
   es-MX: Habilitar presentador integrado del modo de juego
@@ -1047,7 +994,6 @@ enableAnnouncer:
 enableGamemodeCompletion:
   description: Undoes the effect of the disable built-in game mode completion action.
   args: []
-  guid: 00000000AD2F
   return: Void
   en-US: Enable Built-In Game Mode Completion
   es-MX: Habilitar la finalización integrada del modo de juego
@@ -1058,7 +1004,6 @@ enableGamemodeCompletion:
 enableMusic:
   description: Undoes the effect of the disable built-in game mode music action.
   args: []
-  guid: 00000000C3F6
   return: Void
   en-US: Enable Built-In Game Mode Music
   es-MX: Habilitar la música integrada del modo de juego
@@ -1076,7 +1021,6 @@ _&enableRespawn:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B878
   return: Void
   en-US: Enable Built-In Game Mode Respawning
   es-MX: Habilitar la reaparición integrada del modo de juego
@@ -1087,7 +1031,6 @@ _&enableRespawn:
 enableScoring:
   description: Undoes the effect of the disable built-in game mode scoring action.
   args: []
-  guid: 00000000ABF8
   return: Void
   en-US: Enable Built-In Game Mode Scoring
   es-MX: Habilitar el sistema de puntuación integrado del modo de juego
@@ -1105,7 +1048,6 @@ _&enableDeathSpectateAllPlayers:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B9AE
   return: Void
   en-US: Enable Death Spectate All Players
   es-MX: Habilitar la observación de todos los jugadores como espectador muerto
@@ -1123,7 +1065,6 @@ _&enableDeathSpectateTargetHud:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B9B4
   return: Void
   en-US: Enable Death Spectate Target HUD
   es-MX: Habilitar la observación del HUD objetivo como espectador muerto
@@ -1136,7 +1077,6 @@ enableInspector:
     it had been disabled earlier). Enabling recording at specific times may make it
     easier to debug problematic areas in your logic.
   args: []
-  guid: 00000000FB2E
   return: Void
   en-US: Enable Inspector Recording
   es-MX: Activar registro de Inspector
@@ -1148,7 +1088,6 @@ __end__:
   description: Denotes the end of a series of actions started by an if, else if, else,
     while, or for action.
   args: []
-  guid: 00000000FB37
   return: Void
   en-US: End
   es-MX: Fin
@@ -1178,7 +1117,6 @@ __forGlobalVariable__:
     description: This value is added to the control variable when the end action is reached. If this modification causes the control variable to reach or pass the range stop value, then the loop exits, and execution jumps to the next action after the end action. Otherwise, the loop continues, and execution jumps to the next action after the for action.
     type: float
     default: Number (1)
-  guid: 00000000FEE2
   return: Void
   en-US: For Global Variable
   es-MX: Para variable global
@@ -1213,7 +1151,6 @@ __forPlayerVariable__:
     description: This value is added to the control variable when the end action is reached. If this modification causes the control variable to reach or pass the range stop value, then the loop exits, and execution jumps to the next action after the end action. Otherwise, the loop continues, and execution jumps to the next action after the for action.
     type: float
     default: Number (1)
-  guid: 00000000FEE1
   return: Void
   en-US: For Player Variable
   es-MX: Para variable de jugador
@@ -1225,7 +1162,6 @@ goToAssembleHeroes:
   description: Returns the match to the assemble heroes phase of the game mode. Only
     works if the game is in progress.
   args: []
-  guid: 00000000C5B5
   return: Void
   en-US: Go To Assemble Heroes
   es-MX: Ir a Forma tu equipo
@@ -1234,7 +1170,6 @@ goToAssembleHeroes:
   pt-BR: Ir para Escolher Heróis
   zh-CN: 前往集结英雄
 heal:
-  guid: 000000007875
   description: Provides an instantaneous heal to one or more players. This heal will
     not resurrect dead players.
   args:
@@ -1267,14 +1202,12 @@ __if__:
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next else if, else, or end action at the current level.
     type: bool
     default: Compare
-  guid: 00000000FB32
   return: Void
   en-US: If
   es-MX: Si
   fr-FR: Si
   ja-JP: If
 kill:
-  guid: 000000007877
   description: Instantly kills one or more players.
   args:
   - name: Player
@@ -1295,7 +1228,6 @@ kill:
   pt-BR: Abater
   zh-CN: 击杀
 __loop__:
-  guid: 0000000078F5
   description: Restarts the action list from the beginning. To prevent an infinite
     loop, a wait action must execute between the start of the action list and this
     action.
@@ -1317,7 +1249,6 @@ __loopIf__:
     description: Specifies whether the loop will occur.
     type: bool
     default: Compare
-  guid: 00000000BB06
   return: Void
   en-US: Loop If
   es-MX: Repetir si
@@ -1331,7 +1262,6 @@ __loopIfConditionIsFalse__:
     with the next action. To prevent an infinite loop, a wait action must execute
     between the start of the action list and this action.
   args: []
-  guid: 00000000BB05
   return: Void
   en-US: Loop If Condition Is False
   es-MX: Repetir si la condición es falsa
@@ -1345,7 +1275,6 @@ __loopIfConditionIsTrue__:
     To prevent an infinite loop, a wait action must execute between the start of the
     action list and this action.
   args: []
-  guid: 000000007874
   return: Void
   en-US: Loop If Condition Is True
   es-MX: Repetir si la condición es verdadera
@@ -1371,7 +1300,6 @@ __modifyGlobalVariable__:
     - Object
     - Array
     default: Number
-  guid: 00000000786E
   return: Void
   en-US: Modify Global Variable
   es-MX: Modificar variable global
@@ -1401,7 +1329,6 @@ __modifyGlobalVariableAtIndex__:
     - Object
     - Array
     default: Number
-  guid: 00000000C7E1
   return: Void
   en-US: Modify Global Variable At Index
   es-MX: Modificar variable global según el índice
@@ -1423,7 +1350,6 @@ _&addToScore:
     description: The amount the score will increase or decrease. If positive, the score will increase. If negative, the score will decrease.
     type: Integer
     default: Number
-  guid: 000000007873
   return: Void
   en-US: Modify Player Score
   es-MX: Modificar puntuación del jugador
@@ -1455,7 +1381,6 @@ __modifyPlayerVariable__:
     - Object
     - Array
     default: Number
-  guid: 00000000786F
   return: Void
   en-US: Modify Player Variable
   es-MX: Modificar variable de jugador
@@ -1491,7 +1416,6 @@ __modifyPlayerVariableAtIndex__:
     - Object
     - Array
     default: Number
-  guid: 00000000C7DF
   return: Void
   en-US: Modify Player Variable At Index
   es-MX: Modificar variable de jugador según el índice
@@ -1511,7 +1435,6 @@ addToTeamScore:
     description: The amount the score will increase or decrease. If positive, the score will increase. If negative, the score will decrease.
     type: Integer
     default: Number
-  guid: 00000000BB24
   return: Void
   en-US: Modify Team Score
   es-MX: Modificar puntuación del equipo
@@ -1523,7 +1446,6 @@ pauseMatchTime:
   description: Pauses the match time. Players, objective logic, and game mode advancement
     criteria are unaffected by the pause.
   args: []
-  guid: 00000000B9EF
   return: Void
   en-US: Pause Match Time
   es-MX: Pausar tiempo de la partida
@@ -1557,7 +1479,6 @@ playEffect:
     description: The effect's radius in meters.
     type: Float
     default: Number (1)
-  guid: 00000000BB27
   return: Void
   en-US: Play Effect
   es-MX: Reproducir efecto
@@ -1582,7 +1503,6 @@ _&preloadHero:
     - Hero
     - Array: Hero
     default: Hero
-  guid: 00000000B9B1
   return: Void
   en-US: Preload Hero
   es-MX: Precargar héroe
@@ -1604,7 +1524,6 @@ _&forceButtonPress:
     description: The button to be pressed.
     type: ButtonLiteral
     default: Primary Fire
-  guid: 0000000078FB
   return: Void
   en-US: Press Button
   es-MX: Presionar botón
@@ -1624,7 +1543,6 @@ _&resetHeroAvailability:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000BA5A
   return: Void
   en-US: Reset Player Hero Availability
   es-MX: Restablecer disponibilidad de héroes de los jugadores
@@ -1642,7 +1560,6 @@ _&respawn:
     - Player
     - Array: Player
     default: Event Player
-  guid: 0000000078FC
   return: Void
   en-US: Respawn
   es-MX: Reaparecer
@@ -1651,7 +1568,6 @@ _&respawn:
   pt-BR: Ressurgir
   zh-CN: 重生
 _&resurrect:
-  guid: 000000007878
   description: Instantly resurrects one or more players at the location they died
     with no transition.
   args:
@@ -1681,7 +1597,6 @@ _&setAbility1Enabled:
     description: Specifies whether the player or players are able to use ability 1. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  guid: 00000000B9B8
   return: Void
   en-US: Set Ability 1 Enabled
   es-MX: Establecer habilidad 1 habilitada
@@ -1702,7 +1617,6 @@ _&setAbility2Enabled:
     description: Specifies whether the player or players are able to use ability 2. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  guid: 00000000B9B7
   return: Void
   en-US: Set Ability 2 Enabled
   es-MX: Establecer habilidad 2 habilitada
@@ -1728,7 +1642,6 @@ _&setAbilityCooldown:
     type: Float
     default: Number
   return: Void
-  guid: 0000000109CA
   en-US: Set Ability Cooldown
   es-MX: Establecer Reutilización de habilidad
   fr-FR: Définir le temps de recharge de la capacité
@@ -1749,7 +1662,6 @@ _&setAimSpeed:
     description: The percentage of normal aim speed to which the player or players will set their aim speed.
     type: Float
     default: Number
-  guid: 00000000C364
   return: Void
   en-US: Set Aim Speed
   es-MX: Establecer velocidad al apuntar
@@ -1771,7 +1683,6 @@ _&setCrouchEnabled:
     type: bool
     default: 'True'
   return: Void
-  guid: 0000000105A3
   en-US: Set Crouch Enabled
   es-MX: Establecer acción de agacharse activado
   fr-FR: Définir l’activation de S’accroupir
@@ -1792,7 +1703,6 @@ _&setDamageDealt:
     description: The percentage of raw damage dealt to which the player or players will set their damage dealt.
     type: Float
     default: Number
-  guid: 00000000B995
   return: Void
   en-US: Set Damage Dealt
   es-MX: Establecer daño infligido
@@ -1814,7 +1724,6 @@ _&setDamageReceived:
     description: The percentage of raw damage received to which the player or players will set their damage received.
     type: Float
     default: Number
-  guid: 00000000B997
   return: Void
   en-US: Set Damage Received
   es-MX: Establecer daño recibido
@@ -1839,7 +1748,6 @@ _&setFacing:
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
     type: Relativity
     default: To World
-  guid: 00000000BB29
   return: Void
   en-US: Set Facing
   es-MX: Establecer orientación
@@ -1861,7 +1769,6 @@ __setGlobalVariable__:
     - Object
     - Array
     default: Number
-  guid: 0000000077DE
   return: Void
   en-US: Set Global Variable
   es-MX: Establecer variable global
@@ -1888,7 +1795,6 @@ __setGlobalVariableAtIndex__:
     - Object
     - Array
     default: Number
-  guid: 00000000BBAA
   return: Void
   en-US: Set Global Variable At Index
   es-MX: Establecer variable global según el índice
@@ -1910,7 +1816,6 @@ _&setGravity:
     description: The percentage of regular movement gravity to which the player or players will set their personal movement gravity.
     type: Float
     default: Number
-  guid: 00000000B999
   return: Void
   en-US: Set Gravity
   es-MX: Establecer gravedad
@@ -1932,7 +1837,6 @@ _&setHealingDealt:
     description: ''
     type: Float
     default: Number
-  guid: 00000000B991
   return: Void
   en-US: Set Healing Dealt
   es-MX: Establecer sanación realizada
@@ -1954,7 +1858,6 @@ _&setHealingReceived:
     description: The percentage of raw healing received to which the player or players will set their healing received.
     type: Float
     default: Number
-  guid: 00000000B993
   return: Void
   en-US: Set Healing Received
   es-MX: Establecer sanación recibida
@@ -1976,7 +1879,6 @@ _&setInvisibility:
     description: Specifies for whom the player or players will be invisible.
     type: Invis
     default: ALL
-  guid: 00000000B9ED
   return: Void
   en-US: Set Invisible
   es-MX: Establecer invisibilidad
@@ -1998,7 +1900,6 @@ _&setJumpEnabled:
     type: bool
     default: 'True'
   return: Void
-  guid: 0000000105A5
   en-US: Set Jump Enabled
   es-MX: Establecer salto activado
   fr-FR: Définir l’activation de Sauter
@@ -2014,7 +1915,6 @@ setMatchTime:
     description: The match time in seconds.
     type: Integer
     default: Number
-  guid: 00000000AD31
   return: Void
   en-US: Set Match Time
   es-MX: Establecer tiempo de la partida
@@ -2037,7 +1937,6 @@ _&setMaxHealth:
     description: The percentage of raw max health to which the player or players will set their max health.
     type: Float
     default: Number
-  guid: 0000000078FA
   return: Void
   en-US: Set Max Health
   es-MX: Establecer salud máxima
@@ -2059,7 +1958,6 @@ _&setMeleeEnabled:
     type: bool
     default: 'True'
   return: Void
-  guid: 000000010596
   en-US: Set Melee Enabled
   es-MX: Establecer ataques melé activado
   fr-FR: Définir l’activation de Mêlée
@@ -2080,7 +1978,6 @@ _&setMoveSpeed:
     description: The percentage of raw move speed to which the player or players will set their move speed.
     type: Float
     default: Number
-  guid: 00000000B998
   return: Void
   en-US: Set Move Speed
   es-MX: Establecer velocidad de movimiento
@@ -2106,7 +2003,6 @@ setObjectiveDescription:
     description: Specifies which of this action's inputs will be continuously reevaluated. The message will keep asking for and using new values from reevaluated inputs.
     type: HudReeval
     default: Visible To And String
-  guid: 00000000BA85
   return: Void
   en-US: Set Objective Description
   es-MX: Establecer descripción de objetivo
@@ -2131,7 +2027,6 @@ _&setAllowedHeroes:
     - Hero
     - Array: Hero
     default: Hero
-  guid: 00000000BA5B
   return: Void
   en-US: Set Player Allowed Heroes
   es-MX: Establecer héroes permitidos para los jugadores
@@ -2153,7 +2048,6 @@ _&setScore:
     description: The score that will be set.
     type: Integer
     default: Number
-  guid: 00000000BB22
   return: Void
   en-US: Set Player Score
   es-MX: Establecer puntuación del jugador
@@ -2181,7 +2075,6 @@ __setPlayerVariable__:
     - Object
     - Array
     default: Number
-  guid: 0000000077DF
   return: Void
   en-US: Set Player Variable
   es-MX: Establecer variable de jugador
@@ -2214,7 +2107,6 @@ __setPlayerVariableAtIndex__:
     - Object
     - Array
     default: Number
-  guid: 00000000BBA9
   return: Void
   en-US: Set Player Variable At Index
   es-MX: Establecer variable de jugador según el índice
@@ -2235,7 +2127,6 @@ _&setPrimaryFireEnabled:
     description: Specifies whether the player or players are able to use primary fire. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  guid: 00000000C6C5
   return: Void
   en-US: Set Primary Fire Enabled
   es-MX: Establecer disparo principal habilitado
@@ -2257,7 +2148,6 @@ _&setProjectileGravity:
     description: The percentage of regular projectile gravity to which the player or players will set their personal projectile gravity.
     type: Float
     default: Number
-  guid: 00000000B99B
   return: Void
   en-US: Set Projectile Gravity
   es-MX: Establecer gravedad del proyectil
@@ -2279,7 +2169,6 @@ _&setProjectileSpeed:
     description: The percentage of regular projectile speed to which the player or players will set their personal projectile speed.
     type: Float
     default: Number
-  guid: 00000000B99D
   return: Void
   en-US: Set Projectile Speed
   es-MX: Establecer velocidad del proyectil
@@ -2302,7 +2191,6 @@ _&setRespawnTime:
     description: The duration between death and respawn in seconds.
     type: Integer
     default: Number
-  guid: 00000000B9CD
   return: Void
   en-US: Set Respawn Max Time
   es-MX: Establecer tiempo máximo de reaparición
@@ -2323,7 +2211,6 @@ _&setSecondaryFireEnabled:
     description: Specifies whether the player or players are able to use secondary fire. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  guid: 00000000C6C4
   return: Void
   en-US: Set Secondary Fire Enabled
   es-MX: Establecer disparo secundario habilitado
@@ -2339,7 +2226,6 @@ setSlowMotion:
     description: The simulation rate as a percentage of normal speed. Only rates up to 100% are allowed.
     type: Float
     default: Number
-  guid: 00000000B9F2
   return: Void
   en-US: Set Slow Motion
   es-MX: Establecer cámara lenta
@@ -2369,7 +2255,6 @@ _&setStatusEffect:
     description: The duration of the status in seconds. To have a status that lasts until a clear status action is executed, provide an arbitrarily long duration such as 9999.
     type: Float
     default: Number
-  guid: 00000000B588
   return: Void
   en-US: Set Status
   es-MX: Establecer estado
@@ -2389,7 +2274,6 @@ setTeamScore:
     description: The score that will be set.
     type: Integer
     default: Number
-  guid: 00000000BB25
   return: Void
   en-US: Set Team Score
   es-MX: Establecer puntuación del equipo
@@ -2410,7 +2294,6 @@ _&setUltEnabled:
     description: Specifies whether the player or players are able to use their ultimate ability. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  guid: 00000000B9B6
   return: Void
   en-US: Set Ultimate Ability Enabled
   es-MX: Establecer habilidad máxima habilitada
@@ -2432,7 +2315,6 @@ _&setUltCharge:
     description: The percentage of maximum charge.
     type: Float
     default: Number
-  guid: 00000000BB1C
   return: Void
   en-US: Set Ultimate Charge
   es-MX: Establecer carga de habilidad máxima
@@ -2441,7 +2323,6 @@ _&setUltCharge:
   pt-BR: Definir Carga da Suprema
   zh-CN: 设置终极技能充能
 __skip__:
-  guid: 00000000BB01
   description: Skips execution of a certain number of actions in the action list.
   args:
   - name: Number OF Actions
@@ -2468,7 +2349,6 @@ __skipIf__:
     description: The number of actions to skip, not including this action.
     type: Integer
     default: Number
-  guid: 00000000BB00
   return: Void
   en-US: Skip If
   es-MX: Omitir si
@@ -2490,7 +2370,6 @@ smallMessage:
     description: The message to be displayed.
     type: Object
     default: String
-  guid: 00000000BA87
   return: Void
   en-US: Small Message
   es-MX: Mensaje pequeño
@@ -2527,7 +2406,6 @@ _&startAcceleration:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: AccelReeval
     default: Direction, Rate, And Max Speed
-  guid: 00000000BB0D
   return: Void
   en-US: Start Accelerating
   es-MX: Comenzar la aceleración
@@ -2556,7 +2434,6 @@ _&setCamera:
     description: How fast to blend the camera speed as positions change. 0 means do not blend at all, and just change positions instantly.
     type: Float
     default: Number
-  guid: 00000000C393
   return: Void
   en-US: Start Camera
   es-MX: Comenzar cámara
@@ -2590,7 +2467,6 @@ startDamageModification:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: DamageReeval
     default: Receivers, Damagers, And Damage Percent
-  guid: 00000000C639
   return: Void
   en-US: Start Damage Modification
   es-MX: Comenzar modificación de daño
@@ -2621,7 +2497,6 @@ _&startDoT:
     description: The damage per second for the damage over time.
     type: Float
     default: Number
-  guid: 00000000B9C5
   return: Void
   en-US: Start Damage Over Time
   es-MX: Comenzar daño con el tiempo
@@ -2654,7 +2529,6 @@ _&startFacing:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: FacingReeval
     default: Direction And Turn Rate
-  guid: 00000000BB20
   return: Void
   en-US: Start Facing
   es-MX: Comenzar orientación
@@ -2678,7 +2552,6 @@ _&startForcingHero:
     description: The hero that the player or players will be forced to be.
     type: Hero
     default: Hero
-  guid: 00000000ABFB
   return: Void
   en-US: Start Forcing Player To Be Hero
   es-MX: Comenzar a forzar a un jugador a usar un héroe
@@ -2704,7 +2577,6 @@ _&startForcingPosition:
     type: bool
     default: 'True'
   return: Void
-  guid: 000000010E85
   en-US: Start Forcing Player Position
   es-MX: Comenzar a forzar la posición del jugador
   fr-FR: Forcer la position du joueur
@@ -2724,7 +2596,6 @@ startForcingSpawn:
     description: The number of the spawn room to be forced. 0 is the first spawn room, 1 the second, and 2 is the third. If the specified spawn room does not exist, players will use the normal spawn room.
     type: Integer
     default: Number
-  guid: 00000000B573
   return: Void
   en-US: Start Forcing Spawn Room
   es-MX: Comenzar a forzar cuarto de reaparición
@@ -2766,7 +2637,6 @@ _&startForcingThrottle:
     description: Sets the maximum run sideways amount. 0 prevents the player or players from moving Sideways while 1 allows full sideways movement.
     type: Float
     default: Number
-  guid: 00000000BB0F
   return: Void
   en-US: Start Forcing Throttle
   es-MX: Comenzar a forzar la aceleración
@@ -2797,7 +2667,6 @@ _&startHoT:
     description: The healing per second for the heal over time.
     type: Float
     default: Number
-  guid: 00000000B9C2
   return: Void
   en-US: Start Heal Over Time
   es-MX: Comenzar sanación con el tiempo
@@ -2831,7 +2700,6 @@ startHealingModification:
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: HealingReeval
     default: Receivers, Healers, And Healing Percent
-  guid: 00000000C639
   return: Void
   en-US: Start Healing Modification
   es-MX: Comenzar modificación de sanación
@@ -2853,7 +2721,6 @@ _&startForcingButton:
     description: The logical button that is being held virtually.
     type: ButtonLiteral
     default: Primary Fire
-  guid: 00000000B9D3
   return: Void
   en-US: Start Holding Button
   es-MX: Comenzar a mantener el botón presionado
@@ -2875,7 +2742,6 @@ __startRule__:
     description: Determines what should happen if the rule specified by the subroutine is already executing on the same player or global entity.
     type: AsyncBehavior
     default: RESTART RULE
-  guid: '000000010022'
   return: Void
   en-US: Start Rule
   es-MX: Comenzar regla
@@ -2914,7 +2780,6 @@ _&startThrottleInDirection:
     description: Specifies which of this action's inputs will be continuously reevaluated. This aciton will keep asking for and using new values from reevaluated inputs.
     type: ThrottleReeval
     default: Direction And Magnitude
-  guid: 00000000CEA4
   return: Void
   en-US: Start Throttle In Direction
   es-MX: Comenzar aceleración en dirección
@@ -2945,7 +2810,6 @@ _&startTransformingThrottle:
     description: After the axis scalars are applied, the player or players will have their throttle transformed so that it is relative to this unit direction vector. For example, to make the throttle camera relative, provide the direction that the camera is facing. This value is evaluated continuously (meaning it updates every frame) and normalized internally.
     type: Direction
     default: Vector
-  guid: 00000000CC26
   return: Void
   en-US: Start Transforming Throttle
   es-MX: Comenzar a transformar la aceleración
@@ -2963,7 +2827,6 @@ _&stopAcceleration:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000BB0C
   return: Void
   en-US: Stop Accelerating
   es-MX: Detener la aceleración
@@ -2975,7 +2838,6 @@ stopAllDamageModifications:
   description: Stops all damage modifications that were started using the start damage
     modification action.
   args: []
-  guid: 00000000C647
   return: Void
   en-US: Stop All Damage Modifications
   es-MX: Detener todas las modificaciones de daño
@@ -2987,7 +2849,6 @@ stopAllHealingModifications:
   description: Stops all healing modifications that were started using the start healing
     modification action.
   args: []
-  guid: 00000000FD3B
   return: Void
   en-US: Stop All Healing Modifications
   es-MX: Detener todas las modificaciones de sanación
@@ -3005,7 +2866,6 @@ _&stopAllDoT:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B9C3
   return: Void
   en-US: Stop All Damage Over Time
   es-MX: Detener todo el daño con el tiempo
@@ -3023,7 +2883,6 @@ _&stopAllHoT:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000B9C0
   return: Void
   en-US: Stop All Heal Over Time
   es-MX: Detener toda la sanación con el tiempo
@@ -3040,7 +2899,6 @@ _&stopCamera:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000C3B1
   return: Void
   en-US: Stop Camera
   es-MX: Detener cámara
@@ -3056,7 +2914,6 @@ __stopChasingGlobalVariable__:
     description: Specifies which global variable to stop modifying.
     type: GlobalVariable
     default: A
-  guid: 00000000B83E
   return: Void
   en-US: Stop Chasing Global Variable
   es-MX: Detener seguimiento de variable global
@@ -3078,7 +2935,6 @@ __stopChasingPlayerVariable__:
     description: Specifies which of the player's variables to stop modifying.
     type: PlayerVariable
     default: A
-  guid: 00000000B83D
   return: Void
   en-US: Stop Chasing Player Variable
   es-MX: Detener seguimiento de variable de jugador
@@ -3094,7 +2950,6 @@ stopDamageModification:
     description: Specifies which damage modification instance to stop. This id may be last damage modification id or a variable into which last damage modification id was earlier stored.
     type: DamageModificationId
     default: Last Damage Modification ID
-  guid: 00000000C649
   return: Void
   en-US: Stop Damage Modification
   es-MX: Detener modificación de daño
@@ -3110,7 +2965,6 @@ stopDoT:
     description: Specifies which damage over time instance to stop. This id may be last damage over time id or a variable into which last damage over time id was earlier stored.
     type: DotId
     default: Last Damage Over Time ID
-  guid: 00000000B9C4
   return: Void
   en-US: Stop Damage Over Time
   es-MX: Detener daño con el tiempo
@@ -3128,7 +2982,6 @@ _&stopFacing:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000BB21
   return: Void
   en-US: Stop Facing
   es-MX: Detener orientación
@@ -3147,7 +3000,6 @@ _&stopForcingCurrentHero:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000AC1B
   return: Void
   en-US: Stop Forcing Player To Be Hero
   es-MX: Dejar de forzar a un jugador a usar un héroe
@@ -3166,7 +3018,6 @@ _&stopForcingPosition:
     - Array: Player
     default: Event Player
   return: Void
-  guid: 000000010E8D
   en-US: Stop Forcing Player Position
   es-MX: Dejar de forzar la posición del jugador
   fr-FR: Arrêter de forcer la position du joueur
@@ -3181,7 +3032,6 @@ stopForcingSpawn:
     description: The team that will resume using their normal spawn room.
     type: Team
     default: Team
-  guid: 00000000B574
   return: Void
   en-US: Stop Forcing Spawn Room
   es-MX: Dejar de forzar cuarto de reaparición
@@ -3199,7 +3049,6 @@ _&stopForcingThrottle:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000BB0E
   return: Void
   en-US: Stop Forcing Throttle
   es-MX: Dejar de forzar la aceleración
@@ -3215,7 +3064,6 @@ stopHoT:
     description: Specifies which heal over time instance to stop. This id may be last heal over time id or a variable into which last heal over time id was earlier stored.
     type: HotId
     default: Player Variable
-  guid: 00000000B9C1
   return: Void
   en-US: Stop Heal Over Time
   es-MX: Detener sanación con el tiempo
@@ -3231,7 +3079,6 @@ stopHealingModification:
     description: Specifies which healing modification instance to stop. This id may be last healing modification id or a variable into which last healing modification id was earlier stored.
     type: HealingModificationId
     default: Last Healing Modification ID
-  guid: 00000000FD37
   return: Void
   en-US: Stop Healing Modification
   es-MX: Detener modificación de sanación
@@ -3253,7 +3100,6 @@ _&stopForcingButton:
     description: The logical button that is no longer being held virtually.
     type: ButtonLiteral
     default: Primary Fire
-  guid: 00000000B9D2
   return: Void
   en-US: Stop Holding Button
   es-MX: Dejar de mantener el botón presionado
@@ -3270,7 +3116,6 @@ _&stopThrottleInDirection:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000CEA3
   return: Void
   en-US: Stop Throttle In Direction
   es-MX: Detener aceleración en dirección
@@ -3288,7 +3133,6 @@ _&stopTransformingThrottle:
     - Player
     - Array: Player
     default: Event Player
-  guid: 00000000CC25
   return: Void
   en-US: Stop Transforming Throttle
   es-MX: Dejar de transformar la aceleración
@@ -3297,7 +3141,6 @@ _&stopTransformingThrottle:
   pt-BR: Parar Transformação de Aceleração
   zh-CN: 停止转换阈值
 _&teleport:
-  guid: 00000000B9BA
   description: Teleports one or more players to the specified position.
   args:
   - name: Player
@@ -3320,7 +3163,6 @@ _&teleport:
 unpauseMatchTime:
   description: Unpauses the match time.
   args: []
-  guid: 00000000B9F0
   return: Void
   en-US: Unpause Match Time
   es-MX: Despausar tiempo de la partida
@@ -3329,7 +3171,6 @@ unpauseMatchTime:
   pt-BR: Retomar Tempo da Partida
   zh-CN: 比赛时间继续
 __wait__:
-  guid: 000000007872
   description: Pauses the execution of the action list. Unless the wait is interrupted,
     the remainder of the actions will execute after the pause.
   args:
@@ -3359,7 +3200,6 @@ __while__:
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next end action at the current level.
     type: bool
     default: Compare
-  guid: 00000000FB35
   return: Void
   en-US: While
   es-MX: Mientras

--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -9,7 +9,7 @@ __abortIf__:
   args:
   - name: Condition
     description: Specifies whether the execution is stopped.
-    type: bool
+    type: Boolean
     default: Compare
   return: Void
   en-US: Abort If
@@ -433,7 +433,7 @@ createIcon:
     default: Color(White)
   - name: Show When Offscreen
     description: Should this icon appear even when it is behind you?
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Create Icon
@@ -722,7 +722,7 @@ __elif__:
   args:
   - name: Condition
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next else if, else, or end action at the current level.
-    type: bool
+    type: Boolean
     default: Compare
   return: Void
   en-US: Else If
@@ -881,7 +881,7 @@ __if__:
   args:
   - name: Condition
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next else if, else, or end action at the current level.
-    type: bool
+    type: Boolean
     default: Compare
   return: Void
   en-US: If
@@ -915,7 +915,7 @@ __loopIf__:
   args:
   - name: Condition
     description: Specifies whether the loop will occur.
-    type: bool
+    type: Boolean
     default: Compare
   return: Void
   en-US: Loop If
@@ -1183,7 +1183,7 @@ _&setAbility1Enabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use ability 1. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Ability 1 Enabled
@@ -1198,7 +1198,7 @@ _&setAbility2Enabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use ability 2. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Ability 2 Enabled
@@ -1248,7 +1248,7 @@ _&setCrouchEnabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use crouch. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Crouch Enabled
@@ -1415,7 +1415,7 @@ _&setJumpEnabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use jump. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Jump Enabled
@@ -1458,7 +1458,7 @@ _&setMeleeEnabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use melee. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Melee Enabled
@@ -1593,7 +1593,7 @@ _&setPrimaryFireEnabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use primary fire. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Primary Fire Enabled
@@ -1657,7 +1657,7 @@ _&setSecondaryFireEnabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use secondary fire. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Secondary Fire Enabled
@@ -1720,7 +1720,7 @@ _&setUltEnabled:
     default: Event Player
   - name: Enabled
     description: Specifies whether the player or players are able to use their ultimate ability. Expects a boolean value such as true, false, or compare.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Set Ultimate Ability Enabled
@@ -1756,7 +1756,7 @@ __skipIf__:
   args:
   - name: Condition
     description: Specifies whether the skip occurs.
-    type: bool
+    type: Boolean
     default: Compare
   - name: Number OF Actions
     description: The number of actions to skip, not including this action.
@@ -1947,7 +1947,7 @@ _&startForcingPosition:
     default: Vector
   - name: REEVALUATE
     description: If this value is true, then the position will be reevaluated and applied to the player every frame. If this value is false, then the posiiton is only evaluated once when the action begins.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Void
   en-US: Start Forcing Player Position
@@ -2411,7 +2411,7 @@ __while__:
   args:
   - name: Condition
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next end action at the current level.
-    type: bool
+    type: Boolean
     default: Compare
   return: Void
   en-US: While

--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -13,10 +13,10 @@ return:
 __abortIf__:
   description: Stops execution of the action list if this action's condition evaluates to true. If it does not, execution continues with the next action.
   args:
-  - name: CONDITION
+  - name: Condition
     description: Specifies whether the execution is stopped.
     type: bool
-    default: COMPARE
+    default: Compare
   guid: 00000000BB04
   return: void
   en-US: Abort If
@@ -44,22 +44,22 @@ __abortIfConditionIsTrue__:
   en-US: Abort If Condition Is True
   es-MX: Abortar si la condición es verdadera
   fr-FR: Interrompre si la condition est vraie
-  ja-JP: 条件が「TRUE」の場合中止
+  ja-JP: 条件が「True」の場合中止
   pt-BR: Anular se a Condição for Verdadeira
   zh-CN: 如条件为”真“则中止
 _&allowButton:
   description: Undoes the effect of the disallow button action for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose button is being reenabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The logical button that is being reenabled.
     type: ButtonLiteral
-    default: PRIMARY FIRE
+    default: Primary Fire
   guid: 00000000B9D0
   return: void
   en-US: Allow Button
@@ -71,28 +71,28 @@ _&allowButton:
 _&applyImpulse:
   description: Applies an instantaneous change in velocity to the movement of one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose velocity will be changed.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DIRECTION
+    default: Event Player
+  - name: Direction
     description: The unit direction in which the impulse will be applied. This value is normalized internally.
     type: Direction
-    default: VECTOR
-  - name: SPEED
+    default: Vector
+  - name: Speed
     description: The magnitude of the change to the velocities of the player or players.
     type: float
-    default: NUMBER
-  - name: RELATIVE
+    default: Number
+  - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
     type: Relativity
-    default: TO WORLD
+    default: To World
   - name: MOTION
     description: Specifies whether existing velocity that is counter to direction should first be cancelled out before applying the impulse.
     type: Impulse
-    default: CANCEL CONTRARY MOTION
+    default: Cancel Contrary Motion
   guid: 0000000078F6
   return: void
   en-US: Apply Impulse
@@ -107,15 +107,15 @@ _&attachTo:
   - name: CHILD
     description: The player that will attach to the parent. This player will be unable to move freely until detached or teleported away.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: PARENT
     description: The player to whom the child will attach. This player's movement will be unaffected and will determine the child's position.
     type: Player
-    default: LAST CREATED ENTITY
+    default: Last Created Entity Entity
   - name: OFFSET
     description: The coordinates of the child relative to the parent. For example, `vect(1,2,0)` would be above and to the left of the parent's head.
     type: Position
-    default: VECTOR
+    default: Vector
   return: void
   guid: 000000010E4F
   en-US: Attach Players
@@ -127,16 +127,16 @@ _&attachTo:
 bigMessage:
   description: Displays a large message above the reticle that is visible to specific players.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will see the message.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: HEADER
+    default: All Players
+  - name: Header
     description: The message to be displayed.
     type: Object
-    default: STRING
+    default: String
   guid: 00000000BA88
   return: void
   en-US: Big Message
@@ -158,7 +158,7 @@ break:
 __callSubroutine__:
   description: Pauses execution of the current rule and begins executing a subroutine rule (which is a rule with a subroutine event type). When the subroutine rule finishes, the original rule resumes execution. The subroutine will have access to the same contextual values (such as Event Player) as the original rule.
   args:
-  - name: SUBROUTINE
+  - name: Subroutine
     description: Specifies which subroutine to call. If a rule with a subroutine event type specifies the same subroutine, then it will execute. Otherwise, this action is ignored.
     type: Subroutine
     default: Sub0
@@ -173,12 +173,12 @@ __callSubroutine__:
 _&cancelPrimaryAction:
   description: Cancels the active abilities for one or more players. Equivalent to a short stun.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players to cancel active abilities for.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: void
   guid: 0000000109CB
   en-US: Cancel Primary Action
@@ -190,24 +190,24 @@ _&cancelPrimaryAction:
 __chaseGlobalVariableAtRate__:
   description: Gradually modifies the value of a global variable at a specific rate. (A global variable is a variable that belongs to the game itself.)
   args:
-  - name: VARIABLE
+  - name: Variable
     description: Specifies which global variable to modify gradually.
     type: GlobalVariable
     default: A
-  - name: DESTINATION
+  - name: Destination
     description: The value that the global variable will eventually reach. The type of this value may be either a number or a vector, though the variable's existing value must be of the same type before the chase begins.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: RATE
+    default: Number
+  - name: Rate
     description: The amount of change that will happen to the variable's value each second.
     type: float
-    default: NUMBER (1)
-  - name: REEVALUATION
+    default: Number (1)
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseRateReeval__
-    default: DESTINATION AND RATE
+    default: Destination And Rate
   guid: 00000000B840
   return: void
   en-US: Chase Global Variable At Rate
@@ -219,24 +219,24 @@ __chaseGlobalVariableAtRate__:
 __chaseGlobalVariableOverTime__:
   description: Gradually modifies the value of a global variable over time. (A global variable is a variable that belongs to the game itself.)
   args:
-  - name: VARIABLE
+  - name: Variable
     description: Specifies which global variable to modify gradually.
     type: GlobalVariable
     default: A
-  - name: DESTINATION
+  - name: Destination
     description: The value that the global variable will eventually reach. The type of this value may be either a number or a vector, though the variable's existing value must be of the same type before the chase begins.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: DURATION
+    default: Number
+  - name: Duration
     description: The amount of time, in seconds, over which the variable's value will approach the destination.
     type: float
-    default: NUMBER (1)
-  - name: REEVALUATION
+    default: Number (1)
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseTimeReeval__
-    default: DESTINATION AND DURATION
+    default: Destination And Duration
   guid: 00000000B842
   return: void
   en-US: Chase Global Variable Over Time
@@ -248,30 +248,30 @@ __chaseGlobalVariableOverTime__:
 __chasePlayerVariableAtRate__:
   description: Gradually modifies the value of a player variable at a specific rate. (A player variable is a variable that belongs to a specific player.)
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will gradually change. If multiple players are provided, each of their variables will change independently.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which of the player's variables to modify gradually.
     type: PlayerVariable
     default: A
-  - name: DESTINATION
+  - name: Destination
     description: The value that the player variable will eventually reach. The type of this value may be either a number or a vector, though the variable's existing value must be of the same type before the chase begins.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: RATE
+    default: Number
+  - name: Rate
     description: The amount of change that will happen to the variable's value each second.
     type: float
-    default: NUMBER (1)
-  - name: REEVALUATION
+    default: Number (1)
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseRateReeval__
-    default: DESTINATION AND RATE
+    default: Destination And Rate
   guid: 00000000B83F
   return: void
   en-US: Chase Player Variable At Rate
@@ -283,30 +283,30 @@ __chasePlayerVariableAtRate__:
 __chasePlayerVariableOverTime__:
   description: Gradually modifies the value of a player variable over time. (A player variable is a variable that belongs to a specific player.)
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will gradually change. If multiple players are provided, each of their variables will change independently.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which of the player's variables to modify gradually.
     type: PlayerVariable
-    default: VARIABLE
-  - name: DESTINATION
+    default: Variable
+  - name: Destination
     description: The value that the player variable will eventually reach. The type of this value may be either a number or a vector, though the variable's existing value must be of the same type before the chase begins.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: DURATION
+    default: Number
+  - name: Duration
     description: The amount of time, in seconds, over which the variable's value will approach the destination.
     type: float
-    default: NUMBER (1)
-  - name: REEVALUATION
+    default: Number (1)
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: __ChaseTimeReeval__
-    default: DESTINATION AND DURATION
+    default: Destination And Duration
   guid: 00000000B841
   return: void
   en-US: Chase Player Variable Over Time
@@ -318,16 +318,16 @@ __chasePlayerVariableOverTime__:
 _&clearStatusEffect:
   description: Clears a status that was applied from a set status action from one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players from whom the status will be removed.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: STATUS
+    default: Event Player
+  - name: Status
     description: The status to be removed from the player or players.
     type: Status
-    default: HACKED
+    default: Hacked
   guid: 00000000B595
   return: void
   en-US: Clear Status
@@ -339,16 +339,16 @@ _&clearStatusEffect:
 _&communicate:
   description: Causes one or more players to use an emote, voice line, or other equipped communication.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players to perform the communication.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: TYPE
+    default: Event Player
+  - name: Type
     description: The type of communication.
     type: Comms
-    default: VOICE LINE UP
+    default: Voice Line Up
   guid: 00000000B9E3
   return: void
   en-US: Communicate
@@ -371,32 +371,32 @@ continue:
 createBeam:
   description: Creates an in-world beam effect entity. This effect entity will persist until destroyed. To obtain a reference to this entity, use the last created entity value. This action will fail if too many entities have been created.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will be able to see the effect.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: TYPE
+    default: All Players
+  - name: Type
     description: The type of effect to be created.
     type: Beam
-    default: GOOD BEAM
-  - name: START POSITION
+    default: Good Beam
+  - name: Start Position
     description: The effect's start position. If this value is a player, then the effect will move along with the player. Otherwise, the value is interpreted as a position in the world.
     type: Position
-    default: EVENT PLAYER
-  - name: END POSITION
+    default: Event Player
+  - name: End Position
     description: The effect's end position. If this value is a player, then the effect will move along with the player. Otherwise, the value is interpreted as a position in the world.
     type: Position
-    default: EVENT PLAYER
-  - name: COLOR
+    default: Event Player
+  - name: Color
     description: The color of the beam to be created. If a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer. Does not apply to sound effects. Only the "good" and "bad" beam effects can have color applied.
     type: Color
     default: Color(White)
-  - name: REEVALUATION
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. The effect will keep asking for and using new values from reevaluated inputs.
     type: EffectReeval
-    default: VISIBLE TO, POSITION, AND RADIUS
+    default: Visible To, Position, And Radius
   guid: 00000000CE80
   return: void
   en-US: Create Beam Effect
@@ -408,26 +408,26 @@ createBeam:
 createDummy:
   description: Adds a new bot to the specified slot on the specified team so long as the slot is available. This bot will only move, fire, or use abilities if executing workshop actions.
   args:
-  - name: HERO
+  - name: Hero
     description: The hero that the bot will be. If more than one hero is provided, one will be chosen at random.
     type: Hero
-    default: HERO
-  - name: TEAM
+    default: Hero
+  - name: Team
     description: The team on which to create the bot. The "all" option only works in free-for-all game modes, while the "team" options only work in team-based game modes.
     type: Team
-    default: TEAM
-  - name: SLOT
+    default: Team
+  - name: Slot
     description: The player slot which will receive the bot (-1 for first available slot). Up to 6 bots may be added to each team, or 12 bots to the free-for-all team, regardless of lobby settings.
     type: int
-    default: NUMBER
-  - name: POSITION
+    default: Number
+  - name: Position
     description: The initial position where the bot will appear.
     type: Position
-    default: VECTOR
+    default: Vector
   - name: FACING
     description: The initial direction that the bot will face.
     type: Direction
-    default: VECTOR
+    default: Vector
   guid: 00000000CA6A
   return: void
   en-US: Create Dummy Bot
@@ -441,32 +441,32 @@ createEffect:
     until destroyed. To obtain a reference to this entity, use the last created entity
     value. This action will fail if too many entities have been created.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will be able to see the effect.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: TYPE
+    default: All Players
+  - name: Type
     description: The type of effect to be created.
     type: Effect
-    default: SPHERE
-  - name: COLOR
+    default: Sphere
+  - name: Color
     description: The color of the effect to be created. If a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer. Does not apply to sound effects.
     type: Color
     default: Color(White)
-  - name: POSITION
+  - name: Position
     description: The effect's position. If this value is a player, then the effect will move along with the player. Otherwise, the value is interpreted as a position in the world.
     type: Position
-    default: VECTOR
-  - name: RADIUS
+    default: Vector
+  - name: Radius
     description: The radius of this effect.
     type: unsigned float
-    default: NUMBER (1)
-  - name: REEVALUATION
+    default: Number (1)
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated.
     type: EffectReeval
-    default: VISIBLE TO, POSITION, AND RADIUS
+    default: Visible To, Position, And Radius
   guid: 00000000B8AF
   return: void
   en-US: Create Effect
@@ -481,52 +481,52 @@ __hudText__:
     this text, use the last text id value. This action will fail if too many text
     elements have been created.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will see the hud text.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: HEADER
+    default: All Players
+  - name: Header
     description: The text to be displayed (can be blank)
     type: Object
-    default: STRING
-  - name: SUBHEADER
+    default: String
+  - name: Subheader
     description: The subheader text to be displayed (can be blank)
     type: Object
-    default: 'NULL'
-  - name: TEXT
+    default: 'Null'
+  - name: Text
     description: The body text to be displayed (can be blank)
     type: Object
-    default: 'NULL'
-  - name: LOCATION
+    default: 'Null'
+  - name: Location
     description: The location on the screen where the text will appear.
     type: HudPosition
-    default: LEFT
+    default: Left
   - name: SORT ORDER
     description: The sort order of the text relative to other text in the same location. A higher sort order will come after a lower sort order.
     type: float
-    default: NUMBER
-  - name: HEADER COLOR
+    default: Number
+  - name: Header Color
     description: The color of the header.
     type: Color
     default: Color(White)
-  - name: SUBHEADER COLOR
+  - name: Subheader Color
     description: The color of the subheader.
     type: Color
     default: Color(White)
-  - name: TEXT COLOR
+  - name: Text Color
     description: The color of the text.
     type: Color
     default: Color(White)
-  - name: REEVALUATION
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated.
     type: HudReeval
-    default: VISIBLE TO AND STRING
-  - name: SPECTATORS
+    default: Visible To And String
+  - name: Spectators
     description: Whether spectators can see the text or not.
     type: SpecVisibility
-    default: DEFAULT VISIBILITY
+    default: Default Visibility
   guid: 00000000BAD3
   return: void
   en-US: Create HUD Text
@@ -540,32 +540,32 @@ createIcon:
     destroyed. To obtain a reference to this entity, use the last created entity value.
     This action will fail if too many entities have been created.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will be able to see the icon.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: POSITION
+    default: All Players
+  - name: Position
     description: The icon's position. If this value is a player, then the icon will appear above the player's head. Otherwise, the value is interpreted as a position in the world.
     type: Position
-    default: VECTOR
-  - name: ICON
+    default: Vector
+  - name: Icon
     description: The icon to be created.
     type: Icon
-    default: 'ARROW: DOWN'
-  - name: REEVALUATION
+    default: 'Arrow: Down'
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. The icon will keep asking for and using new values from reevaluated inputs.
     type: IconReeval
-    default: VISIBLE TO AND POSITION
-  - name: ICON COLOR
+    default: Visible To And Position
+  - name: Icon Color
     description: The color of the icon to be created. If a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer.
     type: Color
     default: Color(White)
-  - name: SHOW WHEN OFFSCREEN
+  - name: Show When Offscreen
     description: Should this icon appear even when it is behind you?
     type: bool
-    default: 'TRUE'
+    default: 'True'
   guid: 00000000ACFA
   return: void
   en-US: Create Icon
@@ -580,40 +580,40 @@ createInWorldText:
     this text, use the last text id value. This action will fail if too many text
     elements have been created.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will see the in-world text.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: HEADER
+    default: All Players
+  - name: Header
     description: The text to be displayed.
     type: Object
-    default: STRING
-  - name: POSITION
+    default: String
+  - name: Position
     description: The text's position. If this value is a player, then the text will appear above the player's head. Otherwise, the value is interpreted as a position in the world.
     type: Position
-    default: VECTOR
-  - name: SCALE
+    default: Vector
+  - name: Scale
     description: The text's scale.
     type: float
-    default: NUMBER (1)
-  - name: CLIPPING
+    default: Number (1)
+  - name: Clipping
     description: Specifies whether the text can be seen through walls or is instead clipped.
     type: Clip
-    default: CLIP AGAINST SURFACES
-  - name: REEVALUATION
+    default: Clip Against Surfaces
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. The text will keep asking for and using new values from reevaluated inputs.
     type: WorldTextReeval
-    default: VISIBLE TO, POSITION, AND STRING
-  - name: TEXT COLOR
+    default: Visible To, Position, And String
+  - name: Text Color
     description: Specifies the color of the in-world text to use.
     type: Color
     default: Color(White)
-  - name: SPECTATORS
+  - name: Spectators
     description: Whether spectators can see the text or not.
     type: SpecVisibility
-    default: DEFAULT VISIBILITY
+    default: Default Visibility
   guid: 00000000BAD0
   return: void
   en-US: Create In-World Text
@@ -627,20 +627,20 @@ damage:
   description: Applies instantaneous damage to one or more players, possibly killing
     the players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will receive damage.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DAMAGER
+    default: Event Player
+  - name: Damager
     description: The player who will receive credit for the damage. A damager of null indicates no player will receive credit.
     type: Player
-    default: 'NULL'
-  - name: AMOUNT
+    default: 'Null'
+  - name: Amount
     description: The amount of damage to apply. This amount may be modified by buffs, debuffs, or armor.
     type: float
-    default: NUMBER
+    default: Number
   return: void
   en-US: Damage
   es-MX: Infligir daño
@@ -664,10 +664,10 @@ declarePlayerVictory:
   description: Instantly ends the match with the specific player as the winner. This
     action only has an effect in free-for-all modes.
   args:
-  - name: PLAYER
+  - name: Player
     description: The winning player.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000AD30
   return: void
   en-US: Declare Player Victory
@@ -692,10 +692,10 @@ declareRoundVictory:
   description: Declare a team as the current round winner. This only works in the
     control and elimination game modes.
   args:
-  - name: ROUND WINNING TEAM
+  - name: Round Winning Team
     description: Round winning team
     type: Team
-    default: TEAM
+    default: Team
   guid: 00000000BF93
   return: void
   en-US: Declare Round Victory
@@ -708,10 +708,10 @@ declareTeamVictory:
   description: Instantly ends the match with the specified team as the winner. This
     action has no effect in free-for-all modes.
   args:
-  - name: TEAM
+  - name: Team
     description: The winning team.
     type: Team
-    default: TEAM
+    default: Team
   guid: 0000000078FD
   return: void
   en-US: Declare Team Victory
@@ -778,14 +778,14 @@ destroyAllInWorldText:
 destroyDummy:
   description: Removes the specified dummy bot from the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team to remove the dummy bot from. The "all" option only works in free-for-all game modes, while the "team" options only work in team-based game modes.
     type: Team
-    default: TEAM
-  - name: SLOT
+    default: Team
+  - name: Slot
     description: The slot to remove the dummy bot from.
     type: int
-    default: NUMBER
+    default: Number
   guid: 00000000CC21
   return: void
   en-US: Destroy Dummy Bot
@@ -797,10 +797,10 @@ destroyDummy:
 destroyEffect:
   description: Destroys an effect entity that was created by create effect.
   args:
-  - name: ENTITY
+  - name: Entity
     description: Specifies which effect entity to destroy. This entity may be last created entity or a variable into which last created entity was earlier stored.
     type: EntityId
-    default: LAST CREATED ENTITY
+    default: Last Created Entity Entity
   guid: 00000000B8AE
   return: void
   en-US: Destroy Effect
@@ -812,10 +812,10 @@ destroyEffect:
 destroyHudText:
   description: Destroys hud text that was created by create hud text.
   args:
-  - name: TEXT ID
+  - name: Text ID
     description: Specifies which hud text to destroy. This id may be last text id or a variable into which last text id was earlier stored.
     type: TextId
-    default: LAST TEXT ID
+    default: Last Text ID
   guid: 00000000BAD2
   return: void
   en-US: Destroy HUD Text
@@ -827,10 +827,10 @@ destroyHudText:
 destroyIcon:
   description: Destroys an icon entity that was created by create icon.
   args:
-  - name: ENTITY
+  - name: Entity
     description: Specifies which icon entity to destroy. This entity may be last created entity or a variable into which last created entity was earlier stored.
     type: EntityId
-    default: LAST CREATED ENTITY
+    default: Last Created Entity Entity
   guid: 00000000B4E7
   return: void
   en-US: Destroy Icon
@@ -842,10 +842,10 @@ destroyIcon:
 destroyInWorldText:
   description: Destroys in-world text that was created by create in-world text.
   args:
-  - name: TEXT ID
+  - name: Text ID
     description: Specifies which in-world text to destroy. This id may be last text id or a variable into which last text id was earlier stored.
     type: TextId
-    default: LAST TEXT ID
+    default: Last Text ID
   guid: 00000000BACF
   return: void
   en-US: Destroy In-World Text
@@ -863,7 +863,7 @@ _&detach:
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: void
   guid: 000000010E52
   en-US: Detach Players
@@ -911,12 +911,12 @@ _&disableRespawn:
   description: Disables automatic respawning for one or more players, only allowing
     respawning by scripting commands.
   args:
-  - name: PLAYERS
+  - name: PlayerS
     description: The player or players whose respawning is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B87A
   return: void
   en-US: Disable Built-In Game Mode Respawning
@@ -941,12 +941,12 @@ _&disableDeathSpectateAllPlayers:
   description: Undoes the effect of the enable death spectate all players action for
     or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose default death spectate behavior is restored.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B9B5
   return: void
   en-US: Disable Death Spectate All Players
@@ -959,12 +959,12 @@ _&disableDeathSpectateTargetHud:
   description: Undoes the effect of the enable death spectate target hud action for
     or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will revert to seeing their own hud while death spectating.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B9B3
   return: void
   en-US: Disable Death Spectate Target HUD
@@ -990,16 +990,16 @@ _&disallowButton:
   description: Disables a logical button for one or more players such that pressing
     it has no effect.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose button is being disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The logical button that is being disabled.
     type: ButtonLiteral
-    default: PRIMARY FIRE
+    default: Primary Fire
   guid: 00000000B9CF
   return: void
   en-US: Disallow Button
@@ -1017,22 +1017,22 @@ __else__:
   en-US: Else
   es-MX: Si no
   fr-FR: Sinon
-  ja-JP: ELSE
+  ja-JP: Else
 __elif__:
   description: Denotes the beginning of a series of actions that will only execute
     if the specified condition is true and the previous If or Else If action's condition
     was false.
   args:
-  - name: CONDITION
+  - name: Condition
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next else if, else, or end action at the current level.
     type: bool
-    default: COMPARE
+    default: Compare
   guid: 00000000FB33
   return: void
   en-US: Else If
   es-MX: Si no si
   fr-FR: Sinon Si
-  ja-JP: ELSE IF
+  ja-JP: Else If
 enableAnnouncer:
   description: Undoes the effect of the disable built-in game mode announcer action.
   args: []
@@ -1070,12 +1070,12 @@ _&enableRespawn:
   description: Undoes the effect of the disable built-in game mode respawning action
     for one or more players.
   args:
-  - name: PLAYERS
+  - name: PlayerS
     description: The player or players whose respawning is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B878
   return: void
   en-US: Enable Built-In Game Mode Respawning
@@ -1099,12 +1099,12 @@ _&enableDeathSpectateAllPlayers:
   description: Allows one or more players to spectate all players when dead, as opposed
     to only allies.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will be allowed to spectate all players.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B9AE
   return: void
   en-US: Enable Death Spectate All Players
@@ -1117,12 +1117,12 @@ _&enableDeathSpectateTargetHud:
   description: Causes one or more players to see their spectate target's hud instead
     of their own while death spectating.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will begin seeing their spectate targets hud while death spectating.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B9B4
   return: void
   en-US: Enable Death Spectate Target HUD
@@ -1153,7 +1153,7 @@ __end__:
   en-US: End
   es-MX: Fin
   fr-FR: Fin
-  ja-JP: END
+  ja-JP: End
   pt-BR: Término
 __forGlobalVariable__:
   description: Denotes the beginning of a series of actions that will execute in a
@@ -1162,22 +1162,22 @@ __forGlobalVariable__:
     stop value, then the loop exits, and execution jumps to the next action after
     the end action.
   args:
-  - name: CONTROL VARIABLE
+  - name: Control Variable
     description: The variable being modified in this loop. It is set to the range start value when the loop begins, and the loop continues until the control variable reaches or passes the range stop value.
     type: GlobalVariable
     default: A
-  - name: RANGE START
+  - name: Range Start
     description: The control variable is set to this value when the loop begins.
     type: float
-    default: NUMBER
-  - name: RANGE STOP
+    default: Number
+  - name: Range Stop
     description: If the control variable reaches or passes this value, then the loop will exit, and execution jumps to the next action after the end action. Whether this value is considered passed or not is based on whether the step value is negative or positive. If the control variable has already reached or passed this value when the loop begins, then the loop exits.
     type: float
-    default: COUNT OF
-  - name: STEP
+    default: Count OF
+  - name: Step
     description: This value is added to the control variable when the end action is reached. If this modification causes the control variable to reach or pass the range stop value, then the loop exits, and execution jumps to the next action after the end action. Otherwise, the loop continues, and execution jumps to the next action after the for action.
     type: float
-    default: NUMBER (1)
+    default: Number (1)
   guid: 00000000FEE2
   return: void
   en-US: For Global Variable
@@ -1193,26 +1193,26 @@ __forPlayerVariable__:
     stop value, then the loop exits, and execution jumps to the next action after
     the end action.
   args:
-  - name: CONTROL PLAYER
+  - name: Control Player
     description: The player whose variable is being modified in this loop. If multiple players are specified, the first player is used.
     type: Player
-    default: EVENT PLAYER
-  - name: CONTROL VARIABLE
+    default: Event Player
+  - name: Control Variable
     description: The variable being modified in this loop. It is set to the range start value when the loop begins, and the loop continues until the control variable reaches or passes the range stop value.
     type: PlayerVariable
     default: A
-  - name: RANGE START
+  - name: Range Start
     description: The control variable is set to this value when the loop begins.
     type: float
-    default: NUMBER
-  - name: RANGE STOP
+    default: Number
+  - name: Range Stop
     description: If the control variable reaches or passes this value, then the loop will exit, and execution jumps to the next action after the end action. Whether this value is considered passed or not is based on whether the step value is negative or positive. If the control variable has already reached or passed this value when the loop begins, then the loop exits.
     type: float
-    default: COUNT OF
-  - name: STEP
+    default: Count OF
+  - name: Step
     description: This value is added to the control variable when the end action is reached. If this modification causes the control variable to reach or pass the range stop value, then the loop exits, and execution jumps to the next action after the end action. Otherwise, the loop continues, and execution jumps to the next action after the for action.
     type: float
-    default: NUMBER (1)
+    default: Number (1)
   guid: 00000000FEE1
   return: void
   en-US: For Player Variable
@@ -1238,20 +1238,20 @@ heal:
   description: Provides an instantaneous heal to one or more players. This heal will
     not resurrect dead players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose health will be restored.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HEALER
+    default: Event Player
+  - name: Healer
     description: The player who will receive credit for the healing. A healer of null indicates no player will receive credit.
     type: Player
-    default: 'NULL'
-  - name: AMOUNT
+    default: 'Null'
+  - name: Amount
     description: The amount of healing to apply. This amount may be modified by buff or debuffs. Healing is capped by each player's max health.
     type: float
-    default: NUMBER
+    default: Number
   return: void
   en-US: Heal
   es-MX: Sanar
@@ -1263,30 +1263,30 @@ __if__:
   description: Denotes the beginning of a series of actions that will only execute
     if the specified condition is true.
   args:
-  - name: CONDITION
+  - name: Condition
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next else if, else, or end action at the current level.
     type: bool
-    default: COMPARE
+    default: Compare
   guid: 00000000FB32
   return: void
   en-US: If
   es-MX: Si
   fr-FR: Si
-  ja-JP: IF
+  ja-JP: If
 kill:
   guid: 000000007877
   description: Instantly kills one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will be killed.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: KILLER
     description: The player who will receive credit for the kill. A killer of null indicates no player will receive credit.
     type: Player
-    default: 'NULL'
+    default: 'Null'
   return: void
   en-US: Kill
   es-MX: Matar
@@ -1313,10 +1313,10 @@ __loopIf__:
     prevent an infinite loop, a wait action must execute between the start of the
     action list and this action.
   args:
-  - name: CONDITION
+  - name: Condition
     description: Specifies whether the loop will occur.
     type: bool
-    default: COMPARE
+    default: Compare
   guid: 00000000BB06
   return: void
   en-US: Loop If
@@ -1350,27 +1350,27 @@ __loopIfConditionIsTrue__:
   en-US: Loop If Condition Is True
   es-MX: Repetir si la condición es verdadera
   fr-FR: Boucle si la condition est vraie
-  ja-JP: 条件が「TRUE」の場合ループ
+  ja-JP: 条件が「True」の場合ループ
   pt-BR: Gerar Loop se a Condição for Verdadeira
   zh-CN: 如条件为”真“则循环
 __modifyGlobalVariable__:
   description: Modifies the value of a global variable, which is a variable that belongs
     to the game itself.
   args:
-  - name: VARIABLE
+  - name: Variable
     description: The global variable to modify.
     type: GlobalVariable
     default: A
-  - name: OPERATION
+  - name: Operation
     description: The way in which the variable's value will be changed. Options include standard arithmetic operations as well as array operations for appending and removing values.
     type: __Operation__
-    default: ADD
-  - name: VALUE
+    default: Add
+  - name: Value
     description: The value used for the modification. For arithmetic operations, this is the second of the two operands, with the other being the variable's existing value. For array operations, this is the value to append or remove.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 00000000786E
   return: void
   en-US: Modify Global Variable
@@ -1383,24 +1383,24 @@ __modifyGlobalVariableAtIndex__:
   description: Modifies the value of a global variable at an index, which is a variable
     that belongs to the game itself.
   args:
-  - name: VARIABLE
+  - name: Variable
     description: The global variable to modify.
     type: GlobalVariable
     default: A
-  - name: INDEX
+  - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
     type: unsigned int
-    default: NUMBER
-  - name: OPERATION
+    default: Number
+  - name: Operation
     description: The way in which the variable's value will be changed. Options include standard arithmetic operations as well as array operations for appending and removing values.
     type: __Operation__
-    default: ADD
-  - name: VALUE
+    default: Add
+  - name: Value
     description: The value used for the modification. For arithmetic operations, this is the second of the two operands, with the other being the variable's existing value. For array operations, this is the value to append or remove.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 00000000C7E1
   return: void
   en-US: Modify Global Variable At Index
@@ -1413,16 +1413,16 @@ _&addToScore:
   description: Modifies the score (kill count) of one or more players. This action
     only has an effect in free-for-all modes.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose score will change.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: SCORE
+    default: Event Player
+  - name: Score
     description: The amount the score will increase or decrease. If positive, the score will increase. If negative, the score will decrease.
     type: int
-    default: NUMBER
+    default: Number
   guid: 000000007873
   return: void
   en-US: Modify Player Score
@@ -1435,26 +1435,26 @@ __modifyPlayerVariable__:
   description: Modifies the value of a player variable, which is a variable that belongs
     to a specific player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will be modified. If multiple players are provided, each of their variables will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which of the player's variables to modify.
     type: PlayerVariable
     default: A
-  - name: OPERATION
+  - name: Operation
     description: The way in which the variable's value will be changed. Options include standard arithmetic operations as well as array operations for appending and removing values.
     type: __Operation__
-    default: ADD
-  - name: VALUE
+    default: Add
+  - name: Value
     description: The value used for the modification. For arithmetic operations, this is the second of the two operands, with the other being the variable's existing value. For array operations, this is the value to append or remove.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 00000000786F
   return: void
   en-US: Modify Player Variable
@@ -1467,30 +1467,30 @@ __modifyPlayerVariableAtIndex__:
   description: Modifies the value of a player variable at an index, which is a variable
     that belongs to a specific player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will be modified. If multiple players are provided, each of their variables will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which of the player's variables to modify.
     type: PlayerVariable
     default: A
-  - name: INDEX
+  - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
     type: unsigned int
-    default: NUMBER
-  - name: OPERATION
+    default: Number
+  - name: Operation
     description: The way in which the variable's value will be changed. Options include standard arithmetic operations as well as array operations for appending and removing values.
     type: __Operation__
-    default: ADD
-  - name: VALUE
+    default: Add
+  - name: Value
     description: The value used for the modification. For arithmetic operations, this is the second of the two operands, with the other being the variable's existing value. For array operations, this is the value to append or remove.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 00000000C7DF
   return: void
   en-US: Modify Player Variable At Index
@@ -1503,14 +1503,14 @@ addToTeamScore:
   description: Modifies the score of one or both teams. This action has no effect
     in free-for-all modes or modes without a team score.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams whose score will be changed.
     type: Team
-    default: TEAM
-  - name: SCORE
+    default: Team
+  - name: Score
     description: The amount the score will increase or decrease. If positive, the score will increase. If negative, the score will decrease.
     type: int
-    default: NUMBER
+    default: Number
   guid: 00000000BB24
   return: void
   en-US: Modify Team Score
@@ -1535,28 +1535,28 @@ playEffect:
   description: Plays an effect at a position in the world. The lifetime of this effect
     is short, so it does not need to be updated or destroyed.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will be able to see the effect.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: TYPE
+    default: All Players
+  - name: Type
     description: The type of effect to be created.
     type: DynamicEffect
-    default: GOOD EXPLOSION
-  - name: COLOR
+    default: Good Explosion
+  - name: Color
     description: The color of the effect to be created. If a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer.
     type: Color
     default: Color(White)
-  - name: POSITION
+  - name: Position
     description: The effect's position. If this value is a player, then the effect will play at the player's position. Otherwise, the value is interpreted as a position in the world.
     type: Position
-    default: VECTOR
-  - name: RADIUS
+    default: Vector
+  - name: Radius
     description: The effect's radius in meters.
     type: unsigned float
-    default: NUMBER (1)
+    default: Number (1)
   guid: 00000000BB27
   return: void
   en-US: Play Effect
@@ -1570,18 +1570,18 @@ _&preloadHero:
     skins of the specified player or players, available memory permitting. Useful
     whenever rapid hero changing is possible and the next hero is known.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will begin preloading a hero or heroes. Only one preload hero action will be active at a time for a given player.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HERO
+    default: Event Player
+  - name: Hero
     description: The hero or heroes to begin preloading for the specified player or players. When multiple heroes are specified in an array, the heroes towards the beginning of the array are prioritized.
     type:
     - Hero
     - Array: Hero
-    default: HERO
+    default: Hero
   guid: 00000000B9B1
   return: void
   en-US: Preload Hero
@@ -1594,16 +1594,16 @@ _&forceButtonPress:
   description: Forces one or more players to press a button virtually for a single
     frame.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players for whom the virtual button input will be forced.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The button to be pressed.
     type: ButtonLiteral
-    default: PRIMARY FIRE
+    default: Primary Fire
   guid: 0000000078FB
   return: void
   en-US: Press Button
@@ -1618,12 +1618,12 @@ _&resetHeroAvailability:
     the player is forced to choose a different hero and respawn at an appropriate
     spawn location.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose hero list is being reset.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000BA5A
   return: void
   en-US: Reset Player Hero Availability
@@ -1636,12 +1636,12 @@ _&respawn:
   description: Respawns one or more players at an appropriate spawn location with
     full health, even if they were already alive.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players to respawn.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 0000000078FC
   return: void
   en-US: Respawn
@@ -1655,12 +1655,12 @@ _&resurrect:
   description: Instantly resurrects one or more players at the location they died
     with no transition.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will be resurrected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: void
   en-US: Resurrect
   es-MX: Resucitar
@@ -1671,16 +1671,16 @@ _&resurrect:
 _&setAbility1Enabled:
   description: Enables or disables ability 1 for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to ability 1 is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use ability 1. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   guid: 00000000B9B8
   return: void
   en-US: Set Ability 1 Enabled
@@ -1692,16 +1692,16 @@ _&setAbility1Enabled:
 _&setAbility2Enabled:
   description: Enables or disables ability 2 for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to ability 2 is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use ability 2. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   guid: 00000000B9B7
   return: void
   en-US: Set Ability 2 Enabled
@@ -1713,20 +1713,20 @@ _&setAbility2Enabled:
 _&setAbilityCooldown:
   description: Set the ability cooldown time for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose ability cooldown time will be modified.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The logical button associated with the ability to be modified.
     type: Button
-    default: PRIMARY FIRE
+    default: Primary Fire
   - name: COOLDOWN
     description: The cooldown time that will be set in seconds. Max of 1000.
     type: unsigned float
-    default: NUMBER
+    default: Number
   return: void
   guid: 0000000109CA
   en-US: Set Ability Cooldown
@@ -1739,16 +1739,16 @@ _&setAimSpeed:
   description: Sets the aim speed of one or more players to a percentage of their
     normal aim speed.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose aim speed will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: TURN SPEED PERCENT
+    default: Event Player
+  - name: Turn Speed Percent
     description: The percentage of normal aim speed to which the player or players will set their aim speed.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000C364
   return: void
   en-US: Set Aim Speed
@@ -1760,16 +1760,16 @@ _&setAimSpeed:
 _&setCrouchEnabled:
   description: Enables or disables crouch for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to crouch is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use crouch. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: void
   guid: 0000000105A3
   en-US: Set Crouch Enabled
@@ -1782,16 +1782,16 @@ _&setDamageDealt:
   description: Sets the damage dealt of one or more players to a percentage of their
     raw damage dealt.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose damage dealt will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DAMAGE DEALT PERCENT
+    default: Event Player
+  - name: Damage Dealt Percent
     description: The percentage of raw damage dealt to which the player or players will set their damage dealt.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B995
   return: void
   en-US: Set Damage Dealt
@@ -1804,16 +1804,16 @@ _&setDamageReceived:
   description: Sets the damage received of one or more players to a percentage of
     their raw damage received.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose damage received will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DAMAGE RECEIVED PERCENT
+    default: Event Player
+  - name: Damage Received Percent
     description: The percentage of raw damage received to which the player or players will set their damage received.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B997
   return: void
   en-US: Set Damage Received
@@ -1825,20 +1825,20 @@ _&setDamageReceived:
 _&setFacing:
   description: Sets the facing of one or more players to the specified direction.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose facing will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DIRECTION
+    default: Event Player
+  - name: Direction
     description: The unit direction in which the player or players will face. This value is normalized internally.
     type: Direction
-    default: VECTOR
-  - name: RELATIVE
+    default: Vector
+  - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
     type: Relativity
-    default: TO WORLD
+    default: To World
   guid: 00000000BB29
   return: void
   en-US: Set Facing
@@ -1851,16 +1851,16 @@ __setGlobalVariable__:
   description: Stores a value into a global variable, which is a variable that belongs
     to the game itself.
   args:
-  - name: VARIABLE
+  - name: Variable
     description: Specifies which global variable to store the value into.
     type: GlobalVariable
     default: A
-  - name: VALUE
+  - name: Value
     description: The value that will be stored.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 0000000077DE
   return: void
   en-US: Set Global Variable
@@ -1874,20 +1874,20 @@ __setGlobalVariableAtIndex__:
     that belongs to the game itself, then stores a value in the array at the specified
     index.
   args:
-  - name: VARIABLE
+  - name: Variable
     description: Specifies which global variable's value is the array to modify. If the variable's value is not an array, then its value becomes an empty array.
     type: GlobalVariable
     default: A
-  - name: INDEX
+  - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
     type: unsigned int
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The value that will be stored into the array.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 00000000BBAA
   return: void
   en-US: Set Global Variable At Index
@@ -1900,16 +1900,16 @@ _&setGravity:
   description: Sets the movement gravity for one or more players to a percentage regular
     movement gravity.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose movement gravity will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: GRAVITY PERCENT
+    default: Event Player
+  - name: Gravity Percent
     description: The percentage of regular movement gravity to which the player or players will set their personal movement gravity.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B999
   return: void
   en-US: Set Gravity
@@ -1922,16 +1922,16 @@ _&setHealingDealt:
   description: Sets the healing dealt of one or more players to a percentage of their
     raw healing dealt.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose healing dealt will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HEALING DEALT PERCENT
+    default: Event Player
+  - name: Healing Dealt Percent
     description: ''
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B991
   return: void
   en-US: Set Healing Dealt
@@ -1944,16 +1944,16 @@ _&setHealingReceived:
   description: Sets the healing received of one or more players to a percentage of
     their raw healing received.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose healing received will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HEALING RECEIVED PERCENT
+    default: Event Player
+  - name: Healing Received Percent
     description: The percentage of raw healing received to which the player or players will set their healing received.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B993
   return: void
   en-US: Set Healing Received
@@ -1966,13 +1966,13 @@ _&setInvisibility:
   description: Causes one or more players to become invisible to either all other
     players or just enemies.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will become invisible.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: INVISIBLE TO
+    default: Event Player
+  - name: INVisible To
     description: Specifies for whom the player or players will be invisible.
     type: Invis
     default: ALL
@@ -1987,16 +1987,16 @@ _&setInvisibility:
 _&setJumpEnabled:
   description: Enables or disables jump for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to jump is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use jump. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: void
   guid: 0000000105A5
   en-US: Set Jump Enabled
@@ -2010,10 +2010,10 @@ setMatchTime:
     This can be used to shorten or extend the duration of a match or to change the
     duration of assemble heroes or setup.
   args:
-  - name: TIME
+  - name: Time
     description: The match time in seconds.
     type: unsigned int
-    default: NUMBER
+    default: Number
   guid: 00000000AD31
   return: void
   en-US: Set Match Time
@@ -2027,16 +2027,16 @@ _&setMaxHealth:
     max health. This action will ensure that a player's current health will not exceed
     the new max health.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose max health will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HEALTH PERCENT
+    default: Event Player
+  - name: Health Percent
     description: The percentage of raw max health to which the player or players will set their max health.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 0000000078FA
   return: void
   en-US: Set Max Health
@@ -2048,16 +2048,16 @@ _&setMaxHealth:
 _&setMeleeEnabled:
   description: Enables or disables melee for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to melee is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use melee. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: void
   guid: 000000010596
   en-US: Set Melee Enabled
@@ -2070,16 +2070,16 @@ _&setMoveSpeed:
   description: Sets the move speed of one or more players to a percentage of their
     raw move speed.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose move speed will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: MOVE SPEED PERCENT
+    default: Event Player
+  - name: Move Speed Percent
     description: The percentage of raw move speed to which the player or players will set their move speed.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B998
   return: void
   en-US: Set Move Speed
@@ -2092,20 +2092,20 @@ setObjectiveDescription:
   description: Sets the text at the top center of the screen that normally describes
     the objective to a message visible to specific players.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will see the message.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: HEADER
+    default: All Players
+  - name: Header
     description: The message to be displayed.
     type: Object
-    default: STRING
-  - name: REEVALUATION
+    default: String
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. The message will keep asking for and using new values from reevaluated inputs.
     type: HudReeval
-    default: VISIBLE TO AND STRING
+    default: Visible To And String
   guid: 00000000BA85
   return: void
   en-US: Set Objective Description
@@ -2119,18 +2119,18 @@ _&setAllowedHeroes:
     current hero becomes unavailable, the player is forced to choose a different hero
     and respawn at an appropriate spawn location.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose hero list is being set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HERO
+    default: Event Player
+  - name: Hero
     description: The hero or heroes that will be available. If no heroes are provided, the action has no effect.
     type:
     - Hero
     - Array: Hero
-    default: HERO
+    default: Hero
   guid: 00000000BA5B
   return: void
   en-US: Set Player Allowed Heroes
@@ -2143,16 +2143,16 @@ _&setScore:
   description: Sets the score (kill count) of one or more players. This action only
     has an effect in free-for-all modes.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose score will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: SCORE
+    default: Event Player
+  - name: Score
     description: The score that will be set.
     type: int
-    default: NUMBER
+    default: Number
   guid: 00000000BB22
   return: void
   en-US: Set Player Score
@@ -2165,22 +2165,22 @@ __setPlayerVariable__:
   description: Stores a value into a player variable, which is a variable that belongs
     to a specific player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will be set. If multiple players are provided, each of their variables will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which of the player's variables to store the value into.
     type: PlayerVariable
     default: A
-  - name: VALUE
+  - name: Value
     description: The value that will be stored.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 0000000077DF
   return: void
   en-US: Set Player Variable
@@ -2194,26 +2194,26 @@ __setPlayerVariableAtIndex__:
     that belongs to a specific player, then stores a value in the array at the specified
     index.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will be modified. If multiple players are provided, each of their variables will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which player variable's value is the array to modify. If the variable's value is not an array, then its value becomes an empty array.
     type: PlayerVariable
     default: A
-  - name: INDEX
+  - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
     type: unsigned int
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The value that will be stored into the array.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   guid: 00000000BBA9
   return: void
   en-US: Set Player Variable At Index
@@ -2225,16 +2225,16 @@ __setPlayerVariableAtIndex__:
 _&setPrimaryFireEnabled:
   description: Enables or disables primary fire for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to primary fire is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use primary fire. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   guid: 00000000C6C5
   return: void
   en-US: Set Primary Fire Enabled
@@ -2247,16 +2247,16 @@ _&setProjectileGravity:
   description: Sets the projectile gravity for one or more players to a percentage
     of regular projectile gravity.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose projectile gravity will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: PROJECTILE GRAVITY PERCENT
+    default: Event Player
+  - name: Projectile Gravity Percent
     description: The percentage of regular projectile gravity to which the player or players will set their personal projectile gravity.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B99B
   return: void
   en-US: Set Projectile Gravity
@@ -2269,16 +2269,16 @@ _&setProjectileSpeed:
   description: Sets the projectile speed for one or more players to a percentage of
     projectile speed.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose projectile speed will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: PROJECTILE SPEED PERCENT
+    default: Event Player
+  - name: Projectile Speed Percent
     description: The percentage of regular projectile speed to which the player or players will set their personal projectile speed.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B99D
   return: void
   en-US: Set Projectile Speed
@@ -2292,16 +2292,16 @@ _&setRespawnTime:
     For players that are already dead when this action is executed, the change takes
     effect on their next death.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose respawn max time is being defined.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: TIME
+    default: Event Player
+  - name: Time
     description: The duration between death and respawn in seconds.
     type: unsigned int
-    default: NUMBER
+    default: Number
   guid: 00000000B9CD
   return: void
   en-US: Set Respawn Max Time
@@ -2313,16 +2313,16 @@ _&setRespawnTime:
 _&setSecondaryFireEnabled:
   description: Enables or disables secondary fire for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to secondary fire is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use secondary fire. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   guid: 00000000C6C4
   return: void
   en-US: Set Secondary Fire Enabled
@@ -2335,10 +2335,10 @@ setSlowMotion:
   description: Sets the simulation rate for the entire game, including all players,
     projectiles, effects, and game mode logic.
   args:
-  - name: SPEED PERCENT
+  - name: Speed Percent
     description: The simulation rate as a percentage of normal speed. Only rates up to 100% are allowed.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B9F2
   return: void
   en-US: Set Slow Motion
@@ -2351,24 +2351,24 @@ _&setStatusEffect:
   description: Applies a status to one or more players. This status will remain in
     effect for the specified duration or until it is cleared by the clear status action.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players to whom the status will be applied.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ASSISTER
+    default: Event Player
+  - name: Assister
     description: Specifies a player to be awarded assist credit should the affected player or players be killed while the status is in effect. An assister of null indicates no player will receive credit.
     type: Player
-    default: 'NULL'
-  - name: STATUS
+    default: 'Null'
+  - name: Status
     description: The status to be applied to the player or players. These behave similarly to statuses applied from hero abilities.
     type: Status
-    default: HACKED
-  - name: DURATION
+    default: Hacked
+  - name: Duration
     description: The duration of the status in seconds. To have a status that lasts until a clear status action is executed, provide an arbitrarily long duration such as 9999.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B588
   return: void
   en-US: Set Status
@@ -2381,14 +2381,14 @@ setTeamScore:
   description: Sets the score for one or both teams. This action has no effect in
     free-for-all modes or modes without a team score.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams whose score will be set.
     type: Team
-    default: TEAM
-  - name: SCORE
+    default: Team
+  - name: Score
     description: The score that will be set.
     type: int
-    default: NUMBER
+    default: Number
   guid: 00000000BB25
   return: void
   en-US: Set Team Score
@@ -2400,16 +2400,16 @@ setTeamScore:
 _&setUltEnabled:
   description: Enables or disables the ultimate ability of one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose access to their ultimate ability is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: ENABLED
+    default: Event Player
+  - name: Enabled
     description: Specifies whether the player or players are able to use their ultimate ability. Expects a boolean value such as true, false, or compare.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   guid: 00000000B9B6
   return: void
   en-US: Set Ultimate Ability Enabled
@@ -2422,16 +2422,16 @@ _&setUltCharge:
   description: Sets the ultimate charge for one or more players as a percentage of
     maximum charge.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose ultimate charge will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: CHARGE PERCENT
+    default: Event Player
+  - name: Charge Percent
     description: The percentage of maximum charge.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000BB1C
   return: void
   en-US: Set Ultimate Charge
@@ -2444,10 +2444,10 @@ __skip__:
   guid: 00000000BB01
   description: Skips execution of a certain number of actions in the action list.
   args:
-  - name: NUMBER OF ACTIONS
+  - name: Number OF Actions
     description: The number of actions to skip, not including this action.
     type: unsigned int
-    default: NUMBER
+    default: Number
   return: void
   en-US: Skip
   es-MX: Omitir
@@ -2460,14 +2460,14 @@ __skipIf__:
     this action's condition evaluates to true. If it does not, execution continues
     with the next action.
   args:
-  - name: CONDITION
+  - name: Condition
     description: Specifies whether the skip occurs.
     type: bool
-    default: COMPARE
-  - name: NUMBER OF ACTIONS
+    default: Compare
+  - name: Number OF Actions
     description: The number of actions to skip, not including this action.
     type: unsigned int
-    default: NUMBER
+    default: Number
   guid: 00000000BB00
   return: void
   en-US: Skip If
@@ -2480,16 +2480,16 @@ smallMessage:
   description: Displays a small message beneath the reticle that is visible to specific
     players.
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will see the message.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: HEADER
+    default: All Players
+  - name: Header
     description: The message to be displayed.
     type: Object
-    default: STRING
+    default: String
   guid: 00000000BA87
   return: void
   en-US: Small Message
@@ -2501,32 +2501,32 @@ smallMessage:
 _&startAcceleration:
   description: Starts accelerating one or more players in a specified direction.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players that will begin accelerating.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DIRECTION
+    default: Event Player
+  - name: Direction
     description: The unit direction in which the acceleration will be applied. This value is normalized internally.
     type: Direction
-    default: VECTOR
-  - name: RATE
+    default: Vector
+  - name: Rate
     description: The rate of acceleration in meters per second squared. This value may need to be quite high in order to overcome gravity and/or surface friction.
     type: unsigned float
-    default: NUMBER
-  - name: MAX SPEED
+    default: Number
+  - name: Max Speed
     description: The speed at which acceleration will stop for the player or players. It may not be possible to reach this speed due to gravity and/or surface friction.
     type: unsigned float
-    default: NUMBER
-  - name: RELATIVE
+    default: Number
+  - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
     type: Relativity
-    default: TO WORLD
-  - name: REEVALUATION
+    default: To World
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: AccelReeval
-    default: DIRECTION, RATE, AND MAX SPEED
+    default: Direction, Rate, And Max Speed
   guid: 00000000BB0D
   return: void
   en-US: Start Accelerating
@@ -2538,24 +2538,24 @@ _&startAcceleration:
 _&setCamera:
   description: Places your camera at a location, facing a direction.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose cameras will be placed at the location.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: EYE POSITION
+    default: Event Player
+  - name: Eye Position
     description: The position of the camera. Reevaluates continuously.
     type: Position
-    default: VECTOR
-  - name: LOOK AT POSITION
+    default: Vector
+  - name: Look At Position
     description: Where the camera looks at. Reevaluates continuously.
     type: Position
-    default: VECTOR
-  - name: BLEND SPEED
+    default: Vector
+  - name: Blend Speed
     description: How fast to blend the camera speed as positions change. 0 means do not blend at all, and just change positions instantly.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000C393
   return: void
   en-US: Start Camera
@@ -2570,26 +2570,26 @@ startDamageModification:
     from the last damage modification id value. This action will fail if too many
     damage modifications have been started.
   args:
-  - name: RECEIVERS
+  - name: Receivers
     description: The player or players whose incoming damage will be modified (when attacked by the damagers).
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DAMAGERS
+    default: Event Player
+  - name: Damagers
     description: The player or players whose outgoing damage will be modified (when attacking the receivers).
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: DAMAGE PERCENT
+    default: All Players
+  - name: Damage Percent
     description: The percentage of damage that will apply to receivers when attacked by damagers.
     type: unsigned float
-    default: NUMBER
-  - name: REEVALUATION
+    default: Number
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: DamageReeval
-    default: RECEIVERS, DAMAGERS, AND DAMAGE PERCENT
+    default: Receivers, Damagers, And Damage Percent
   guid: 00000000C639
   return: void
   en-US: Start Damage Modification
@@ -2603,24 +2603,24 @@ _&startDoT:
     specified duration or until stopped by script. To obtain a reference to this dot,
     use the last damage over time id value.
   args:
-  - name: PLAYER
+  - name: Player
     description: One or more players who will receive the damage over time.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DAMAGER
+    default: Event Player
+  - name: Damager
     description: The player who will receive credit for the damage. A damager of null indicates no player will receive credit.
     type: Player
-    default: 'NULL'
-  - name: DURATION
+    default: 'Null'
+  - name: Duration
     description: The duration of the damage over time in seconds. To have a dot that lasts until stopped by script, provide an arbitrarily long duration such as 9999.
     type: unsigned float
-    default: NUMBER
-  - name: DAMAGE PER SECOND
+    default: Number
+  - name: Damage Per Second
     description: The damage per second for the damage over time.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B9C5
   return: void
   en-US: Start Damage Over Time
@@ -2632,28 +2632,28 @@ _&startDoT:
 _&startFacing:
   description: Starts turning one or more players to face the specified direction.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will start turning.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DIRECTION
+    default: Event Player
+  - name: Direction
     description: The unit direction in which the player or players will eventually face. This value is normalized internally.
     type: Direction
-    default: VECTOR
-  - name: TURN RATE
+    default: Vector
+  - name: Turn Rate
     description: The turn rate in degrees per second.
     type: unsigned float
-    default: NUMBER
-  - name: RELATIVE
+    default: Number
+  - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
     type: Relativity
-    default: TO WORLD
-  - name: REEVALUATION
+    default: To World
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: FacingReeval
-    default: DIRECTION AND TURN RATE
+    default: Direction And Turn Rate
   guid: 00000000BB20
   return: void
   en-US: Start Facing
@@ -2668,16 +2668,16 @@ _&startForcingHero:
     available to the player or players until the stop forcing player to be hero action
     is executed.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will be forced to be a specific hero.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HERO
+    default: Event Player
+  - name: Hero
     description: The hero that the player or players will be forced to be.
     type: Hero
-    default: HERO
+    default: Hero
   guid: 00000000ABFB
   return: void
   en-US: Start Forcing Player To Be Hero
@@ -2687,22 +2687,22 @@ _&startForcingHero:
   pt-BR: Começar a Forçar Jogador a Ser o Herói
   zh-CN: 开始强制玩家选择英雄
 _&startForcingPosition:
-  description: Starts forcing a player to be in a given position. IF reevaluation
+  description: Starts forcing a player to be in a given position. If reevaluation
     is enabled, then the position is evaluated every frame, allowing the player to
     be moved around over time.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose position will be forced. (The reevaluation option does not apply to this value.)
     type: Player
-    default: EVENT PLAYER
-  - name: POSITION
+    default: Event Player
+  - name: Position
     description: The position the player will occupy. If reevaluation is enabled, this value can be used to move the player around over time.
     type: Position
-    default: VECTOR
+    default: Vector
   - name: REEVALUATE
     description: If this value is true, then the position will be reevaluated and applied to the player every frame. If this value is false, then the posiiton is only evaluated once when the action begins.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: void
   guid: 000000010E85
   en-US: Start Forcing Player Position
@@ -2716,14 +2716,14 @@ startForcingSpawn:
     spawn room normally used by the game mode. This action only has an effect in assault,
     hybrid, and payload maps.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose spawn room will be forced.
     type: Team
-    default: TEAM
-  - name: ROOM
+    default: Team
+  - name: Room
     description: The number of the spawn room to be forced. 0 is the first spawn room, 1 the second, and 2 is the third. If the specified spawn room does not exist, players will use the normal spawn room.
     type: unsigned int
-    default: NUMBER
+    default: Number
   guid: 00000000B573
   return: void
   en-US: Start Forcing Spawn Room
@@ -2736,36 +2736,36 @@ _&startForcingThrottle:
   description: Defines minimum and maximum movement input values for one or more players,
     possibly forcing or preventing movement.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose movement will be forced or limited.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: MIN FORWARD
+    default: Event Player
+  - name: Min Forward
     description: Sets the minimum run forward amount. 0 allows the player or players to stop while 1 forces full forward movement.
     type: unsigned float
-    default: NUMBER
-  - name: MAX FORWARD
+    default: Number
+  - name: Max Forward
     description: Sets the maximum run forward amount. 0 prevents the player or players from moving forward while 1 allows full forward movement.
     type: unsigned float
-    default: NUMBER
-  - name: MIN BACKWARD
+    default: Number
+  - name: Min Backward
     description: Sets the minimum run backward amount. 0 allows the player or players to stop while 1 forces full backward movement.
     type: unsigned float
-    default: NUMBER
-  - name: MAX BACKWARD
+    default: Number
+  - name: Max Backward
     description: Sets the maximum run backward amount. 0 prevents the player or players from moving backward while 1 allows full backward movement.
     type: unsigned float
-    default: NUMBER
-  - name: MIN SIDEWAYS
+    default: Number
+  - name: Min Sideways
     description: Sets the minimum run sideways amount. 0 allows the player or players to stop while 1 forces full sideways movement.
     type: unsigned float
-    default: NUMBER
-  - name: MAX SIDEWAYS
-    description: Sets the maximum run sideways amount. 0 prevents the player or players from moving SIDEWAYS while 1 allows full sideways movement.
+    default: Number
+  - name: Max Sideways
+    description: Sets the maximum run sideways amount. 0 prevents the player or players from moving Sideways while 1 allows full sideways movement.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000BB0F
   return: void
   en-US: Start Forcing Throttle
@@ -2779,24 +2779,24 @@ _&startHoT:
     specified duration or until stopped by script. To obtain a reference to this hot,
     use the last heal over time id value.
   args:
-  - name: PLAYER
+  - name: Player
     description: One or more players who will receive the heal over time.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HEALER
+    default: Event Player
+  - name: Healer
     description: The player who will receive credit for the healing. A healer of null indicates no player will receive credit.
     type: Player
-    default: 'NULL'
-  - name: DURATION
+    default: 'Null'
+  - name: Duration
     description: The duration of the heal over time in seconds. To have a hot that lasts until stopped by script, provide an arbitrarily long duration such as 9999.
     type: unsigned float
-    default: NUMBER
-  - name: HEALING PER SECOND
+    default: Number
+  - name: Healing Per Second
     description: The healing per second for the heal over time.
     type: unsigned float
-    default: NUMBER
+    default: Number
   guid: 00000000B9C2
   return: void
   en-US: Start Heal Over Time
@@ -2811,26 +2811,26 @@ startHealingModification:
     from the last healing modification id value. This action will fail if too many
     healing modifications have been started.
   args:
-  - name: RECEIVERS
+  - name: Receivers
     description: The player or players whose incoming healing will be modified (when healed by the healers).
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: HEALERS
+    default: Event Player
+  - name: Healers
     description: The player or players whose outgoing healing will be modified (when healing the receivers).
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
-  - name: HEALING PERCENT
+    default: All Players
+  - name: Healing Percent
     description: The percentage of healing that will apply to receivers when healed by healers.
     type: unsigned float
-    default: NUMBER
-  - name: REEVALUATION
+    default: Number
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This action will keep asking for and using new values from reevaluated inputs.
     type: HealingReeval
-    default: RECEIVERS, HEALERS, AND HEALING PERCENT
+    default: Receivers, Healers, And Healing Percent
   guid: 00000000C639
   return: void
   en-US: Start Healing Modification
@@ -2843,16 +2843,16 @@ _&startForcingButton:
   description: Forces one or more players to hold a button virtually until stopped
     by the stop holding button action.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who are holding a button virtually.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The logical button that is being held virtually.
     type: ButtonLiteral
-    default: PRIMARY FIRE
+    default: Primary Fire
   guid: 00000000B9D3
   return: void
   en-US: Start Holding Button
@@ -2867,11 +2867,11 @@ __startRule__:
     The subroutine will have access to the same contextual values (such as Event Player)
     as the original rule.
   args:
-  - name: SUBROUTINE
+  - name: Subroutine
     description: Specifies which subroutine to start. If a rule with a subroutine event type specifies the same subroutine, then it will execute. Otherwise, this action is ignored.
     type: Subroutine
     default: Sub0
-  - name: IF ALREADY EXECUTING
+  - name: If ALREADY EXECUTING
     description: Determines what should happen if the rule specified by the subroutine is already executing on the same player or global entity.
     type: AsyncBehavior
     default: RESTART RULE
@@ -2888,32 +2888,32 @@ _&startThrottleInDirection:
     or players such that they begin moving in a particular direction. Any previous
     throttle in direction is cancelled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose throttle will be set or added to.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: DIRECTION
+    default: Event Player
+  - name: Direction
     description: The unit direction in which the throttle will be set or added to. This value is normalized internally.
     type: Direction
-    default: VECTOR
-  - name: MAGNITUDE
+    default: Vector
+  - name: Magnitude
     description: The amount of throttle (or change to throttle). A value of 1 denotes full throttle.
     type: unsigned float
-    default: NUMBER
-  - name: RELATIVE
+    default: Number
+  - name: Relative
     description: Specifies whether direction is relative to world coordinates or the local coordinates of the player or players.
     type: Relativity
-    default: TO WORLD
-  - name: BEHAVIOR
+    default: To World
+  - name: Behavior
     description: Specifies whether preexisting throttle is replaced or added to.
     type: Throttle
-    default: REPLACE EXISTING THROTTLE
-  - name: REEVALUATION
+    default: Replace Existing Throttle
+  - name: Reevaluation
     description: Specifies which of this action's inputs will be continuously reevaluated. This aciton will keep asking for and using new values from reevaluated inputs.
     type: ThrottleReeval
-    default: DIRECTION AND MAGNITUDE
+    default: Direction And Magnitude
   guid: 00000000CEA4
   return: void
   en-US: Start Throttle In Direction
@@ -2927,24 +2927,24 @@ _&startTransformingThrottle:
     input control) of a player or players. Cancels any existing start transforming
     throttle behavior.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose throttle will be transformed.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: X AXIS SCALAR
+    default: Event Player
+  - name: X Axis Scalar
     description: The player or players will have their throttle X axis (left to right) multiplied by this value before the throttle is rotated to its new relative direction. This value is evaluated continuously (meaning it updates every frame).
     type: unsigned float
-    default: NUMBER
-  - name: Y AXIS SCALAR
+    default: Number
+  - name: Y Axis Scalar
     description: The player or players will have their throttle Y axis (front to back) multiplied by this value before the throttle is rotated to its new relative direction. This value is evaluated continuously (meaning it updates every frame).
     type: unsigned float
-    default: NUMBER
-  - name: RELATIVE DIRECTION
+    default: Number
+  - name: Relative Direction
     description: After the axis scalars are applied, the player or players will have their throttle transformed so that it is relative to this unit direction vector. For example, to make the throttle camera relative, provide the direction that the camera is facing. This value is evaluated continuously (meaning it updates every frame) and normalized internally.
     type: Direction
-    default: VECTOR
+    default: Vector
   guid: 00000000CC26
   return: void
   en-US: Start Transforming Throttle
@@ -2957,12 +2957,12 @@ _&stopAcceleration:
   description: Stops the acceleration started by the start accelerating action for
     one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will stop accelerating.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000BB0C
   return: void
   en-US: Stop Accelerating
@@ -2999,12 +2999,12 @@ _&stopAllDoT:
   description: Stops all damage over time started by start damage over time for one
     or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose scripted damage over time will stop.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B9C3
   return: void
   en-US: Stop All Damage Over Time
@@ -3017,12 +3017,12 @@ _&stopAllHoT:
   description: Stops all heal over time started by start heal over time for one or
     more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose scripted heal over time will stop.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000B9C0
   return: void
   en-US: Stop All Heal Over Time
@@ -3034,12 +3034,12 @@ _&stopAllHoT:
 _&stopCamera:
   description: Restores the camera to the default view.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose cameras will be put back to the default view.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000C3B1
   return: void
   en-US: Stop Camera
@@ -3052,7 +3052,7 @@ __stopChasingGlobalVariable__:
   description: Stops an in-progress chase of a global variable, leaving it at its
     current value.
   args:
-  - name: VARIABLE
+  - name: Variable
     description: Specifies which global variable to stop modifying.
     type: GlobalVariable
     default: A
@@ -3068,13 +3068,13 @@ __stopChasingPlayerVariable__:
   description: Stops an in-progress chase of a player variable, leaving it at its
     current value.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable will stop changing. If multiple players are provided, each of their variables will stop changing.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: Specifies which of the player's variables to stop modifying.
     type: PlayerVariable
     default: A
@@ -3090,10 +3090,10 @@ stopDamageModification:
   description: Stops a damage modification that was started by the start damage modification
     action.
   args:
-  - name: DAMAGE MODIFICATION
+  - name: Damage Modification
     description: Specifies which damage modification instance to stop. This id may be last damage modification id or a variable into which last damage modification id was earlier stored.
     type: DamageModificationId
-    default: LAST DAMAGE MODIFICATION ID
+    default: Last Damage Modification ID
   guid: 00000000C649
   return: void
   en-US: Stop Damage Modification
@@ -3106,10 +3106,10 @@ stopDoT:
   description: Stops an instance of damage over time started by the start damage over
     time action.
   args:
-  - name: DAMAGE OVER TIME ID
+  - name: Damage Over Time ID
     description: Specifies which damage over time instance to stop. This id may be last damage over time id or a variable into which last damage over time id was earlier stored.
     type: DotId
-    default: LAST DAMAGE OVER TIME ID
+    default: Last Damage Over Time ID
   guid: 00000000B9C4
   return: void
   en-US: Stop Damage Over Time
@@ -3122,12 +3122,12 @@ _&stopFacing:
   description: Stops the turning started by the start facing action for one or more
     players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will stop turning.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000BB21
   return: void
   en-US: Stop Facing
@@ -3141,12 +3141,12 @@ _&stopForcingCurrentHero:
     not respawn the player or players, but it will restore their hero availability
     the next time they go to select a hero.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who will no longer be forced to be a specific hero.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000AC1B
   return: void
   en-US: Stop Forcing Player To Be Hero
@@ -3159,12 +3159,12 @@ _&stopForcingPosition:
   description: Cancels the behavior of `startForcingPosition()` for the specified
     player or players. Regular movement will resume from the last forced position(s).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose positions will stop being forced.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: void
   guid: 000000010E8D
   en-US: Stop Forcing Player Position
@@ -3177,10 +3177,10 @@ stopForcingSpawn:
   description: Undoes the effect of the start forcing spawn room action for the specified
     team.
   args:
-  - name: TEAM
+  - name: Team
     description: The team that will resume using their normal spawn room.
     type: Team
-    default: TEAM
+    default: Team
   guid: 00000000B574
   return: void
   en-US: Stop Forcing Spawn Room
@@ -3193,12 +3193,12 @@ _&stopForcingThrottle:
   description: Undoes the effect of the start forcing throttle action for one or more
     players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose movement input will be restored.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000BB0E
   return: void
   en-US: Stop Forcing Throttle
@@ -3211,10 +3211,10 @@ stopHoT:
   description: Stops an instance of heal over time started by the start heal over
     time action.
   args:
-  - name: HEAL OVER TIME ID
+  - name: HEAL Over Time ID
     description: Specifies which heal over time instance to stop. This id may be last heal over time id or a variable into which last heal over time id was earlier stored.
     type: HotId
-    default: PLAYER VARIABLE
+    default: Player Variable
   guid: 00000000B9C1
   return: void
   en-US: Stop Heal Over Time
@@ -3227,10 +3227,10 @@ stopHealingModification:
   description: Stops a healing modification that was started by the start healing
     modification action.
   args:
-  - name: HEALING MODIFICATION ID
+  - name: Healing Modification ID
     description: Specifies which healing modification instance to stop. This id may be last healing modification id or a variable into which last healing modification id was earlier stored.
     type: HealingModificationId
-    default: LAST HEALING MODIFICATION ID
+    default: Last Healing Modification ID
   guid: 00000000FD37
   return: void
   en-US: Stop Healing Modification
@@ -3243,16 +3243,16 @@ _&stopForcingButton:
   description: Undoes the effect of the start holding button action for one or more
     players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players who are no longer holding a button virtually.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The logical button that is no longer being held virtually.
     type: ButtonLiteral
-    default: PRIMARY FIRE
+    default: Primary Fire
   guid: 00000000B9D2
   return: void
   en-US: Stop Holding Button
@@ -3264,12 +3264,12 @@ _&stopForcingButton:
 _&stopThrottleInDirection:
   description: Cancels the behavior caused by start throttle in direction.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose default throttle control will be restored.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000CEA3
   return: void
   en-US: Stop Throttle In Direction
@@ -3282,12 +3282,12 @@ _&stopTransformingThrottle:
   description: Stops the throttle transform started by start transforming throttle
     for one or more players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose throttle will stop being transformed.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   guid: 00000000CC25
   return: void
   en-US: Stop Transforming Throttle
@@ -3300,16 +3300,16 @@ _&teleport:
   guid: 00000000B9BA
   description: Teleports one or more players to the specified position.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players to teleport.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: POSITION
+    default: Event Player
+  - name: Position
     description: The position to which the player or players will teleport. If a player is provided, the position of the player is used.
     type: Position
-    default: VECTOR
+    default: Vector
   return: void
   en-US: Teleport
   es-MX: Transportar
@@ -3333,14 +3333,14 @@ __wait__:
   description: Pauses the execution of the action list. Unless the wait is interrupted,
     the remainder of the actions will execute after the pause.
   args:
-  - name: TIME
+  - name: Time
     description: The duration of the pause.
     type: unsigned float
-    default: NUMBER
-  - name: WAIT BEHAVIOR
+    default: Number
+  - name: Wait Behavior
     description: Specifies if and how the wait can be interrupted. If the condition list is ignored, the wait will not be interrupted. Otherwise, the condition list will determine if and when the action list will abort or restart.
     type: Wait
-    default: IGNORE CONDITION
+    default: Ignore Condition
   return: void
   en-US: Wait
   es-MX: Esperar
@@ -3355,26 +3355,26 @@ __while__:
     is at the top of the loop, then the loop exits, and execution jumps to the next
     action after the end action.
   args:
-  - name: CONDITION
+  - name: Condition
     description: If this evaluates to true, execution continues with the next action. Otherwise, execution jumps to the next end action at the current level.
     type: bool
-    default: COMPARE
+    default: Compare
   guid: 00000000FB35
   return: void
   en-US: While
   es-MX: Mientras
   fr-FR: Tant que
-  ja-JP: WHILE
+  ja-JP: While
 setAmmo:
   description: Set the ammo of one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose ammo will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: CLIP
+    default: Event Player
+  - name: Clip
     description: The index of the clip whose ammo will be set. 0 Is the first clip, and 1 is the second. If the specified type does not exist, this will do nothing.
     type: Integer
     default: 0
@@ -3386,13 +3386,13 @@ setAmmo:
 setMaxAmmo:
   description: Set the max ammo of one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose max ammo will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
-  - name: CLIP
+    default: Event Player
+  - name: Clip
     description: The index of the clip whose ammo will be set. 0 Is the first clip, and 1 is the second. If the specified type does not exist, this will do nothing.
     type: Integer
     default: 0
@@ -3404,12 +3404,12 @@ setMaxAmmo:
 setWeapon:
   description: Sets the weapon of one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player or players whose weapon will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Weapon
     description: The number of the weapon to be equipped. 1 Is the first weapon, and 2 is the second. If the specified weapon does not exist, players will use the default weapon.
     type: Unsigned integer
@@ -3418,12 +3418,12 @@ setWeapon:
 setReloadEnabled:
   description: Enables or disables Reload for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose access to reload is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Enabled
     description: Specifies whether the Player or Players are able to use reload. Expects a boolean value such as True, False, or Compare.
     type: Boolean
@@ -3432,136 +3432,136 @@ setReloadEnabled:
 disableGameModeHUD:
   description: Disables the Game Mode HUD for one or more Players until reenabled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Game Mode HUD disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Game Mode HUD
 enableGameModeHUD:
   description: Undoes the effect of the Disable Game Mode HUD Action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Game Mode HUD enabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enabled Game Mode HUD
 disableGameModeInWorldUI:
   description: Disables the Game Mode In-World UI for one or more Players until reenabled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Game Mode In-World UI disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Game Mode In-World UI
 enableGameModeInWorldUI:
   description: Undoes the effect of the Disable Game Mode In-World UI Action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Game Mode In-World UI enabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Game Mode In-World UI
 disableHeroHUD:
   description: Disables the Hero HUD for one or more Players until reenabled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Hero HUD disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Hero HUD
 enableHeroHUD:
   description: Undoes the effect of the Disable Hero HUD Action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Hero HUD enabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Hero HUD
 disableKillFeed:
   description: Disables the Kill Feed for one or more Players until reenabled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Kill Feed disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Kill Feed
 enableKillFeed:
   description: Undoes the effect of the Disable Kill Feed Action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Kill Feed enabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Kill Feed
 disableMessages:
   description: Disables Messages for one or more Players until reenabled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Messages disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Messages
 enableMessages:
   description: Undoes the effect of the Disable Messages Action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Messages enabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Messages
 disableScoreboard:
   description: Disables the Scoreboard for one or more Players until reenabled.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Scoreboard disabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Scoreboard
 enableScoreboard:
   description: Undoes the effect of the Disable Scoreboard Action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players who will have their Scoreboard enabled.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Scoreboard
 setAbilityCharge:
   description: Set the Ability Charge Count for one or more Players if supported.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose ability charge count will be modified.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Button
     description: The logical button associated with the Ability to be modified.
     type: Button
-    default: PRIMARY FIRE
+    default: Primary Fire
   - name: Charge Count
     description: The Charge count that will be set.
     type: Integer
@@ -3570,16 +3570,16 @@ setAbilityCharge:
 setAbilityResource:
   description: Set the Ability Resource Percentage for one or more Players if supported.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose Ability Resource Percentage will be modified.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Button
     description: The logical button associated with the Ability to be modified.
     type: Button
-    default: PRIMARY FIRE
+    default: Primary Fire
   - name: Resource Percent
     description: The Percentage of Resource that will be set with respect to each Player's Ability Resource capacity.
     type: Unsigned Float
@@ -3588,12 +3588,12 @@ setAbilityResource:
 setJumpVerticalSpeed:
   description: Sets the jump vertical speed of one or more Players to a percentage of their raw jump vertical speed.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose jump vertical speed will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Jump Vertical Speed Percent
     description: The Percentage of Resource that will be set with respect to each Player's Ability Resource capacity.
     type: Unsigned Float
@@ -3607,7 +3607,7 @@ disableNameplates:
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Viewing Players
     description: The Viewing Player or Players for whom the viewed Player's nameplate will be disabled.
     type:
@@ -3623,7 +3623,7 @@ enableNameplates:
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Viewing Players
     description: The Viewing Player or Players for whom the viewed Player's nameplate will be enabled.
     type:
@@ -3639,7 +3639,7 @@ startForcingPlayerOutlines:
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Viewing Players
     description: The Viewing Player or Players for whom the viewed Player's outlines will be modified.
     type:
@@ -3667,7 +3667,7 @@ stopForcingPlayerOutlines:
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Viewing Players
     description: The Viewing Player or Players for whom the viewed Player's outlines will be reset.
     type:
@@ -3678,17 +3678,17 @@ stopForcingPlayerOutlines:
 startScalingPlayer:
   description: Start modifying the size of a Player or Players (including mode, movement collision, hit detection, and certain abilities). Note that large players placed into complex environments will severely impact server load, so consider also applying the Disable Movement Collision With Environment action.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose size will be modified.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Scale
     description: The multiplier applied to the size of the player or players (So 0.5 halves the size, 2.0 doubles the size, etc.).
     type: Unsigned Float
     default: 1
-  - name: REEVALUATION
+  - name: Reevaluation
     description: If this value is True, then scale will be Reevaluated and applied to the Player or Players every frame. If this value is False, then the scale is only avaluated once when the action begins.
     type: Boolean
     default: True
@@ -3696,27 +3696,27 @@ startScalingPlayer:
 stopScalingPlayer:
   description: Stops overring the size of a Player or Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose size will stop being overridden.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Stop Scaling Player
 startScalingBarriers:
   description: Start modifying the size of barriers for a Player or Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose barriers will have their size modified.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Scale
     description: The multiplier applied to the size of the barriers (So 0.5 halves the size, 2.0 doubles the size, etc.).
     type: Unsigned Float
     default: 1
-  - name: REEVALUATION
+  - name: Reevaluation
     description: If this value is True, then scale will be Reevaluated and applied to the Player or Players every frame. If this value is False, then the scale is only avaluated once when the action begins.
     type: Boolean
     default: True
@@ -3724,22 +3724,22 @@ startScalingBarriers:
 stopScalingBarriers:
   description: Stops overring the size of barriers of a Player or Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose barriers will stop having their size being overridden.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Stop Scaling Barriers
 disableMovementCollisionWithEnvironment:
   description: Causes a Player or Players to stop colliding with the environment (walls, ceilings, certain objects, etc.)
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Include Floors
     description: If True, collision with the floors is also disabled.
     type: Boolean
@@ -3748,47 +3748,47 @@ disableMovementCollisionWithEnvironment:
 enableMovementCollisionWithEnvironment:
   description: Undoes the effect of the Disable Movement Collision With Environment action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Movement Collision With Environment
 disableMovementCollisionWithPlayers:
   description: Causes a Player or Players to stop colliding with other Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Disable Movement Collision With Players
 enableMovementCollisionWithPlayers:
   description: Undoes the effect of the Disable Movement Collision With Players action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Enable Movement Collision With Players
 startModifyingHeroVoiceLines:
   description: Modifies the way hero voice lines sound for a Player or Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Pitch Scalar
     description: The amount that the pitch of the voice will be raised. (Up to 1.5) or lowered (Down to 0.5).
     type: Unsigned float
     default: 0
-  - name: REEVALUATION
+  - name: Reevaluation
     description: If True, Pitch Scalar is evaluated and updated every frame. If False, Pitch Scalar is evaluated once when the actions executes.
     type: Boolean
     default: True
@@ -3796,22 +3796,22 @@ startModifyingHeroVoiceLines:
 stopModifyingHeroVoiceLines:
   description: Undoes the effect of the Starting Modifying Hero Voice Lines action for one or more Players.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Stop Modifying Hero Voice Lines
 addHealthPoolToPlayer:
   description: Adds a temporary health pool to a Player or Players. This health pool can be referenced using the Last Created Health Pool value. Up to 16 health pools of a given health type (Health, Armor, or Shields) may exist on a player (including base pools and pools generated by abilities).
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose movement collision is affected.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Health Type
     description: Specifies the type of health (Armor or shields) contained in the Health Pool.
     type:
@@ -3826,7 +3826,7 @@ addHealthPoolToPlayer:
     description: Whether health in this pool can be healed once it is lost. If this is value is False, then the Health Pool will shrink and disappear as it is damaged.
     type: Boolean
     default: True
-  - name: REEVALUATION
+  - name: Reevaluation
     description: If True and Recoverable is also True, then Max Health will be reevaluated every frame, if False or Recoverable is False, then Max Health is only evaluated once when this action executes.
     type: Boolean
     default: True
@@ -3842,23 +3842,23 @@ removeHealthPoolFromPlayer:
 removeAllHealthPoolsFromPlayer:
   description: Removes all health pools that were added to a Player or Players via the Add Health Pool action.
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose added Health Pools will be removed.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   en-US: Remove All Health Pools From Player
 
 setPlayerHealth:
   description: Sets the health of a Player or Players without affecting stats or granting damage/healing credit. This action only has an effect on living players. (For dead players, use the Resurrect Player action instead.)
   args:
-  - name: PLAYER
+  - name: Player
     description: The Player or Players whose Health will be set.
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Amount
     description: How much health the Player or Players will have.
     type: Unsigned float
@@ -3871,7 +3871,7 @@ LogToInspector:
   - name: Text
     description: The String to be logged to the Workshop Inspector.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   en-US: Log To Inspector
 
 WaitUntil:
@@ -3895,7 +3895,7 @@ SetKnockbackDealt:
     type:
       - Player
       - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Knockback Dealt Percentage
     description: The percentage of raw knockback dealt to which the Player or Players will set their knockback dealt.
     type: Integer
@@ -3910,7 +3910,7 @@ SetKnockbackReceived:
     type:
       - Player
       - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Knockback Dealt Percentage
     description: The percentage of raw knockback received to which the Player or Players will set their knockback dealt.
     type: Integer
@@ -3925,13 +3925,13 @@ SetEnvironmentCreditPlayer:
     type:
     - Player
     - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Environment Credit Player
     description: The Player who will received credit if the target Player or Players die to the environment before landing on the ground. An Environment Credit Player of Null indicates no Player will receive credit.
     type:
     - Player
     - Array: Player
-    default: 'NULL'
+    default: 'Null'
   en-US: Set Environment Credit Player
 
 StartAssist:
@@ -3942,13 +3942,13 @@ StartAssist:
     type:
       - Player
       - Array: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: Targets
     description: The Player or Players whose eliminations will grant assist credit to the Assisters. If the Target or Targets are allied to the Assister, this will be a defensive assist. Otherwise, this will be an offensive assist.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
+    default: All Players
   - name: Reevaluation
     description: Specifies which of this Action's Inputs will be continously reevaluated. This Action will keep asking for and using new Values from reevaluated Inputs.
     type: __ChaseRateReeval__
@@ -3976,7 +3976,7 @@ CreateProgressBarHUDText:
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
+    default: All Players
   - name: Value
     description: The value of the progress bar to be displayed as a percentage from 0 to 100.
     type: Unsigned float
@@ -4032,7 +4032,7 @@ CreateProgressBarIn-WorldText:
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
+    default: All Players
   - name: Value
     description: The value of the progress bar to be displayed as a percentage from 0 to 100.
     type: Unsigned float
@@ -4048,11 +4048,11 @@ CreateProgressBarIn-WorldText:
   - name: Scale
     description: The text's scale.
     type: float
-    default: NUMBER
+    default: Number
   - name: Clipping
     description: Specifies whether the text can be seen through walls or is instead clipped.
     type: Clip
-    default: CLIP AGAINST SURFACES
+    default: Clip Against Surfaces
   - name: Progress Bar Color
     description: The color of the Progress Bar text to be created. If a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer.
     type: Color
@@ -4155,7 +4155,7 @@ MovePlayertoTeam:
     description: The team on which to move the Player. The "all" option only works in free-for-all game modes, while the "team" options only work in team-based game modes.
     type: Team
     default: All
-  - name: SLOT
+  - name: Slot
     description: The player slot which will receive the Player (-1 for first available slot).
     type: int
     default: -1
@@ -4350,12 +4350,12 @@ Create Projectile Effect:
   description: Creates an in-world projectile effect entity. This effect entity will persist until destroyed. To obtain a reference to this entity, use the Last Created Entity value. This action will fail if too many entities have been created.
   en-US: Create Projectile Effect
   args:
-  - name: VISIBLE TO
+  - name: Visible To
     description: One or more players who will be able to see the effect.
     type:
     - Player
     - Array: Player
-    default: ALL PLAYERS
+    default: All Players
   - name: Projectile Type
     description: Type of projectile to be created. New options can be added to this list by enabling the Projectiles Workshop Extension.
     type: Projectile Effect

--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -3,7 +3,7 @@ return:
   description: Stops execution of the action list.
   args:
   guid: 00000000BB09
-  return: void
+  return: Void
   en-US: Abort
   es-MX: Abortar
   fr-FR: Interrompre
@@ -18,7 +18,7 @@ __abortIf__:
     type: bool
     default: Compare
   guid: 00000000BB04
-  return: void
+  return: Void
   en-US: Abort If
   es-MX: Abortar si
   fr-FR: Interrompre si
@@ -29,7 +29,7 @@ __abortIfConditionIsFalse__:
   description: Stops execution of the action list if at least one condition in the condition list is false. If all conditions are true, execution continues with the next action.
   args: []
   guid: 00000000BB02
-  return: void
+  return: Void
   en-US: Abort If Condition Is False
   es-MX: Abortar si la condición es falsa
   fr-FR: Interrompre si la condition est fausse
@@ -40,7 +40,7 @@ __abortIfConditionIsTrue__:
   description: Stops execution of the action list if all conditions in the condition list are true. If any are false, execution continues with the next action.
   args: []
   guid: 00000000BB03
-  return: void
+  return: Void
   en-US: Abort If Condition Is True
   es-MX: Abortar si la condición es verdadera
   fr-FR: Interrompre si la condition est vraie
@@ -61,7 +61,7 @@ _&allowButton:
     type: ButtonLiteral
     default: Primary Fire
   guid: 00000000B9D0
-  return: void
+  return: Void
   en-US: Allow Button
   es-MX: Habilitar botón
   fr-FR: Autoriser un bouton
@@ -94,7 +94,7 @@ _&applyImpulse:
     type: Impulse
     default: Cancel Contrary Motion
   guid: 0000000078F6
-  return: void
+  return: Void
   en-US: Apply Impulse
   es-MX: Aplicar impulso
   fr-FR: Appliquer une impulsion
@@ -116,7 +116,7 @@ _&attachTo:
     description: The coordinates of the child relative to the parent. For example, `vect(1,2,0)` would be above and to the left of the parent's head.
     type: Position
     default: Vector
-  return: void
+  return: Void
   guid: 000000010E4F
   en-US: Attach Players
   es-MX: Anexar jugadores
@@ -138,7 +138,7 @@ bigMessage:
     type: Object
     default: String
   guid: 00000000BA88
-  return: void
+  return: Void
   en-US: Big Message
   es-MX: Mensaje grande
   fr-FR: Message en grand
@@ -148,7 +148,7 @@ bigMessage:
 break:
   description: Goes to the end of the innermost `switch` statement, or `do/while`, `while` or `for` loop.
   args:
-  return: void
+  return: Void
   guid: 0000000105B6
   en-US: Break
   fr-FR: Arrêter
@@ -163,7 +163,7 @@ __callSubroutine__:
     type: Subroutine
     default: Sub0
   guid: 00000001001E
-  return: void
+  return: Void
   en-US: Call Subroutine
   es-MX: Llamada a subrutina
   fr-FR: Sous-programme à appeler
@@ -179,7 +179,7 @@ _&cancelPrimaryAction:
     - Player
     - Array: Player
     default: Event Player
-  return: void
+  return: Void
   guid: 0000000109CB
   en-US: Cancel Primary Action
   es-MX: Cancelar acción primaria
@@ -209,7 +209,7 @@ __chaseGlobalVariableAtRate__:
     type: __ChaseRateReeval__
     default: Destination And Rate
   guid: 00000000B840
-  return: void
+  return: Void
   en-US: Chase Global Variable At Rate
   es-MX: Seguir variable global según la tasa
   fr-FR: Modifier une variable globale selon une cadence
@@ -238,7 +238,7 @@ __chaseGlobalVariableOverTime__:
     type: __ChaseTimeReeval__
     default: Destination And Duration
   guid: 00000000B842
-  return: void
+  return: Void
   en-US: Chase Global Variable Over Time
   es-MX: Seguir variable global con el tiempo
   fr-FR: Modifier une variable globale sur la durée
@@ -273,7 +273,7 @@ __chasePlayerVariableAtRate__:
     type: __ChaseRateReeval__
     default: Destination And Rate
   guid: 00000000B83F
-  return: void
+  return: Void
   en-US: Chase Player Variable At Rate
   es-MX: Seguir variable de jugador según la tasa
   fr-FR: Modifier une variable de joueur selon une cadence
@@ -308,7 +308,7 @@ __chasePlayerVariableOverTime__:
     type: __ChaseTimeReeval__
     default: Destination And Duration
   guid: 00000000B841
-  return: void
+  return: Void
   en-US: Chase Player Variable Over Time
   es-MX: Seguir variable del jugador con el tiempo
   fr-FR: Modifier une variable de joueur sur la durée
@@ -329,7 +329,7 @@ _&clearStatusEffect:
     type: Status
     default: Hacked
   guid: 00000000B595
-  return: void
+  return: Void
   en-US: Clear Status
   es-MX: Eliminar estado
   fr-FR: Effacer le statut
@@ -350,7 +350,7 @@ _&communicate:
     type: Comms
     default: Voice Line Up
   guid: 00000000B9E3
-  return: void
+  return: Void
   en-US: Communicate
   es-MX: Comunicar
   fr-FR: Communiquer
@@ -361,7 +361,7 @@ continue:
   description: Goes back to the start of the innermost loop.
   args:
   guid: 0000000105B7
-  return: void
+  return: Void
   en-US: Continue
   es-MX: Continuar
   fr-FR: Continuer
@@ -398,7 +398,7 @@ createBeam:
     type: EffectReeval
     default: Visible To, Position, And Radius
   guid: 00000000CE80
-  return: void
+  return: Void
   en-US: Create Beam Effect
   es-MX: Crear efecto de rayo
   fr-FR: Créer un effet de rayon
@@ -418,7 +418,7 @@ createDummy:
     default: Team
   - name: Slot
     description: The player slot which will receive the bot (-1 for first available slot). Up to 6 bots may be added to each team, or 12 bots to the free-for-all team, regardless of lobby settings.
-    type: int
+    type: Integer
     default: Number
   - name: Position
     description: The initial position where the bot will appear.
@@ -429,7 +429,7 @@ createDummy:
     type: Direction
     default: Vector
   guid: 00000000CA6A
-  return: void
+  return: Void
   en-US: Create Dummy Bot
   es-MX: Crear robot de entrenamiento
   fr-FR: Créer une I.A.
@@ -468,7 +468,7 @@ createEffect:
     type: EffectReeval
     default: Visible To, Position, And Radius
   guid: 00000000B8AF
-  return: void
+  return: Void
   en-US: Create Effect
   es-MX: Crear efecto
   fr-FR: Créer un effet
@@ -528,7 +528,7 @@ __hudText__:
     type: SpecVisibility
     default: Default Visibility
   guid: 00000000BAD3
-  return: void
+  return: Void
   en-US: Create HUD Text
   es-MX: Crear texto del HUD
   fr-FR: Créer du texte d’interface
@@ -567,7 +567,7 @@ createIcon:
     type: bool
     default: 'True'
   guid: 00000000ACFA
-  return: void
+  return: Void
   en-US: Create Icon
   es-MX: Crear ícono
   fr-FR: Créer une icône
@@ -615,7 +615,7 @@ createInWorldText:
     type: SpecVisibility
     default: Default Visibility
   guid: 00000000BAD0
-  return: void
+  return: Void
   en-US: Create In-World Text
   es-MX: Crear texto dentro del mundo
   fr-FR: Créer du texte en jeu
@@ -641,7 +641,7 @@ damage:
     description: The amount of damage to apply. This amount may be modified by buffs, debuffs, or armor.
     type: float
     default: Number
-  return: void
+  return: Void
   en-US: Damage
   es-MX: Infligir daño
   fr-FR: Infliger des dégâts
@@ -653,7 +653,7 @@ declareDraw:
     modes.
   args: []
   guid: 00000000B9F1
-  return: void
+  return: Void
   en-US: Declare Match Draw
   es-MX: Declarar empate de la partida
   fr-FR: Déclarer le match nul
@@ -669,7 +669,7 @@ declarePlayerVictory:
     type: Player
     default: Event Player
   guid: 00000000AD30
-  return: void
+  return: Void
   en-US: Declare Player Victory
   es-MX: Declarar victoria del jugador
   fr-FR: Déclarer la victoire d’un joueur
@@ -680,7 +680,7 @@ declareRoundDraw:
   description: Declare a draw for the current round. This only works in the elimination
     game mode.
   args: []
-  return: void
+  return: Void
   guid: 00000001098F
   en-US: Declare Round Draw
   es-MX: Declarar ronda empatada
@@ -697,7 +697,7 @@ declareRoundVictory:
     type: Team
     default: Team
   guid: 00000000BF93
-  return: void
+  return: Void
   en-US: Declare Round Victory
   es-MX: Declarar victoria de la ronda
   fr-FR: Déclarer la victoire de la manche
@@ -713,7 +713,7 @@ declareTeamVictory:
     type: Team
     default: Team
   guid: 0000000078FD
-  return: void
+  return: Void
   en-US: Declare Team Victory
   es-MX: Declarar la victoria del equipo
   fr-FR: Déclarer la victoire d’une équipe
@@ -724,7 +724,7 @@ destroyAllDummies:
   description: Removes all dummy bots from the match.
   args: []
   guid: 00000000D1D4
-  return: void
+  return: Void
   en-US: Destroy All Dummy Bots
   es-MX: Destruir todos los robots de entrenamiento
   fr-FR: Détruire toutes les I.A.
@@ -735,7 +735,7 @@ destroyAllEffects:
   description: Destroys all effect entities created by create effect.
   args: []
   guid: 00000000B8AD
-  return: void
+  return: Void
   en-US: Destroy All Effects
   es-MX: Destruir todos los efectos
   fr-FR: Détruire tous les effets
@@ -746,7 +746,7 @@ destroyAllHudTexts:
   description: Destroys all hud text that was created by the create hud text action.
   args: []
   guid: 00000000BAD1
-  return: void
+  return: Void
   en-US: Destroy All HUD Text
   es-MX: Destruir todo el texto del HUD
   fr-FR: Détruire tous les textes d’interface
@@ -757,7 +757,7 @@ destroyAllIcons:
   description: Destroys all icon entities created by create icon.
   args: []
   guid: 00000000B8AC
-  return: void
+  return: Void
   en-US: Destroy All Icons
   es-MX: Destruir todos los íconos
   fr-FR: Détruire toutes les icônes
@@ -768,7 +768,7 @@ destroyAllInWorldText:
   description: Destroys all in-world text created by create in-world text.
   args: []
   guid: 00000000B8AB
-  return: void
+  return: Void
   en-US: Destroy All In-World Text
   es-MX: Destruir todo el texto dentro del mundo
   fr-FR: Détruire tous les textes en jeu
@@ -784,10 +784,10 @@ destroyDummy:
     default: Team
   - name: Slot
     description: The slot to remove the dummy bot from.
-    type: int
+    type: Integer
     default: Number
   guid: 00000000CC21
-  return: void
+  return: Void
   en-US: Destroy Dummy Bot
   es-MX: Destruir robot de entrenamiento
   fr-FR: Détruire une I.A.
@@ -802,7 +802,7 @@ destroyEffect:
     type: EntityId
     default: Last Created Entity Entity
   guid: 00000000B8AE
-  return: void
+  return: Void
   en-US: Destroy Effect
   es-MX: Destruir efecto
   fr-FR: Détruire un effet
@@ -817,7 +817,7 @@ destroyHudText:
     type: TextId
     default: Last Text ID
   guid: 00000000BAD2
-  return: void
+  return: Void
   en-US: Destroy HUD Text
   es-MX: Destruir texto del HUD
   fr-FR: Détruire du texte d’interface
@@ -832,7 +832,7 @@ destroyIcon:
     type: EntityId
     default: Last Created Entity Entity
   guid: 00000000B4E7
-  return: void
+  return: Void
   en-US: Destroy Icon
   es-MX: Destruir ícono
   fr-FR: Détruire une icône
@@ -847,7 +847,7 @@ destroyInWorldText:
     type: TextId
     default: Last Text ID
   guid: 00000000BACF
-  return: void
+  return: Void
   en-US: Destroy In-World Text
   es-MX: Destruir texto dentro del mundo
   fr-FR: Détruire du texte en jeu
@@ -864,7 +864,7 @@ _&detach:
     - Player
     - Array: Player
     default: Event Player
-  return: void
+  return: Void
   guid: 000000010E52
   en-US: Detach Players
   es-MX: Separar jugadores
@@ -877,7 +877,7 @@ disableAnnouncer:
     or the match ends.
   args: []
   guid: 00000000C3F8
-  return: void
+  return: Void
   en-US: Disable Built-In Game Mode Announcer
   es-MX: Deshabilitar el presentador integrado del modo de juego
   fr-FR: Désactiver l’annonceur prédéfini par le mode de jeu
@@ -889,7 +889,7 @@ disableGamemodeCompletion:
     the match to be completed by scripting commands.
   args: []
   guid: 00000000AD2D
-  return: void
+  return: Void
   en-US: Disable Built-In Game Mode Completion
   es-MX: Deshabilitar la finalización integrada del modo de juego
   fr-FR: Désactiver l’accomplissement prédéfini par le mode de jeu
@@ -900,7 +900,7 @@ disableMusic:
   description: Disables all game mode music until reenabled or the match ends.
   args: []
   guid: 00000000C3F4
-  return: void
+  return: Void
   en-US: Disable Built-In Game Mode Music
   es-MX: Deshabilitar la música integrada del modo de juego
   fr-FR: Désactiver la musique prédéfinie par le mode de jeu
@@ -918,7 +918,7 @@ _&disableRespawn:
     - Array: Player
     default: Event Player
   guid: 00000000B87A
-  return: void
+  return: Void
   en-US: Disable Built-In Game Mode Respawning
   es-MX: Deshabilitar la reaparición integrada del modo de juego
   fr-FR: Désactiver la réapparition prédéfinie par le mode de jeu
@@ -930,7 +930,7 @@ disableScoring:
     only allowing scores to be changed by scripting commands.
   args: []
   guid: 00000000ABFA
-  return: void
+  return: Void
   en-US: Disable Built-In Game Mode Scoring
   es-MX: Deshabilitar el sistema de puntuación integrado del modo de juego
   fr-FR: Désactiver le calcul des points prédéfini par le mode de jeu
@@ -948,7 +948,7 @@ _&disableDeathSpectateAllPlayers:
     - Array: Player
     default: Event Player
   guid: 00000000B9B5
-  return: void
+  return: Void
   en-US: Disable Death Spectate All Players
   es-MX: Deshabilitar la observación de todos los jugadores como espectador muerto
   fr-FR: Empêcher d’observer n’importe qui après la mort
@@ -966,7 +966,7 @@ _&disableDeathSpectateTargetHud:
     - Array: Player
     default: Event Player
   guid: 00000000B9B3
-  return: void
+  return: Void
   en-US: Disable Death Spectate Target HUD
   es-MX: Deshabilitar la observación del HUD objetivo como espectador muerto
   fr-FR: Empêcher de voir l’interface de la cible après la mort
@@ -979,7 +979,7 @@ disableInspector:
     arrays.
   args: []
   guid: 00000000FB2F
-  return: void
+  return: Void
   en-US: Disable Inspector Recording
   es-MX: Desactivar registro de Inspector
   fr-FR: Désactiver l’enregistrement du contrôleur
@@ -1001,7 +1001,7 @@ _&disallowButton:
     type: ButtonLiteral
     default: Primary Fire
   guid: 00000000B9CF
-  return: void
+  return: Void
   en-US: Disallow Button
   es-MX: Deshabilitar botón
   fr-FR: Interdire le bouton
@@ -1013,7 +1013,7 @@ __else__:
     if the previous If or Else If action's condition was false.
   args: []
   guid: 00000000FB34
-  return: void
+  return: Void
   en-US: Else
   es-MX: Si no
   fr-FR: Sinon
@@ -1028,7 +1028,7 @@ __elif__:
     type: bool
     default: Compare
   guid: 00000000FB33
-  return: void
+  return: Void
   en-US: Else If
   es-MX: Si no si
   fr-FR: Sinon Si
@@ -1037,7 +1037,7 @@ enableAnnouncer:
   description: Undoes the effect of the disable built-in game mode announcer action.
   args: []
   guid: 00000000C3FA
-  return: void
+  return: Void
   en-US: Enable Built-In Game Mode Announcer
   es-MX: Habilitar presentador integrado del modo de juego
   fr-FR: Activer l’annonceur prédéfini par le mode de jeu
@@ -1048,7 +1048,7 @@ enableGamemodeCompletion:
   description: Undoes the effect of the disable built-in game mode completion action.
   args: []
   guid: 00000000AD2F
-  return: void
+  return: Void
   en-US: Enable Built-In Game Mode Completion
   es-MX: Habilitar la finalización integrada del modo de juego
   fr-FR: Activer l’accomplissement prédéfini par le mode de jeu
@@ -1059,7 +1059,7 @@ enableMusic:
   description: Undoes the effect of the disable built-in game mode music action.
   args: []
   guid: 00000000C3F6
-  return: void
+  return: Void
   en-US: Enable Built-In Game Mode Music
   es-MX: Habilitar la música integrada del modo de juego
   fr-FR: Activer la musique prédéfinie par le mode de jeu
@@ -1077,7 +1077,7 @@ _&enableRespawn:
     - Array: Player
     default: Event Player
   guid: 00000000B878
-  return: void
+  return: Void
   en-US: Enable Built-In Game Mode Respawning
   es-MX: Habilitar la reaparición integrada del modo de juego
   fr-FR: Activer la réapparition prédéfinie par le mode de jeu
@@ -1088,7 +1088,7 @@ enableScoring:
   description: Undoes the effect of the disable built-in game mode scoring action.
   args: []
   guid: 00000000ABF8
-  return: void
+  return: Void
   en-US: Enable Built-In Game Mode Scoring
   es-MX: Habilitar el sistema de puntuación integrado del modo de juego
   fr-FR: Activer le calcul des points prédéfini par le mode de jeu
@@ -1106,7 +1106,7 @@ _&enableDeathSpectateAllPlayers:
     - Array: Player
     default: Event Player
   guid: 00000000B9AE
-  return: void
+  return: Void
   en-US: Enable Death Spectate All Players
   es-MX: Habilitar la observación de todos los jugadores como espectador muerto
   fr-FR: Permettre d’observer n’importe qui après la mort
@@ -1124,7 +1124,7 @@ _&enableDeathSpectateTargetHud:
     - Array: Player
     default: Event Player
   guid: 00000000B9B4
-  return: void
+  return: Void
   en-US: Enable Death Spectate Target HUD
   es-MX: Habilitar la observación del HUD objetivo como espectador muerto
   fr-FR: Permettre de voir l’interface de la cible après la mort
@@ -1137,7 +1137,7 @@ enableInspector:
     easier to debug problematic areas in your logic.
   args: []
   guid: 00000000FB2E
-  return: void
+  return: Void
   en-US: Enable Inspector Recording
   es-MX: Activar registro de Inspector
   fr-FR: Activer l’enregistrement du contrôleur
@@ -1149,7 +1149,7 @@ __end__:
     while, or for action.
   args: []
   guid: 00000000FB37
-  return: void
+  return: Void
   en-US: End
   es-MX: Fin
   fr-FR: Fin
@@ -1179,7 +1179,7 @@ __forGlobalVariable__:
     type: float
     default: Number (1)
   guid: 00000000FEE2
-  return: void
+  return: Void
   en-US: For Global Variable
   es-MX: Para variable global
   fr-FR: Pour variable globale
@@ -1214,7 +1214,7 @@ __forPlayerVariable__:
     type: float
     default: Number (1)
   guid: 00000000FEE1
-  return: void
+  return: Void
   en-US: For Player Variable
   es-MX: Para variable de jugador
   fr-FR: Pour variable de joueur
@@ -1226,7 +1226,7 @@ goToAssembleHeroes:
     works if the game is in progress.
   args: []
   guid: 00000000C5B5
-  return: void
+  return: Void
   en-US: Go To Assemble Heroes
   es-MX: Ir a Forma tu equipo
   fr-FR: Aller à Choisissez vos héros
@@ -1252,7 +1252,7 @@ heal:
     description: The amount of healing to apply. This amount may be modified by buff or debuffs. Healing is capped by each player's max health.
     type: float
     default: Number
-  return: void
+  return: Void
   en-US: Heal
   es-MX: Sanar
   fr-FR: Soigner
@@ -1268,7 +1268,7 @@ __if__:
     type: bool
     default: Compare
   guid: 00000000FB32
-  return: void
+  return: Void
   en-US: If
   es-MX: Si
   fr-FR: Si
@@ -1287,7 +1287,7 @@ kill:
     description: The player who will receive credit for the kill. A killer of null indicates no player will receive credit.
     type: Player
     default: 'Null'
-  return: void
+  return: Void
   en-US: Kill
   es-MX: Matar
   fr-FR: Tuer
@@ -1300,7 +1300,7 @@ __loop__:
     loop, a wait action must execute between the start of the action list and this
     action.
   args: []
-  return: void
+  return: Void
   en-US: Loop
   es-MX: Bucle
   fr-FR: Boucle
@@ -1318,7 +1318,7 @@ __loopIf__:
     type: bool
     default: Compare
   guid: 00000000BB06
-  return: void
+  return: Void
   en-US: Loop If
   es-MX: Repetir si
   fr-FR: Boucle si
@@ -1332,7 +1332,7 @@ __loopIfConditionIsFalse__:
     between the start of the action list and this action.
   args: []
   guid: 00000000BB05
-  return: void
+  return: Void
   en-US: Loop If Condition Is False
   es-MX: Repetir si la condición es falsa
   fr-FR: Boucle si la condition est fausse
@@ -1346,7 +1346,7 @@ __loopIfConditionIsTrue__:
     action list and this action.
   args: []
   guid: 000000007874
-  return: void
+  return: Void
   en-US: Loop If Condition Is True
   es-MX: Repetir si la condición es verdadera
   fr-FR: Boucle si la condition est vraie
@@ -1372,7 +1372,7 @@ __modifyGlobalVariable__:
     - Array
     default: Number
   guid: 00000000786E
-  return: void
+  return: Void
   en-US: Modify Global Variable
   es-MX: Modificar variable global
   fr-FR: Modifier une variable globale
@@ -1389,7 +1389,7 @@ __modifyGlobalVariableAtIndex__:
     default: A
   - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
-    type: unsigned int
+    type: Integer
     default: Number
   - name: Operation
     description: The way in which the variable's value will be changed. Options include standard arithmetic operations as well as array operations for appending and removing values.
@@ -1402,7 +1402,7 @@ __modifyGlobalVariableAtIndex__:
     - Array
     default: Number
   guid: 00000000C7E1
-  return: void
+  return: Void
   en-US: Modify Global Variable At Index
   es-MX: Modificar variable global según el índice
   fr-FR: Modifier une variable globale à l’index
@@ -1421,10 +1421,10 @@ _&addToScore:
     default: Event Player
   - name: Score
     description: The amount the score will increase or decrease. If positive, the score will increase. If negative, the score will decrease.
-    type: int
+    type: Integer
     default: Number
   guid: 000000007873
-  return: void
+  return: Void
   en-US: Modify Player Score
   es-MX: Modificar puntuación del jugador
   fr-FR: Modifier le score d’un joueur
@@ -1456,7 +1456,7 @@ __modifyPlayerVariable__:
     - Array
     default: Number
   guid: 00000000786F
-  return: void
+  return: Void
   en-US: Modify Player Variable
   es-MX: Modificar variable de jugador
   fr-FR: Modifier une variable de joueur
@@ -1479,7 +1479,7 @@ __modifyPlayerVariableAtIndex__:
     default: A
   - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
-    type: unsigned int
+    type: Integer
     default: Number
   - name: Operation
     description: The way in which the variable's value will be changed. Options include standard arithmetic operations as well as array operations for appending and removing values.
@@ -1492,7 +1492,7 @@ __modifyPlayerVariableAtIndex__:
     - Array
     default: Number
   guid: 00000000C7DF
-  return: void
+  return: Void
   en-US: Modify Player Variable At Index
   es-MX: Modificar variable de jugador según el índice
   fr-FR: Modifier une variable de joueur à l’index
@@ -1509,10 +1509,10 @@ addToTeamScore:
     default: Team
   - name: Score
     description: The amount the score will increase or decrease. If positive, the score will increase. If negative, the score will decrease.
-    type: int
+    type: Integer
     default: Number
   guid: 00000000BB24
-  return: void
+  return: Void
   en-US: Modify Team Score
   es-MX: Modificar puntuación del equipo
   fr-FR: Modifier le score de l’équipe
@@ -1524,7 +1524,7 @@ pauseMatchTime:
     criteria are unaffected by the pause.
   args: []
   guid: 00000000B9EF
-  return: void
+  return: Void
   en-US: Pause Match Time
   es-MX: Pausar tiempo de la partida
   fr-FR: Mettre en pause le temps de jeu
@@ -1558,7 +1558,7 @@ playEffect:
     type: unsigned float
     default: Number (1)
   guid: 00000000BB27
-  return: void
+  return: Void
   en-US: Play Effect
   es-MX: Reproducir efecto
   fr-FR: Jouer un effet
@@ -1583,7 +1583,7 @@ _&preloadHero:
     - Array: Hero
     default: Hero
   guid: 00000000B9B1
-  return: void
+  return: Void
   en-US: Preload Hero
   es-MX: Precargar héroe
   fr-FR: Précharger un héros
@@ -1605,7 +1605,7 @@ _&forceButtonPress:
     type: ButtonLiteral
     default: Primary Fire
   guid: 0000000078FB
-  return: void
+  return: Void
   en-US: Press Button
   es-MX: Presionar botón
   fr-FR: Appuyer sur un bouton
@@ -1625,7 +1625,7 @@ _&resetHeroAvailability:
     - Array: Player
     default: Event Player
   guid: 00000000BA5A
-  return: void
+  return: Void
   en-US: Reset Player Hero Availability
   es-MX: Restablecer disponibilidad de héroes de los jugadores
   fr-FR: Réinitialiser la disponibilité du héros pour un joueur
@@ -1643,7 +1643,7 @@ _&respawn:
     - Array: Player
     default: Event Player
   guid: 0000000078FC
-  return: void
+  return: Void
   en-US: Respawn
   es-MX: Reaparecer
   fr-FR: Réapparaître
@@ -1661,7 +1661,7 @@ _&resurrect:
     - Player
     - Array: Player
     default: Event Player
-  return: void
+  return: Void
   en-US: Resurrect
   es-MX: Resucitar
   fr-FR: Ressusciter
@@ -1682,7 +1682,7 @@ _&setAbility1Enabled:
     type: bool
     default: 'True'
   guid: 00000000B9B8
-  return: void
+  return: Void
   en-US: Set Ability 1 Enabled
   es-MX: Establecer habilidad 1 habilitada
   fr-FR: Définir l’activation de la capacité 1
@@ -1703,7 +1703,7 @@ _&setAbility2Enabled:
     type: bool
     default: 'True'
   guid: 00000000B9B7
-  return: void
+  return: Void
   en-US: Set Ability 2 Enabled
   es-MX: Establecer habilidad 2 habilitada
   fr-FR: Définir l’activation de la capacité 2
@@ -1727,7 +1727,7 @@ _&setAbilityCooldown:
     description: The cooldown time that will be set in seconds. Max of 1000.
     type: unsigned float
     default: Number
-  return: void
+  return: Void
   guid: 0000000109CA
   en-US: Set Ability Cooldown
   es-MX: Establecer Reutilización de habilidad
@@ -1750,7 +1750,7 @@ _&setAimSpeed:
     type: unsigned float
     default: Number
   guid: 00000000C364
-  return: void
+  return: Void
   en-US: Set Aim Speed
   es-MX: Establecer velocidad al apuntar
   fr-FR: Définir la vitesse de visée
@@ -1770,7 +1770,7 @@ _&setCrouchEnabled:
     description: Specifies whether the player or players are able to use crouch. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  return: void
+  return: Void
   guid: 0000000105A3
   en-US: Set Crouch Enabled
   es-MX: Establecer acción de agacharse activado
@@ -1793,7 +1793,7 @@ _&setDamageDealt:
     type: unsigned float
     default: Number
   guid: 00000000B995
-  return: void
+  return: Void
   en-US: Set Damage Dealt
   es-MX: Establecer daño infligido
   fr-FR: Définir les dégâts infligés
@@ -1815,7 +1815,7 @@ _&setDamageReceived:
     type: unsigned float
     default: Number
   guid: 00000000B997
-  return: void
+  return: Void
   en-US: Set Damage Received
   es-MX: Establecer daño recibido
   fr-FR: Définir les dégâts subis
@@ -1840,7 +1840,7 @@ _&setFacing:
     type: Relativity
     default: To World
   guid: 00000000BB29
-  return: void
+  return: Void
   en-US: Set Facing
   es-MX: Establecer orientación
   fr-FR: Définir la direction du regard
@@ -1862,7 +1862,7 @@ __setGlobalVariable__:
     - Array
     default: Number
   guid: 0000000077DE
-  return: void
+  return: Void
   en-US: Set Global Variable
   es-MX: Establecer variable global
   fr-FR: Définir une variable globale
@@ -1880,7 +1880,7 @@ __setGlobalVariableAtIndex__:
     default: A
   - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
-    type: unsigned int
+    type: Integer
     default: Number
   - name: Value
     description: The value that will be stored into the array.
@@ -1889,7 +1889,7 @@ __setGlobalVariableAtIndex__:
     - Array
     default: Number
   guid: 00000000BBAA
-  return: void
+  return: Void
   en-US: Set Global Variable At Index
   es-MX: Establecer variable global según el índice
   fr-FR: Définir une variable globale à l’index
@@ -1911,7 +1911,7 @@ _&setGravity:
     type: unsigned float
     default: Number
   guid: 00000000B999
-  return: void
+  return: Void
   en-US: Set Gravity
   es-MX: Establecer gravedad
   fr-FR: Définir la gravité
@@ -1933,7 +1933,7 @@ _&setHealingDealt:
     type: unsigned float
     default: Number
   guid: 00000000B991
-  return: void
+  return: Void
   en-US: Set Healing Dealt
   es-MX: Establecer sanación realizada
   fr-FR: Définir les soins prodigués
@@ -1955,7 +1955,7 @@ _&setHealingReceived:
     type: unsigned float
     default: Number
   guid: 00000000B993
-  return: void
+  return: Void
   en-US: Set Healing Received
   es-MX: Establecer sanación recibida
   fr-FR: Définir les soins reçus
@@ -1977,7 +1977,7 @@ _&setInvisibility:
     type: Invis
     default: ALL
   guid: 00000000B9ED
-  return: void
+  return: Void
   en-US: Set Invisible
   es-MX: Establecer invisibilidad
   fr-FR: Définir l’invisibilité
@@ -1997,7 +1997,7 @@ _&setJumpEnabled:
     description: Specifies whether the player or players are able to use jump. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  return: void
+  return: Void
   guid: 0000000105A5
   en-US: Set Jump Enabled
   es-MX: Establecer salto activado
@@ -2012,10 +2012,10 @@ setMatchTime:
   args:
   - name: Time
     description: The match time in seconds.
-    type: unsigned int
+    type: Integer
     default: Number
   guid: 00000000AD31
-  return: void
+  return: Void
   en-US: Set Match Time
   es-MX: Establecer tiempo de la partida
   fr-FR: Définir le temps de jeu
@@ -2038,7 +2038,7 @@ _&setMaxHealth:
     type: unsigned float
     default: Number
   guid: 0000000078FA
-  return: void
+  return: Void
   en-US: Set Max Health
   es-MX: Establecer salud máxima
   fr-FR: Définir les points de vie maximum
@@ -2058,7 +2058,7 @@ _&setMeleeEnabled:
     description: Specifies whether the player or players are able to use melee. Expects a boolean value such as true, false, or compare.
     type: bool
     default: 'True'
-  return: void
+  return: Void
   guid: 000000010596
   en-US: Set Melee Enabled
   es-MX: Establecer ataques melé activado
@@ -2081,7 +2081,7 @@ _&setMoveSpeed:
     type: unsigned float
     default: Number
   guid: 00000000B998
-  return: void
+  return: Void
   en-US: Set Move Speed
   es-MX: Establecer velocidad de movimiento
   fr-FR: Définir la vitesse de déplacement
@@ -2107,7 +2107,7 @@ setObjectiveDescription:
     type: HudReeval
     default: Visible To And String
   guid: 00000000BA85
-  return: void
+  return: Void
   en-US: Set Objective Description
   es-MX: Establecer descripción de objetivo
   fr-FR: Définir la description d’objectif
@@ -2132,7 +2132,7 @@ _&setAllowedHeroes:
     - Array: Hero
     default: Hero
   guid: 00000000BA5B
-  return: void
+  return: Void
   en-US: Set Player Allowed Heroes
   es-MX: Establecer héroes permitidos para los jugadores
   fr-FR: Définir les héros autorisés pour un joueur
@@ -2151,10 +2151,10 @@ _&setScore:
     default: Event Player
   - name: Score
     description: The score that will be set.
-    type: int
+    type: Integer
     default: Number
   guid: 00000000BB22
-  return: void
+  return: Void
   en-US: Set Player Score
   es-MX: Establecer puntuación del jugador
   fr-FR: Définir le score d’un joueur
@@ -2182,7 +2182,7 @@ __setPlayerVariable__:
     - Array
     default: Number
   guid: 0000000077DF
-  return: void
+  return: Void
   en-US: Set Player Variable
   es-MX: Establecer variable de jugador
   fr-FR: Définir une variable de joueur
@@ -2206,7 +2206,7 @@ __setPlayerVariableAtIndex__:
     default: A
   - name: Index
     description: The index of the array to modify. If the index is beyond the end of the array, the array is extended with new elements given a value of zero.
-    type: unsigned int
+    type: Integer
     default: Number
   - name: Value
     description: The value that will be stored into the array.
@@ -2215,7 +2215,7 @@ __setPlayerVariableAtIndex__:
     - Array
     default: Number
   guid: 00000000BBA9
-  return: void
+  return: Void
   en-US: Set Player Variable At Index
   es-MX: Establecer variable de jugador según el índice
   fr-FR: Définir une variable de joueur à l’index
@@ -2236,7 +2236,7 @@ _&setPrimaryFireEnabled:
     type: bool
     default: 'True'
   guid: 00000000C6C5
-  return: void
+  return: Void
   en-US: Set Primary Fire Enabled
   es-MX: Establecer disparo principal habilitado
   fr-FR: Définir l’activation du tir principal
@@ -2258,7 +2258,7 @@ _&setProjectileGravity:
     type: unsigned float
     default: Number
   guid: 00000000B99B
-  return: void
+  return: Void
   en-US: Set Projectile Gravity
   es-MX: Establecer gravedad del proyectil
   fr-FR: Définir la gravité des projectiles
@@ -2280,7 +2280,7 @@ _&setProjectileSpeed:
     type: unsigned float
     default: Number
   guid: 00000000B99D
-  return: void
+  return: Void
   en-US: Set Projectile Speed
   es-MX: Establecer velocidad del proyectil
   fr-FR: Définir la vitesse des projectiles
@@ -2300,10 +2300,10 @@ _&setRespawnTime:
     default: Event Player
   - name: Time
     description: The duration between death and respawn in seconds.
-    type: unsigned int
+    type: Integer
     default: Number
   guid: 00000000B9CD
-  return: void
+  return: Void
   en-US: Set Respawn Max Time
   es-MX: Establecer tiempo máximo de reaparición
   fr-FR: Définir la durée maximum avant réapparition
@@ -2324,7 +2324,7 @@ _&setSecondaryFireEnabled:
     type: bool
     default: 'True'
   guid: 00000000C6C4
-  return: void
+  return: Void
   en-US: Set Secondary Fire Enabled
   es-MX: Establecer disparo secundario habilitado
   fr-FR: Définir l’activation du tir secondaire
@@ -2340,7 +2340,7 @@ setSlowMotion:
     type: unsigned float
     default: Number
   guid: 00000000B9F2
-  return: void
+  return: Void
   en-US: Set Slow Motion
   es-MX: Establecer cámara lenta
   fr-FR: Définir un ralenti
@@ -2370,7 +2370,7 @@ _&setStatusEffect:
     type: unsigned float
     default: Number
   guid: 00000000B588
-  return: void
+  return: Void
   en-US: Set Status
   es-MX: Establecer estado
   fr-FR: Définir un statut
@@ -2387,10 +2387,10 @@ setTeamScore:
     default: Team
   - name: Score
     description: The score that will be set.
-    type: int
+    type: Integer
     default: Number
   guid: 00000000BB25
-  return: void
+  return: Void
   en-US: Set Team Score
   es-MX: Establecer puntuación del equipo
   fr-FR: Définir le score d’une équipe
@@ -2411,7 +2411,7 @@ _&setUltEnabled:
     type: bool
     default: 'True'
   guid: 00000000B9B6
-  return: void
+  return: Void
   en-US: Set Ultimate Ability Enabled
   es-MX: Establecer habilidad máxima habilitada
   fr-FR: Définir l’activation de la capacité ultime
@@ -2433,7 +2433,7 @@ _&setUltCharge:
     type: unsigned float
     default: Number
   guid: 00000000BB1C
-  return: void
+  return: Void
   en-US: Set Ultimate Charge
   es-MX: Establecer carga de habilidad máxima
   fr-FR: Définir la charge de la capacité ultime
@@ -2446,9 +2446,9 @@ __skip__:
   args:
   - name: Number OF Actions
     description: The number of actions to skip, not including this action.
-    type: unsigned int
+    type: Integer
     default: Number
-  return: void
+  return: Void
   en-US: Skip
   es-MX: Omitir
   fr-FR: Passer
@@ -2466,10 +2466,10 @@ __skipIf__:
     default: Compare
   - name: Number OF Actions
     description: The number of actions to skip, not including this action.
-    type: unsigned int
+    type: Integer
     default: Number
   guid: 00000000BB00
-  return: void
+  return: Void
   en-US: Skip If
   es-MX: Omitir si
   fr-FR: Passer si
@@ -2491,7 +2491,7 @@ smallMessage:
     type: Object
     default: String
   guid: 00000000BA87
-  return: void
+  return: Void
   en-US: Small Message
   es-MX: Mensaje pequeño
   fr-FR: Message en petit
@@ -2528,7 +2528,7 @@ _&startAcceleration:
     type: AccelReeval
     default: Direction, Rate, And Max Speed
   guid: 00000000BB0D
-  return: void
+  return: Void
   en-US: Start Accelerating
   es-MX: Comenzar la aceleración
   fr-FR: Accélérer
@@ -2557,7 +2557,7 @@ _&setCamera:
     type: unsigned float
     default: Number
   guid: 00000000C393
-  return: void
+  return: Void
   en-US: Start Camera
   es-MX: Comenzar cámara
   fr-FR: Lancer la caméra
@@ -2591,7 +2591,7 @@ startDamageModification:
     type: DamageReeval
     default: Receivers, Damagers, And Damage Percent
   guid: 00000000C639
-  return: void
+  return: Void
   en-US: Start Damage Modification
   es-MX: Comenzar modificación de daño
   fr-FR: Lancer la modification des dégâts
@@ -2622,7 +2622,7 @@ _&startDoT:
     type: unsigned float
     default: Number
   guid: 00000000B9C5
-  return: void
+  return: Void
   en-US: Start Damage Over Time
   es-MX: Comenzar daño con el tiempo
   fr-FR: Infliger des dégâts sur la durée
@@ -2655,7 +2655,7 @@ _&startFacing:
     type: FacingReeval
     default: Direction And Turn Rate
   guid: 00000000BB20
-  return: void
+  return: Void
   en-US: Start Facing
   es-MX: Comenzar orientación
   fr-FR: Regarder vers
@@ -2679,7 +2679,7 @@ _&startForcingHero:
     type: Hero
     default: Hero
   guid: 00000000ABFB
-  return: void
+  return: Void
   en-US: Start Forcing Player To Be Hero
   es-MX: Comenzar a forzar a un jugador a usar un héroe
   fr-FR: Forcer un héros
@@ -2703,7 +2703,7 @@ _&startForcingPosition:
     description: If this value is true, then the position will be reevaluated and applied to the player every frame. If this value is false, then the posiiton is only evaluated once when the action begins.
     type: bool
     default: 'True'
-  return: void
+  return: Void
   guid: 000000010E85
   en-US: Start Forcing Player Position
   es-MX: Comenzar a forzar la posición del jugador
@@ -2722,10 +2722,10 @@ startForcingSpawn:
     default: Team
   - name: Room
     description: The number of the spawn room to be forced. 0 is the first spawn room, 1 the second, and 2 is the third. If the specified spawn room does not exist, players will use the normal spawn room.
-    type: unsigned int
+    type: Integer
     default: Number
   guid: 00000000B573
-  return: void
+  return: Void
   en-US: Start Forcing Spawn Room
   es-MX: Comenzar a forzar cuarto de reaparición
   fr-FR: Forcer une salle d’apparition
@@ -2767,7 +2767,7 @@ _&startForcingThrottle:
     type: unsigned float
     default: Number
   guid: 00000000BB0F
-  return: void
+  return: Void
   en-US: Start Forcing Throttle
   es-MX: Comenzar a forzar la aceleración
   fr-FR: Forcer l’accélération
@@ -2798,7 +2798,7 @@ _&startHoT:
     type: unsigned float
     default: Number
   guid: 00000000B9C2
-  return: void
+  return: Void
   en-US: Start Heal Over Time
   es-MX: Comenzar sanación con el tiempo
   fr-FR: Prodiguer des soins sur la durée
@@ -2832,7 +2832,7 @@ startHealingModification:
     type: HealingReeval
     default: Receivers, Healers, And Healing Percent
   guid: 00000000C639
-  return: void
+  return: Void
   en-US: Start Healing Modification
   es-MX: Comenzar modificación de sanación
   fr-FR: Lancer la modification des soins
@@ -2854,7 +2854,7 @@ _&startForcingButton:
     type: ButtonLiteral
     default: Primary Fire
   guid: 00000000B9D3
-  return: void
+  return: Void
   en-US: Start Holding Button
   es-MX: Comenzar a mantener el botón presionado
   fr-FR: Maintenir un bouton enfoncé
@@ -2876,7 +2876,7 @@ __startRule__:
     type: AsyncBehavior
     default: RESTART RULE
   guid: '000000010022'
-  return: void
+  return: Void
   en-US: Start Rule
   es-MX: Comenzar regla
   fr-FR: Lancer la règle
@@ -2915,7 +2915,7 @@ _&startThrottleInDirection:
     type: ThrottleReeval
     default: Direction And Magnitude
   guid: 00000000CEA4
-  return: void
+  return: Void
   en-US: Start Throttle In Direction
   es-MX: Comenzar aceleración en dirección
   fr-FR: Commencer l’accélération directionnelle
@@ -2946,7 +2946,7 @@ _&startTransformingThrottle:
     type: Direction
     default: Vector
   guid: 00000000CC26
-  return: void
+  return: Void
   en-US: Start Transforming Throttle
   es-MX: Comenzar a transformar la aceleración
   fr-FR: Début de modification de l’accélération
@@ -2964,7 +2964,7 @@ _&stopAcceleration:
     - Array: Player
     default: Event Player
   guid: 00000000BB0C
-  return: void
+  return: Void
   en-US: Stop Accelerating
   es-MX: Detener la aceleración
   fr-FR: Arrêter l’accélération
@@ -2976,7 +2976,7 @@ stopAllDamageModifications:
     modification action.
   args: []
   guid: 00000000C647
-  return: void
+  return: Void
   en-US: Stop All Damage Modifications
   es-MX: Detener todas las modificaciones de daño
   fr-FR: Arrêter toutes les modifications de dégâts
@@ -2988,7 +2988,7 @@ stopAllHealingModifications:
     modification action.
   args: []
   guid: 00000000FD3B
-  return: void
+  return: Void
   en-US: Stop All Healing Modifications
   es-MX: Detener todas las modificaciones de sanación
   fr-FR: Terminer toutes les modifications de soins
@@ -3006,7 +3006,7 @@ _&stopAllDoT:
     - Array: Player
     default: Event Player
   guid: 00000000B9C3
-  return: void
+  return: Void
   en-US: Stop All Damage Over Time
   es-MX: Detener todo el daño con el tiempo
   fr-FR: Arrêter tous les dégâts sur la durée
@@ -3024,7 +3024,7 @@ _&stopAllHoT:
     - Array: Player
     default: Event Player
   guid: 00000000B9C0
-  return: void
+  return: Void
   en-US: Stop All Heal Over Time
   es-MX: Detener toda la sanación con el tiempo
   fr-FR: Arrêter tous les soins sur la durée
@@ -3041,7 +3041,7 @@ _&stopCamera:
     - Array: Player
     default: Event Player
   guid: 00000000C3B1
-  return: void
+  return: Void
   en-US: Stop Camera
   es-MX: Detener cámara
   fr-FR: Arrêter la caméra
@@ -3057,7 +3057,7 @@ __stopChasingGlobalVariable__:
     type: GlobalVariable
     default: A
   guid: 00000000B83E
-  return: void
+  return: Void
   en-US: Stop Chasing Global Variable
   es-MX: Detener seguimiento de variable global
   fr-FR: Arrêter de modifier une variable globale
@@ -3079,7 +3079,7 @@ __stopChasingPlayerVariable__:
     type: PlayerVariable
     default: A
   guid: 00000000B83D
-  return: void
+  return: Void
   en-US: Stop Chasing Player Variable
   es-MX: Detener seguimiento de variable de jugador
   fr-FR: Arrêter de modifier une variable de joueur
@@ -3095,7 +3095,7 @@ stopDamageModification:
     type: DamageModificationId
     default: Last Damage Modification ID
   guid: 00000000C649
-  return: void
+  return: Void
   en-US: Stop Damage Modification
   es-MX: Detener modificación de daño
   fr-FR: Arrêter la modification des dégâts
@@ -3111,7 +3111,7 @@ stopDoT:
     type: DotId
     default: Last Damage Over Time ID
   guid: 00000000B9C4
-  return: void
+  return: Void
   en-US: Stop Damage Over Time
   es-MX: Detener daño con el tiempo
   fr-FR: Arrêter des dégâts sur la durée
@@ -3129,7 +3129,7 @@ _&stopFacing:
     - Array: Player
     default: Event Player
   guid: 00000000BB21
-  return: void
+  return: Void
   en-US: Stop Facing
   es-MX: Detener orientación
   fr-FR: Arrêter de regarder vers
@@ -3148,7 +3148,7 @@ _&stopForcingCurrentHero:
     - Array: Player
     default: Event Player
   guid: 00000000AC1B
-  return: void
+  return: Void
   en-US: Stop Forcing Player To Be Hero
   es-MX: Dejar de forzar a un jugador a usar un héroe
   fr-FR: Arrêter de forcer un héros
@@ -3165,7 +3165,7 @@ _&stopForcingPosition:
     - Player
     - Array: Player
     default: Event Player
-  return: void
+  return: Void
   guid: 000000010E8D
   en-US: Stop Forcing Player Position
   es-MX: Dejar de forzar la posición del jugador
@@ -3182,7 +3182,7 @@ stopForcingSpawn:
     type: Team
     default: Team
   guid: 00000000B574
-  return: void
+  return: Void
   en-US: Stop Forcing Spawn Room
   es-MX: Dejar de forzar cuarto de reaparición
   fr-FR: Arrêter de forcer une salle d’apparition
@@ -3200,7 +3200,7 @@ _&stopForcingThrottle:
     - Array: Player
     default: Event Player
   guid: 00000000BB0E
-  return: void
+  return: Void
   en-US: Stop Forcing Throttle
   es-MX: Dejar de forzar la aceleración
   fr-FR: Arrêter de forcer l’accélération
@@ -3216,7 +3216,7 @@ stopHoT:
     type: HotId
     default: Player Variable
   guid: 00000000B9C1
-  return: void
+  return: Void
   en-US: Stop Heal Over Time
   es-MX: Detener sanación con el tiempo
   fr-FR: Arrêter des soins sur la durée
@@ -3232,7 +3232,7 @@ stopHealingModification:
     type: HealingModificationId
     default: Last Healing Modification ID
   guid: 00000000FD37
-  return: void
+  return: Void
   en-US: Stop Healing Modification
   es-MX: Detener modificación de sanación
   fr-FR: Terminer la modification de soins
@@ -3254,7 +3254,7 @@ _&stopForcingButton:
     type: ButtonLiteral
     default: Primary Fire
   guid: 00000000B9D2
-  return: void
+  return: Void
   en-US: Stop Holding Button
   es-MX: Dejar de mantener el botón presionado
   fr-FR: Arrêter de maintenir un bouton enfoncé
@@ -3271,7 +3271,7 @@ _&stopThrottleInDirection:
     - Array: Player
     default: Event Player
   guid: 00000000CEA3
-  return: void
+  return: Void
   en-US: Stop Throttle In Direction
   es-MX: Detener aceleración en dirección
   fr-FR: Arrêter l’accélération directionnelle
@@ -3289,7 +3289,7 @@ _&stopTransformingThrottle:
     - Array: Player
     default: Event Player
   guid: 00000000CC25
-  return: void
+  return: Void
   en-US: Stop Transforming Throttle
   es-MX: Dejar de transformar la aceleración
   fr-FR: Arrêt de modification de l’accélération
@@ -3310,7 +3310,7 @@ _&teleport:
     description: The position to which the player or players will teleport. If a player is provided, the position of the player is used.
     type: Position
     default: Vector
-  return: void
+  return: Void
   en-US: Teleport
   es-MX: Transportar
   fr-FR: Téléportation
@@ -3321,7 +3321,7 @@ unpauseMatchTime:
   description: Unpauses the match time.
   args: []
   guid: 00000000B9F0
-  return: void
+  return: Void
   en-US: Unpause Match Time
   es-MX: Despausar tiempo de la partida
   fr-FR: Reprendre le temps de jeu
@@ -3341,7 +3341,7 @@ __wait__:
     description: Specifies if and how the wait can be interrupted. If the condition list is ignored, the wait will not be interrupted. Otherwise, the condition list will determine if and when the action list will abort or restart.
     type: Wait
     default: Ignore Condition
-  return: void
+  return: Void
   en-US: Wait
   es-MX: Esperar
   fr-FR: Attente
@@ -3360,7 +3360,7 @@ __while__:
     type: bool
     default: Compare
   guid: 00000000FB35
-  return: void
+  return: Void
   en-US: While
   es-MX: Mientras
   fr-FR: Tant que
@@ -4157,7 +4157,7 @@ MovePlayertoTeam:
     default: All
   - name: Slot
     description: The player slot which will receive the Player (-1 for first available slot).
-    type: int
+    type: Integer
     default: -1
   en-US: Move Player To Team
 
@@ -4262,7 +4262,7 @@ CreateProjectile:
     default: Number
   - name: Ricochet Count
     description: How many times the projectile will ricochet off the environment before expiring.
-    type: Interger
+    type: Integer
     default: Number
   - name: Gravity
     description: The amount of gravity affecting the projectile, creating an arc. If negative, the projectile will arc upwards.

--- a/config/arrays/wiki/constants.yml
+++ b/config/arrays/wiki/constants.yml
@@ -1,6 +1,5 @@
 Transform:
   ROTATION:
-    guid: 00000000B33B
     description: The resulting vector will be rotated to the new frame of reference.
       Use this option when the provided vector is a direction or velocity.
     en-US: Rotation
@@ -9,7 +8,6 @@ Transform:
     pt-BR: Rotação
     zh-CN: 旋转
   ROTATION_AND_TRANSLATION:
-    guid: 00000000B33C
     description: The resulting vector will be rotated and translated to the new frame
       of reference. Use this option when the provided vector is a position.
     en-US: Rotation And Translation
@@ -20,7 +18,6 @@ Transform:
     zh-CN: 旋转并转换
 Team:
   '1':
-    guid: 00000000B472
     en-US: Team 1
     es-MX: Equipo 1
     fr-FR: Équipe 1
@@ -28,7 +25,6 @@ Team:
     pt-BR: Equipe 1
     zh-CN: 队伍1
   '2':
-    guid: 00000000B471
     en-US: Team 2
     es-MX: Equipo 2
     fr-FR: Équipe 2
@@ -36,7 +32,6 @@ Team:
     pt-BR: Equipe 2
     zh-CN: 队伍2
   ALL:
-    guid: 00000000B470
     en-US: All Teams
     es-MX: Todos los equipos
     fr-FR: Toutes les équipes
@@ -45,7 +40,6 @@ Team:
     zh-CN: 所有队伍
 Invisible:
   ALL:
-    guid: 00000000B9EB
     en-US: All
     es-MX: Todos
     fr-FR: Tous
@@ -53,7 +47,6 @@ Invisible:
     pt-BR: Todos
     zh-CN: 全部
   ENEMIES:
-    guid: 00000000B9EA
     en-US: Enemies
     es-MX: Enemigos
     fr-FR: Ennemis
@@ -61,7 +54,6 @@ Invisible:
     pt-BR: Inimigos
     zh-CN: 敌人
   NONE:
-    guid: 00000000B9EC
     en-US: None
     es-MX: Ninguno
     fr-FR: Personne
@@ -70,7 +62,6 @@ Invisible:
     zh-CN: 全部禁用
 Color:
   AQUA:
-    guid: 00000000CDB3
     en-US: Aqua
     es-MX: Aguamarina
     fr-FR: Cyan
@@ -78,7 +69,6 @@ Color:
     pt-BR: Azul-piscina
     zh-CN: 水绿色
   BLUE:
-    guid: 00000000B939
     en-US: Blue
     es-MX: Azul
     fr-FR: Bleu
@@ -86,7 +76,6 @@ Color:
     pt-BR: Azul
     zh-CN: 蓝色
   GREEN:
-    guid: 00000000B93A
     en-US: Green
     es-MX: Verde
     fr-FR: Vert
@@ -94,7 +83,6 @@ Color:
     pt-BR: Verde
     zh-CN: 绿色
   LIME_GREEN:
-    guid: 00000000CDB7
     en-US: Lime Green
     es-MX: Verde lima
     fr-FR: Citron vert
@@ -102,14 +90,12 @@ Color:
     pt-BR: Verde-limão
     zh-CN: 灰绿色
   ORANGE:
-    guid: 00000000CDB4
     en-US: Orange
     es-MX: Naranja
     ja-JP: オレンジ
     pt-BR: Laranja
     zh-CN: 橙色
   PURPLE:
-    guid: 00000000BC1C
     en-US: Purple
     es-MX: Morado
     fr-FR: Violet
@@ -117,7 +103,6 @@ Color:
     pt-BR: Roxo
     zh-CN: 紫色
   RED:
-    guid: 00000000B938
     en-US: Red
     es-MX: Rojo
     fr-FR: Rouge
@@ -125,7 +110,6 @@ Color:
     pt-BR: Vermelho
     zh-CN: 红色
   SKY_BLUE:
-    guid: 00000000CDB5
     en-US: Sky Blue
     es-MX: Azul cielo
     fr-FR: Bleu ciel
@@ -133,7 +117,6 @@ Color:
     pt-BR: Azul-celeste
     zh-CN: 天蓝色
   TEAM_1:
-    guid: 00000000B472
     en-US: Team 1
     es-MX: Equipo 1
     fr-FR: Équipe 1
@@ -141,7 +124,6 @@ Color:
     pt-BR: Equipe 1
     zh-CN: 队伍1
   TEAM_2:
-    guid: 00000000B471
     en-US: Team 2
     es-MX: Equipo 2
     fr-FR: Équipe 2
@@ -149,14 +131,12 @@ Color:
     pt-BR: Equipe 2
     zh-CN: 队伍2
   TURQUOISE:
-    guid: 00000000CDB6
     en-US: Turquoise
     es-MX: Turquesa
     ja-JP: ターコイズ
     pt-BR: Turquesa
     zh-CN: 青绿色
   WHITE:
-    guid: 00000000B93C
     en-US: White
     es-MX: Blanco
     fr-FR: Blanc
@@ -164,7 +144,6 @@ Color:
     pt-BR: Branco
     zh-CN: 白色
   YELLOW:
-    guid: 00000000B93B
     en-US: Yellow
     es-MX: Amarillo
     fr-FR: Jaune
@@ -200,7 +179,6 @@ Color:
     zh-CN: 紫色
 Button:
   ABILITY_1:
-    guid: 00000000B179
     en-US: Ability 1
     es-MX: Habilidad 1
     fr-FR: Capacité 1
@@ -208,7 +186,6 @@ Button:
     pt-BR: Habilidade 1
     zh-CN: 技能1
   ABILITY_2:
-    guid: 00000000B178
     en-US: Ability 2
     es-MX: Habilidad 2
     fr-FR: Capacité 2
@@ -216,7 +193,6 @@ Button:
     pt-BR: Habilidade 2
     zh-CN: 技能2
   CROUCH:
-    guid: 00000000B175
     en-US: Crouch
     es-MX: Agacharse
     fr-FR: S’accroupir
@@ -224,7 +200,6 @@ Button:
     pt-BR: Agachar
     zh-CN: 蹲下
   INTERACT:
-    guid: 00000000B31E
     en-US: Interact
     es-MX: Interactuar
     fr-FR: Interaction
@@ -232,7 +207,6 @@ Button:
     pt-BR: Interagir
     zh-CN: 互动
   JUMP:
-    guid: 00000000B176
     en-US: Jump
     es-MX: Saltar
     fr-FR: Sauter
@@ -240,7 +214,6 @@ Button:
     pt-BR: Pular
     zh-CN: 跳跃
   MELEE:
-    guid: 00000000FC8D
     en-US: Melee
     es-MX: Melé
     fr-FR: Mêlée
@@ -248,7 +221,6 @@ Button:
     pt-BR: Corpo a corpo
     zh-CN: 近身攻击
   PRIMARY_FIRE:
-    guid: 00000000B17B
     en-US: Primary Fire
     es-MX: Disparo principal
     fr-FR: Tir principal
@@ -256,7 +228,6 @@ Button:
     pt-BR: Disparo Primário
     zh-CN: 主要攻击模式
   RELOAD:
-    guid: 00000000FC8E
     en-US: Reload
     es-MX: Recargar
     fr-FR: Rechargement
@@ -264,7 +235,6 @@ Button:
     pt-BR: Recarregar
     zh-CN: 装填
   SECONDARY_FIRE:
-    guid: 00000000B17A
     en-US: Secondary Fire
     es-MX: Disparo secundario
     fr-FR: Tir secondaire
@@ -272,7 +242,6 @@ Button:
     pt-BR: Disparo Secundário
     zh-CN: 辅助攻击模式
   ULTIMATE:
-    guid: 00000000B177
     en-US: Ultimate
     es-MX: Habilidad máxima
     fr-FR: Capacité ultime
@@ -281,7 +250,6 @@ Button:
     zh-CN: 终极技能
 Operation:
   __add__:
-    guid: 00000000B16D
     en-US: Add
     es-MX: Agregar
     fr-FR: Addition
@@ -289,7 +257,6 @@ Operation:
     pt-BR: Adicionar
     zh-CN: 加
   __appendToArray__:
-    guid: 00000000B167
     en-US: Append To Array
     es-MX: Anexar a la matriz
     fr-FR: Ajouter au tableau
@@ -297,7 +264,6 @@ Operation:
     pt-BR: Juntar à Matriz
     zh-CN: 添加至数组
   __divide__:
-    guid: 00000000B16A
     en-US: Divide
     es-MX: Dividir
     fr-FR: Division
@@ -305,7 +271,6 @@ Operation:
     pt-BR: Dividir
     zh-CN: 除
   __max__:
-    guid: 00000000B18F
     en-US: Max
     es-MX: Máximo
     fr-FR: Maximum
@@ -313,7 +278,6 @@ Operation:
     pt-BR: Máx.
     zh-CN: 最大
   __min__:
-    guid: 00000000B190
     en-US: Min
     es-MX: Mínimo
     fr-FR: Minimum
@@ -321,14 +285,12 @@ Operation:
     pt-BR: Mín.
     zh-CN: 最小
   __modulo__:
-    guid: 00000000B169
     en-US: Modulo
     es-MX: Módulo
     ja-JP: 剰余
     pt-BR: Modular
     zh-CN: 余数
   __multiply__:
-    guid: 00000000B16B
     en-US: Multiply
     es-MX: Multiplicar
     fr-FR: Multiplication
@@ -336,7 +298,6 @@ Operation:
     pt-BR: Multiplicar
     zh-CN: 乘
   __raiseToPower__:
-    guid: 00000000B168
     en-US: Raise To Power
     es-MX: Elevar a la potencia
     fr-FR: 'Élévation à une puissance '
@@ -344,7 +305,6 @@ Operation:
     pt-BR: Elevar à Potência
     zh-CN: 乘方
   __removeFromArrayByIndex__:
-    guid: 00000000C61B
     en-US: Remove From Array By Index
     es-MX: Eliminar de la matriz por índice
     fr-FR: Supprimer du tableau par index
@@ -352,7 +312,6 @@ Operation:
     pt-BR: Remover da Matriz por Índice
     zh-CN: 根据索引从数组中移除
   __removeFromArrayByValue__:
-    guid: 00000000B166
     en-US: Remove From Array By Value
     es-MX: Eliminar de la matriz por valor
     fr-FR: Supprimer du tableau par valeur
@@ -360,7 +319,6 @@ Operation:
     pt-BR: Remover da Matriz por Valor
     zh-CN: 根据值从数组中移除
   __subtract__:
-    guid: 00000000B16C
     en-US: Subtract
     es-MX: Restar
     fr-FR: Soustraction
@@ -369,7 +327,6 @@ Operation:
     zh-CN: 减
 Dynamic Effect:
   BAD_EXPLOSION:
-    guid: 00000000BC1A
     en-US: Bad Explosion
     es-MX: Mala explosión
     fr-FR: Mauvaise explosion
@@ -377,7 +334,6 @@ Dynamic Effect:
     pt-BR: Explosão Ruim
     zh-CN: 有害爆炸
   BAD_PICKUP_EFFECT:
-    guid: 00000000BC18
     en-US: Bad Pickup Effect
     es-MX: Mal efecto de captura
     fr-FR: Mauvais effet de ramassage
@@ -385,7 +341,6 @@ Dynamic Effect:
     pt-BR: Efeito de Coleta Ruim
     zh-CN: '有害选择效果 '
   BUFF_EXPLOSION_SOUND:
-    guid: 00000000C400
     en-US: Buff Explosion Sound
     es-MX: Sonido de explosión de potenciamiento
     fr-FR: Son d’explosion d’amélioration
@@ -393,7 +348,6 @@ Dynamic Effect:
     pt-BR: Som de Explosão para Bônus
     zh-CN: 状态爆炸声音
   BUFF_IMPACT_SOUND:
-    guid: 00000000C3FE
     en-US: Buff Impact Sound
     es-MX: Sonido de impacto de potenciamiento
     fr-FR: Son d’impact d’amélioration
@@ -401,7 +355,6 @@ Dynamic Effect:
     pt-BR: Som de Impacto para Bônus
     zh-CN: 正面状态施加声音
   DEBUFF_IMPACT_SOUND:
-    guid: 00000000C3FD
     en-US: Debuff Impact Sound
     es-MX: Sonido de impacto de despotenciamiento
     fr-FR: Son d’impact d’affaiblissement
@@ -409,7 +362,6 @@ Dynamic Effect:
     pt-BR: Som de Impacto para Penalidade
     zh-CN: 负面状态施加声音
   EXPLOSION_SOUND:
-    guid: 00000000C401
     en-US: Explosion Sound
     es-MX: Sonido de explosión
     fr-FR: Son de l’explosion
@@ -417,7 +369,6 @@ Dynamic Effect:
     pt-BR: Som de Explosão
     zh-CN: 爆炸声音
   GOOD_EXPLOSION:
-    guid: 00000000BB28
     en-US: Good Explosion
     es-MX: Buena explosión
     fr-FR: Bonne explosion
@@ -425,7 +376,6 @@ Dynamic Effect:
     pt-BR: Explosão Boa
     zh-CN: 有益爆炸
   GOOD_PICKUP_EFFECT:
-    guid: 00000000BC19
     en-US: Good Pickup Effect
     es-MX: Buen efecto de captura
     fr-FR: Bon effet de ramassage
@@ -433,7 +383,6 @@ Dynamic Effect:
     pt-BR: Efeito de Coleta Bom
     zh-CN: '有益选择效果 '
   RING_EXPLOSION:
-    guid: 00000000BC1B
     en-US: Ring Explosion
     es-MX: Explosión en anillo
     fr-FR: Explosion concentrique
@@ -441,7 +390,6 @@ Dynamic Effect:
     pt-BR: Explosão em Anel
     zh-CN: 环状爆炸
   RING_EXPLOSION_SOUND:
-    guid: 00000000C3FF
     en-US: Ring Explosion Sound
     es-MX: Sonido de explosión en anillo
     fr-FR: Son d’explosion concentrique
@@ -450,7 +398,6 @@ Dynamic Effect:
     zh-CN: 环状爆炸声音
 Effect:
   BAD_AURA:
-    guid: 00000000BC17
     en-US: Bad Aura
     es-MX: Mala Aura
     fr-FR: Mauvaise aura
@@ -458,7 +405,6 @@ Effect:
     pt-BR: Aura Ruim
     zh-CN: 有害光环
   BAD_AURA_SOUND:
-    guid: 00000000C4DA
     en-US: Bad Aura Sound
     es-MX: Sonido de aura mala
     fr-FR: Son de mauvaise aura
@@ -466,7 +412,6 @@ Effect:
     pt-BR: Som de Aura Ruim
     zh-CN: 负面光环音效
   BEACON_SOUND:
-    guid: 00000000C4D3
     en-US: Beacon Sound
     es-MX: Sonido de baliza
     fr-FR: Son de balise
@@ -474,7 +419,6 @@ Effect:
     pt-BR: Som de Sinalizador
     zh-CN: 信标声音
   CLOUD:
-    guid: 00000000BC15
     en-US: Cloud
     es-MX: Nube
     fr-FR: Nuage
@@ -482,7 +426,6 @@ Effect:
     pt-BR: Nuvem
     zh-CN: 云
   DECAL_SOUND:
-    guid: 00000000C4D4
     en-US: Decal Sound
     es-MX: Sonido de calcomanía
     fr-FR: Son de décal
@@ -490,7 +433,6 @@ Effect:
     pt-BR: Som de Símbolo
     zh-CN: 诱饵声音
   ENERGY_SOUND:
-    guid: 00000000C3FC
     en-US: Energy Sound
     es-MX: Sonido de energía
     fr-FR: Son de l’énergie
@@ -498,7 +440,6 @@ Effect:
     pt-BR: Som de Energia
     zh-CN: 能量声音
   GOOD_AURA:
-    guid: 00000000BC13
     en-US: Good Aura
     es-MX: Buena aura
     fr-FR: Bonne aura
@@ -506,7 +447,6 @@ Effect:
     pt-BR: Aura Boa
     zh-CN: 有益光环
   GOOD_AURA_SOUND:
-    guid: 00000000C4D8
     en-US: Good Aura Sound
     es-MX: Sonido de aura buena
     fr-FR: Son de bonne aura
@@ -514,7 +454,6 @@ Effect:
     pt-BR: Som de Aura Boa
     zh-CN: 有益光环声音
   LIGHT_SHAFT:
-    guid: 00000000B934
     en-US: Light Shaft
     es-MX: Haz de luz
     fr-FR: Puits de lumière
@@ -522,7 +461,6 @@ Effect:
     pt-BR: Feixe de Luz
     zh-CN: 光柱
   ORB:
-    guid: 00000000B933
     en-US: Orb
     es-MX: Orbe
     fr-FR: Orbe
@@ -530,7 +468,6 @@ Effect:
     pt-BR: Orbe
     zh-CN: 球
   PICKUP_SOUND:
-    guid: 00000000C4D9
     en-US: Pick-up Sound
     es-MX: Sonido de objeto recogido
     fr-FR: Son de ramassage
@@ -538,7 +475,6 @@ Effect:
     pt-BR: Som de Coleta
     zh-CN: 拾取音效
   RING:
-    guid: 00000000BC16
     en-US: Ring
     es-MX: Anillo
     fr-FR: Anneau
@@ -546,7 +482,6 @@ Effect:
     pt-BR: Anel
     zh-CN: 环
   SMOKE_SOUND:
-    guid: 00000000C4D5
     en-US: Smoke Sound
     es-MX: Sonido de humo
     fr-FR: Son de la fumée
@@ -554,7 +489,6 @@ Effect:
     pt-BR: Som de Fumaça
     zh-CN: 烟雾声音
   SPARKLES:
-    guid: 00000000BC14
     en-US: Sparkles
     es-MX: Chispas
     fr-FR: Etincelles
@@ -562,7 +496,6 @@ Effect:
     pt-BR: Faíscas
     zh-CN: 火花
   SPARKLES_SOUND:
-    guid: 00000000C4D6
     en-US: Sparkles Sound
     es-MX: Sonido de chispas
     fr-FR: Son des étincelles
@@ -570,7 +503,6 @@ Effect:
     pt-BR: Som de Faíscas
     zh-CN: 火花声音
   SPHERE:
-    guid: 00000000B935
     en-US: Sphere
     es-MX: Esfera
     fr-FR: Sphère
@@ -579,7 +511,6 @@ Effect:
     zh-CN: 球体
 Communication:
   ACKNOWLEDGE:
-    guid: 00000000B9D5
     en-US: Acknowledge
     es-MX: De acuerdo
     fr-FR: Bien reçu
@@ -587,7 +518,6 @@ Communication:
     pt-BR: Reconhecer
     zh-CN: 收到
   ATTACKING:
-    guid: 000000010BEF
     en-US: Attacking
     es-MX: Atacando
     fr-FR: J’attaque
@@ -595,7 +525,6 @@ Communication:
     pt-BR: Atacando
     zh-CN: 正在进攻
   COUNTDOWN:
-    guid: 000000010BF3
     en-US: Countdown
     es-MX: Conteo regresivo
     fr-FR: Compte à rebours
@@ -603,7 +532,6 @@ Communication:
     pt-BR: Contagem Regressiva
     zh-CN: 倒计时
   DEFENDING:
-    guid: 000000010BF0
     en-US: Defending
     es-MX: Defendiendo
     fr-FR: Je défends
@@ -611,7 +539,6 @@ Communication:
     pt-BR: Defendendo
     zh-CN: 正在防守
   EMOTE_DOWN:
-    guid: 00000000B9DB
     en-US: Emote Down
     es-MX: Gesto hacia abajo
     fr-FR: Emote bas
@@ -619,7 +546,6 @@ Communication:
     pt-BR: Emote Abaixo
     zh-CN: 表情（下）
   EMOTE_LEFT:
-    guid: 00000000B9DD
     en-US: Emote Left
     es-MX: Gesto hacia la izquierda
     fr-FR: Emote gauche
@@ -627,7 +553,6 @@ Communication:
     pt-BR: Emote à Esquerda
     zh-CN: 表情（左）
   EMOTE_RIGHT:
-    guid: 00000000B9DC
     en-US: Emote Right
     es-MX: Gesto hacia la derecha
     fr-FR: Emote droite
@@ -635,7 +560,6 @@ Communication:
     pt-BR: Emote à Direita
     zh-CN: 表情（右）
   EMOTE_UP:
-    guid: 00000000B9DE
     en-US: Emote Up
     es-MX: Gesto hacia arriba
     fr-FR: Emote haut
@@ -643,7 +567,6 @@ Communication:
     pt-BR: Emote Acima
     zh-CN: 表情（上）
   FALL_BACK:
-    guid: 000000010BE9
     en-US: Fall Back
     es-MX: Retroceder
     fr-FR: Repli
@@ -651,7 +574,6 @@ Communication:
     pt-BR: Recuar
     zh-CN: 撤退
   GO:
-    guid: 000000010BE7
     en-US: Go
     es-MX: Vamos
     fr-FR: On y va
@@ -659,7 +581,6 @@ Communication:
     pt-BR: Vai
     zh-CN: 前进
   GOING_IN:
-    guid: 000000010BED
     en-US: Going In
     es-MX: Entrando
     fr-FR: J’y vais
@@ -667,7 +588,6 @@ Communication:
     pt-BR: Vou Avançar
     zh-CN: 我上了
   GOODBYE:
-    guid: 000000010BE6
     en-US: Goodbye
     es-MX: Adiós
     fr-FR: Au revoir
@@ -675,7 +595,6 @@ Communication:
     pt-BR: Tchau
     zh-CN: 再见
   GROUP_UP:
-    guid: 00000000B9D7
     en-US: Group Up
     es-MX: Agrúpense
     fr-FR: Regroupement
@@ -683,7 +602,6 @@ Communication:
     pt-BR: Agrupem-se
     zh-CN: 集合
   HELLO:
-    guid: 00000000B9D9
     en-US: Hello
     es-MX: Hola
     fr-FR: Bonjour
@@ -691,7 +609,6 @@ Communication:
     pt-BR: Olá
     zh-CN: 问候
   INCOMING:
-    guid: 000000010BEB
     en-US: Incoming
     es-MX: Enemigos aproximándose
     fr-FR: En approche
@@ -699,7 +616,6 @@ Communication:
     pt-BR: Chegando
     zh-CN: 敌人来袭
   NEED_HEALING:
-    guid: 00000000B9D8
     en-US: Need Healing
     es-MX: Necesito sanación
     fr-FR: Besoin de soins
@@ -707,7 +623,6 @@ Communication:
     pt-BR: Preciso de Cura
     zh-CN: 需要治疗
   NEED_HELP:
-    guid: 000000010BF1
     en-US: Need Help
     es-MX: Necesito ayuda
     fr-FR: À l’aide
@@ -715,14 +630,12 @@ Communication:
     pt-BR: Preciso de Ajuda
     zh-CN: 需要帮助
   'NO':
-    guid: 000000010BE5
     en-US: 'No'
     fr-FR: Non
     ja-JP: いいえ
     pt-BR: Não
     zh-CN: 不行
   ON_MY_WAY:
-    guid: 000000010BEE
     en-US: On My Way
     es-MX: En camino
     fr-FR: J’arrive
@@ -730,7 +643,6 @@ Communication:
     pt-BR: A Caminho
     zh-CN: 正在赶来
   PRESS_THE_ATTACK:
-    guid: 000000010BE2
     en-US: Press the Attack
     es-MX: Al ataque
     fr-FR: Poursuivons l’offensive
@@ -738,7 +650,6 @@ Communication:
     pt-BR: Force o Ataque
     zh-CN: 继续攻击
   PUSH_FORWARD:
-    guid: 000000010BEA
     en-US: Push Forward
     es-MX: Avancen
     fr-FR: En avant
@@ -746,7 +657,6 @@ Communication:
     pt-BR: Avançar
     zh-CN: 推进
   READY:
-    guid: 000000010BE8
     en-US: Ready
     es-MX: Listo
     fr-FR: Prêt
@@ -754,7 +664,6 @@ Communication:
     pt-BR: Pronto
     zh-CN: 做好准备
   SORRY:
-    guid: 000000010BF2
     en-US: Sorry
     es-MX: Lo siento
     fr-FR: Désolé
@@ -762,7 +671,6 @@ Communication:
     pt-BR: Desculpe
     zh-CN: 抱歉
   THANKS:
-    guid: 00000000B9D6
     en-US: Thanks
     es-MX: Gracias
     fr-FR: Merci
@@ -770,7 +678,6 @@ Communication:
     pt-BR: Obrigado
     zh-CN: 感谢
   ULTIMATE_STATUS:
-    guid: 00000000B9DA
     en-US: Ultimate Status
     es-MX: Estado de habilidad máxima
     fr-FR: Statut de l’ulti
@@ -778,7 +685,6 @@ Communication:
     pt-BR: Status da Suprema
     zh-CN: 终极技能状态
   VOICE_LINE_DOWN:
-    guid: 00000000B9DF
     en-US: Voice Line Down
     es-MX: Línea de voz hacia abajo
     fr-FR: Réplique bas
@@ -786,7 +692,6 @@ Communication:
     pt-BR: Fala Abaixo
     zh-CN: 语音（下）
   VOICE_LINE_LEFT:
-    guid: 00000000B9E1
     en-US: Voice Line Left
     es-MX: Línea de voz hacia la izquierda
     fr-FR: Réplique gauche
@@ -794,7 +699,6 @@ Communication:
     pt-BR: Fala à Esquerda
     zh-CN: 语音（左）
   VOICE_LINE_RIGHT:
-    guid: 00000000B9E0
     en-US: Voice Line Right
     es-MX: Línea de voz hacia la derecha
     fr-FR: Réplique droite
@@ -802,7 +706,6 @@ Communication:
     pt-BR: Fala à Direita
     zh-CN: 语音（右）
   VOICE_LINE_UP:
-    guid: 00000000B9E2
     en-US: Voice Line Up
     es-MX: Línea de voz hacia arriba
     fr-FR: Réplique haut
@@ -810,7 +713,6 @@ Communication:
     pt-BR: Fala Acima
     zh-CN: 语音（上）
   WITH_YOU:
-    guid: 000000010BEC
     en-US: With You
     es-MX: Contigo
     fr-FR: Je te suis
@@ -818,7 +720,6 @@ Communication:
     pt-BR: Com Você
     zh-CN: 你先上
   'YES':
-    guid: 000000010BE4
     en-US: 'Yes'
     es-MX: Sí
     fr-FR: Oui
@@ -826,7 +727,6 @@ Communication:
     pt-BR: Sim
     zh-CN: 好的
   YOURE_WELCOME:
-    guid: 000000010BE3
     en-US: You are Welcome
     es-MX: De nada
     fr-FR: C’est tout naturel
@@ -835,7 +735,6 @@ Communication:
     zh-CN: 不用谢
 Icon:
   ARROW_DOWN:
-    guid: 00000000C2C9
     en-US: 'Arrow: Down'
     es-MX: 'Flecha: Hacia abajo'
     fr-FR: Flèche bas
@@ -843,7 +742,6 @@ Icon:
     pt-BR: 'Seta: Baixo'
     zh-CN: 箭头：向下
   ARROW_LEFT:
-    guid: 00000000C2CA
     en-US: 'Arrow: Left'
     es-MX: 'Flecha: Hacia la izquierda'
     fr-FR: Flèche gauche
@@ -851,7 +749,6 @@ Icon:
     pt-BR: 'Seta: Esquerda'
     zh-CN: 箭头：向左
   ARROW_RIGHT:
-    guid: 00000000C2CB
     en-US: 'Arrow: Right'
     es-MX: 'Flecha: Hacia la derecha'
     fr-FR: Flèche droite
@@ -859,7 +756,6 @@ Icon:
     pt-BR: 'Seta: Direita'
     zh-CN: 箭头：向右
   ARROW_UP:
-    guid: 00000000C2CC
     en-US: 'Arrow: Up'
     es-MX: 'Flecha: Hacia arriba'
     fr-FR: Flèche haut
@@ -867,7 +763,6 @@ Icon:
     pt-BR: 'Seta: Cima'
     zh-CN: 箭头：向上
   ASTERISK:
-    guid: 00000000C2CD
     en-US: Asterisk
     es-MX: Asterisco
     fr-FR: Astérisque
@@ -875,7 +770,6 @@ Icon:
     pt-BR: Asterisco
     zh-CN: 星形
   BOLT:
-    guid: 00000000C2CE
     en-US: Bolt
     es-MX: Rayo
     fr-FR: Boulon
@@ -883,7 +777,6 @@ Icon:
     pt-BR: Raio
     zh-CN: 箭矢
   CHECKMARK:
-    guid: 00000000C2CF
     en-US: Checkmark
     es-MX: Marca de control
     fr-FR: Point d’exclamation
@@ -891,7 +784,6 @@ Icon:
     pt-BR: Marca de Verificação
     zh-CN: 对号
   CIRCLE:
-    guid: 00000000C2D0
     en-US: Circle
     es-MX: Círculo
     fr-FR: Cercle
@@ -899,7 +791,6 @@ Icon:
     pt-BR: Círculo
     zh-CN: 圆圈
   CLUB:
-    guid: 00000000C2D1
     en-US: Club
     es-MX: Trébol
     fr-FR: Trèfle
@@ -907,7 +798,6 @@ Icon:
     pt-BR: Paus
     zh-CN: 梅花
   DIAMOND:
-    guid: 00000000C2D2
     en-US: Diamond
     es-MX: Diamante
     fr-FR: Carreau
@@ -915,7 +805,6 @@ Icon:
     pt-BR: Ouros
     zh-CN: 方块
   DIZZY:
-    guid: 00000000C2D3
     en-US: Dizzy
     es-MX: Mareado
     fr-FR: Étourdi
@@ -923,7 +812,6 @@ Icon:
     pt-BR: Tonto
     zh-CN: 晕眩
   EXCLAMATION_MARK:
-    guid: 00000000C2D4
     en-US: Exclamation Mark
     es-MX: Signo de exclamación
     fr-FR: Point d’exclamation
@@ -931,7 +819,6 @@ Icon:
     pt-BR: Ponto de Exclamação
     zh-CN: 感叹号
   EYE:
-    guid: 00000000C2D5
     en-US: Eye
     es-MX: Ojo
     fr-FR: Œil
@@ -939,7 +826,6 @@ Icon:
     pt-BR: Olho
     zh-CN: 眼睛
   FIRE:
-    guid: 00000000C2D6
     en-US: Fire
     es-MX: Fuego
     fr-FR: Flamme
@@ -947,7 +833,6 @@ Icon:
     pt-BR: Fogo
     zh-CN: 火焰
   FLAG:
-    guid: 00000000C2F0
     en-US: Flag
     es-MX: Bandera
     fr-FR: Drapeau
@@ -955,13 +840,11 @@ Icon:
     pt-BR: Bandeira
     zh-CN: 旗帜
   HALO:
-    guid: 00000000C2D7
     en-US: Halo
     ja-JP: 光輪
     pt-BR: Auréola
     zh-CN: 光晕
   HAPPY:
-    guid: 00000000C2D8
     en-US: Happy
     es-MX: Feliz
     fr-FR: Smiley content
@@ -969,7 +852,6 @@ Icon:
     pt-BR: Feliz
     zh-CN: 高兴
   HEART:
-    guid: 00000000C2D9
     en-US: Heart
     es-MX: Corazón
     fr-FR: Cœur
@@ -977,7 +859,6 @@ Icon:
     pt-BR: Copas
     zh-CN: 红桃
   MOON:
-    guid: 00000000C2DA
     en-US: Moon
     es-MX: Luna
     fr-FR: Lune
@@ -985,28 +866,24 @@ Icon:
     pt-BR: Lua
     zh-CN: 满月
   'NO':
-    guid: 00000000C2DB
     en-US: 'No'
     fr-FR: Interdit
     ja-JP: いいえ
     pt-BR: Não
     zh-CN: 拒绝
   PLUS:
-    guid: 00000000C2DC
     en-US: Plus
     es-MX: Signo de suma
     ja-JP: プラス
     pt-BR: Mais
     zh-CN: 加号
   POISON:
-    guid: 00000000C2DD
     en-US: Poison
     es-MX: Veneno
     ja-JP: ポイズン
     pt-BR: Veneno
     zh-CN: 剧毒
   POISON_2:
-    guid: 00000000C2DE
     en-US: Poison 2
     es-MX: Veneno 2
     fr-FR: Poison 2
@@ -1014,7 +891,6 @@ Icon:
     pt-BR: Veneno 2
     zh-CN: 剧毒2
   QUESTION_MARK:
-    guid: 00000000C2DF
     en-US: Question Mark
     es-MX: Signo de interrogación
     fr-FR: Point d’interrogation
@@ -1022,7 +898,6 @@ Icon:
     pt-BR: Ponto de Interrogação
     zh-CN: 问号
   RADIOACTIVE:
-    guid: 00000000C2E4
     en-US: Radioactive
     es-MX: Radiactivo
     fr-FR: Radioactif
@@ -1030,7 +905,6 @@ Icon:
     pt-BR: Radiativo
     zh-CN: 辐射
   RECYCLE:
-    guid: 00000000C2E5
     en-US: Recycle
     es-MX: Reciclaje
     fr-FR: Recyclage
@@ -1038,7 +912,6 @@ Icon:
     pt-BR: Reciclagem
     zh-CN: 回收
   RING_THICK:
-    guid: 00000000C2E6
     en-US: Ring Thick
     es-MX: Anillo grueso
     fr-FR: Anneau épais
@@ -1046,7 +919,6 @@ Icon:
     pt-BR: Anel Grosso
     zh-CN: 宽环
   RING_THIN:
-    guid: 00000000C2E7
     en-US: Ring Thin
     es-MX: Anillo delgado
     fr-FR: Anneau fin
@@ -1054,7 +926,6 @@ Icon:
     pt-BR: Anel Fino
     zh-CN: 细环
   SAD:
-    guid: 00000000C2E8
     en-US: Sad
     es-MX: Triste
     fr-FR: Smiley triste
@@ -1062,7 +933,6 @@ Icon:
     pt-BR: Triste
     zh-CN: 难过
   SKULL:
-    guid: 00000000C2E9
     en-US: Skull
     es-MX: Cráneo
     fr-FR: Crâne
@@ -1070,7 +940,6 @@ Icon:
     pt-BR: Caveira
     zh-CN: 骷髅
   SPADE:
-    guid: 00000000C2EA
     en-US: Spade
     es-MX: Pica
     fr-FR: Pique
@@ -1078,7 +947,6 @@ Icon:
     pt-BR: Espadas
     zh-CN: 黑桃
   SPIRAL:
-    guid: 00000000C2EB
     en-US: Spiral
     es-MX: Espiral
     fr-FR: Spirale
@@ -1086,14 +954,12 @@ Icon:
     pt-BR: Espiral
     zh-CN: 螺旋
   STOP:
-    guid: 00000000C2EC
     en-US: Stop
     es-MX: Alto
     ja-JP: 停止
     pt-BR: Parada
     zh-CN: 停止
   TRASHCAN:
-    guid: 00000000C2ED
     en-US: Trashcan
     es-MX: Tacho de basura
     fr-FR: Poubelle
@@ -1101,7 +967,6 @@ Icon:
     pt-BR: Lata de Lixo
     zh-CN: 垃圾箱
   WARNING:
-    guid: 00000000C2EE
     en-US: Warning
     es-MX: Advertencia
     fr-FR: Avertissement
@@ -1109,12 +974,10 @@ Icon:
     pt-BR: Aviso
     zh-CN: 警告
   CROSS:
-    guid: 00000000C2EF
     en-US: X
     fr-FR: Croix
 Relativity:
   TO_PLAYER:
-    guid: 00000000B16F
     description: Relative to the player's local coordinate system (which moves and
       rotates with the player).
     en-US: To Player
@@ -1124,7 +987,6 @@ Relativity:
     pt-BR: Ao Jogador
     zh-CN: 至玩家
   TO_WORLD:
-    guid: 00000000B170
     description: Relative to the world's coordinate system.
     en-US: To World
     es-MX: Al mundo
@@ -1134,7 +996,6 @@ Relativity:
     zh-CN: 至地图
 Impulse:
   CANCEL_CONTRARY_MOTION:
-    guid: 00000000B520
     description: If the target is moving against the direction of the impulse, this
       relative velocity is negated before the impulse is applied.
     en-US: Cancel Contrary Motion
@@ -1144,7 +1005,6 @@ Impulse:
     pt-BR: Cancelar Deslocamento Contrário
     zh-CN: 取消相反运动
   INCORPORATE_CONTRARY_MOTION:
-    guid: 00000000B521
     description: The impulse is added directly to the velocity of the target, so if
       the target is moving against the direction of the impulse, it might seem like
       the impulse has less of an effect.
@@ -1156,7 +1016,6 @@ Impulse:
     zh-CN: 合并相反运动
 Rounding:
   __roundUp__:
-    guid: 00000000C34F
     en-US: Up
     es-MX: Hacia arriba
     fr-FR: Au-dessus
@@ -1164,7 +1023,6 @@ Rounding:
     pt-BR: Cima
     zh-CN: 上
   __roundDown__:
-    guid: 00000000C34E
     en-US: Down
     es-MX: Hacia abajo
     fr-FR: En dessous
@@ -1172,7 +1030,6 @@ Rounding:
     pt-BR: Baixo
     zh-CN: 下
   __roundToNearest__:
-    guid: 00000000C34D
     en-US: To Nearest
     es-MX: Al más cercano
     fr-FR: Au plus près
@@ -1181,7 +1038,6 @@ Rounding:
     zh-CN: 至最近
 Line of Sight Check:
   'OFF':
-    guid: 00000000B1E2
     description: Line of sight is never blocked, allowing results through walls.
     en-US: 'Off'
     es-MX: Apagado
@@ -1190,7 +1046,6 @@ Line of Sight Check:
     pt-BR: Desligado
     zh-CN: 关闭
   SURFACES:
-    guid: 00000000B1E3
     description: Line of sight is blocked by ceilings, walls, floors, platforms, and
       any fixed object that blocks projectiles.
     en-US: Surfaces
@@ -1199,7 +1054,6 @@ Line of Sight Check:
     pt-BR: Superfícies
     zh-CN: 表面
   SURFACES_AND_ALL_BARRIERS:
-    guid: 00000000B1E5
     description: Line of sight is blocked by ceilings, walls, floors, platforms, any
       fixed object that blocks projectiles, and all barriers.
     en-US: Surfaces And All Barriers
@@ -1209,7 +1063,6 @@ Line of Sight Check:
     pt-BR: Superfícies e Todas as Barreiras
     zh-CN: 表面及全部屏障
   SURFACES_AND_ENEMY_BARRIERS:
-    guid: 00000000B1E4
     description: Line of sight is blocked by ceilings, walls, floors, platforms, any
       fixed object that blocks projectiles, and barriers created by the enemy team.
     en-US: Surfaces And Enemy Barriers
@@ -1220,7 +1073,6 @@ Line of Sight Check:
     zh-CN: 表面及敌方屏障
 Clip:
   SURFACES:
-    guid: 00000000BAF5
     description: The text may be partially or completely obscured by walls, floors,
       ceilings, players, or other solid objects.
     en-US: Clip Against Surfaces
@@ -1230,7 +1082,6 @@ Clip:
     pt-BR: Cortar nas Superfícies
     zh-CN: 根据表面截取
   NONE:
-    guid: 00000000BAF4
     description: The text will always be fully visible, even if it is behind a wall
       or solid object.
     en-US: Do Not Clip
@@ -1241,7 +1092,6 @@ Clip:
     zh-CN: 不要截取
 HUD Position:
   LEFT:
-    guid: 00000000BAF6
     en-US: Left
     es-MX: Izquierda
     fr-FR: Gauche
@@ -1249,7 +1099,6 @@ HUD Position:
     pt-BR: Esquerda
     zh-CN: 左边
   TOP:
-    guid: 00000000BAF7
     en-US: Top
     es-MX: Arriba
     fr-FR: Haut
@@ -1257,7 +1106,6 @@ HUD Position:
     pt-BR: Topo
     zh-CN: 顶部
   RIGHT:
-    guid: 00000000BAF8
     en-US: Right
     es-MX: Derecha
     fr-FR: Droite
@@ -1266,14 +1114,12 @@ HUD Position:
     zh-CN: 右边
 Icon Reevaluation:
   POSITION:
-    guid: 00000000B8D8
     en-US: Position
     es-MX: Posición
     ja-JP: 位置
     pt-BR: Posição
     zh-CN: 位置
   NONE:
-    guid: 00000000B8C3
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1281,7 +1127,6 @@ Icon Reevaluation:
     pt-BR: Ninguém
     zh-CN: 无
   VISIBILITY:
-    guid: 00000000B8C4
     en-US: Visible To
     es-MX: Visible para
     fr-FR: Visible pour
@@ -1289,7 +1134,6 @@ Icon Reevaluation:
     pt-BR: Visível para
     zh-CN: 可见
   VISIBILITY_AND_POSITION:
-    guid: 00000000B8D9
     en-US: Visible To and Position
     es-MX: Visible para y posición
     fr-FR: Visible pour et Position
@@ -1298,7 +1142,6 @@ Icon Reevaluation:
     zh-CN: 可见和位置
 Effect Reevaluation:
   POSITION_AND_RADIUS:
-    guid: 00000000B8C5
     en-US: Position and Radius
     es-MX: Posición y radio
     fr-FR: Position et Rayon
@@ -1306,7 +1149,6 @@ Effect Reevaluation:
     pt-BR: Posição e Raio
     zh-CN: 位置和半径
   NONE:
-    guid: 00000000B8C3
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1314,7 +1156,6 @@ Effect Reevaluation:
     pt-BR: Ninguém
     zh-CN: 无
   VISIBILITY:
-    guid: 00000000B8C4
     en-US: Visible To
     es-MX: Visible para
     fr-FR: Visible pour
@@ -1322,7 +1163,6 @@ Effect Reevaluation:
     pt-BR: Visível para
     zh-CN: 可见
   VISIBILITY_POSITION_AND_RADIUS:
-    guid: 00000000B8C6
     en-US: Visible To Position and Radius
     es-MX: Visible para posición y radio
     fr-FR: Visible pour Position et Rayon
@@ -1331,7 +1171,6 @@ Effect Reevaluation:
     zh-CN: 可见，位置和半径
 HUD Reevaluation:
   NONE:
-    guid: 00000000B8C3
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1339,7 +1178,6 @@ HUD Reevaluation:
     pt-BR: Ninguém
     zh-CN: 无
   SORT_ORDER:
-    guid: 00000001095F
     en-US: Sort Order
     es-MX: Orden de vista
     fr-FR: Tri
@@ -1347,7 +1185,6 @@ HUD Reevaluation:
     pt-BR: Ordem de Classificação
     zh-CN: 排序
   SORT_ORDER_AND_STRING:
-    guid: 00000000FCA6
     en-US: Sort Order and String
     es-MX: Clasificar orden y cadena
     fr-FR: Tri et Chaîne de texte
@@ -1355,14 +1192,12 @@ HUD Reevaluation:
     pt-BR: Ordem de classificação e string
     zh-CN: 排序规则与字符串
   STRING:
-    guid: 00000000BB31
     en-US: String
     es-MX: Cadena
     fr-FR: Chaîne de texte
     ja-JP: 文字列
     zh-CN: 字符串
   VISIBILITY:
-    guid: 00000000B8C4
     en-US: Visible To
     es-MX: Visible para
     fr-FR: Visible pour
@@ -1370,7 +1205,6 @@ HUD Reevaluation:
     pt-BR: Visível para
     zh-CN: 可见
   VISIBILITY_AND_SORT_ORDER:
-    guid: 00000001095E
     en-US: Visible To and Sort Order
     es-MX: Visible para y orden de vista
     fr-FR: Visible pour et Tri
@@ -1378,7 +1212,6 @@ HUD Reevaluation:
     pt-BR: Visível para e Ordem de Classificação
     zh-CN: 可见性和排序
   VISIBILITY_AND_STRING:
-    guid: 00000000BA8C
     en-US: Visible To and String
     es-MX: Visible para y cadena
     fr-FR: Visible pour et Chaîne de texte
@@ -1386,7 +1219,6 @@ HUD Reevaluation:
     pt-BR: Visível para e String
     zh-CN: 可见和字符串
   VISIBILITY_SORT_ORDER_AND_STRING:
-    guid: 00000000FCA5
     en-US: Visible To Sort Order and String
     es-MX: Visible para clasificar orden y cadena
     fr-FR: Visible pour Tri et Chaîne de texte
@@ -1397,7 +1229,6 @@ HUD Reevaluation:
     zh-CN: 可见性，排序规则，以及字符串
 In-World Text Reevaulation:
   NONE:
-    guid: 00000000B8C3
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1405,14 +1236,12 @@ In-World Text Reevaulation:
     pt-BR: Ninguém
     zh-CN: 无
   STRING:
-    guid: 00000000BB31
     en-US: String
     es-MX: Cadena
     fr-FR: Chaîne de texte
     ja-JP: 文字列
     zh-CN: 字符串
   VISIBILITY:
-    guid: 00000000B8C4
     en-US: Visible To
     es-MX: Visible para
     fr-FR: Visible pour
@@ -1420,7 +1249,6 @@ In-World Text Reevaulation:
     pt-BR: Visível para
     zh-CN: 可见
   VISIBILITY_AND_POSITION:
-    guid: 00000000B8D9
     en-US: Visible To and Position
     es-MX: Visible para y posición
     fr-FR: Visible pour et Position
@@ -1428,7 +1256,6 @@ In-World Text Reevaulation:
     pt-BR: Visível para e Posição
     zh-CN: 可见和位置
   VISIBILITY_AND_STRING:
-    guid: 00000000BA8C
     en-US: Visible To and String
     es-MX: Visible para y cadena
     fr-FR: Visible pour et Chaîne de texte
@@ -1436,7 +1263,6 @@ In-World Text Reevaulation:
     pt-BR: Visível para e String
     zh-CN: 可见和字符串
   VISIBILITY_POSITION_AND_STRING:
-    guid: 00000000BAD4
     en-US: Visible To Position and String
     es-MX: Visible para posición y cadena
     fr-FR: Visible pour Position et Chaîne de texte
@@ -1445,7 +1271,6 @@ In-World Text Reevaulation:
     zh-CN: 可见，位置和字符串
 Chase Reevaluation:
   DESTINATION_AND_RATE:
-    guid: 00000000B8CA
     en-US: Destination and Rate
     es-MX: Destino y tasa
     fr-FR: Destination et Taux
@@ -1453,7 +1278,6 @@ Chase Reevaluation:
     pt-BR: Destino e Taxa
     zh-CN: 速率及最终值
   NONE:
-    guid: 00000000B8C9
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1462,7 +1286,6 @@ Chase Reevaluation:
     zh-CN: 全部禁用
 Chase Time Reevaluation:
   DESTINATION_AND_DURATION:
-    guid: 00000000C479
     en-US: Destination and Duration
     es-MX: Destino y duración
     fr-FR: Destination et Durée
@@ -1470,7 +1293,6 @@ Chase Time Reevaluation:
     pt-BR: Destino e Duração
     zh-CN: 终点及持续时间
   NONE:
-    guid: 00000000B8C9
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1479,7 +1301,6 @@ Chase Time Reevaluation:
     zh-CN: 全部禁用
 Damage Reevaluation:
   NONE:
-    guid: 00000000C643
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucun
@@ -1487,7 +1308,6 @@ Damage Reevaluation:
     pt-BR: Nenhuma
     zh-CN: 无
   RECEIVERS_AND_DAMAGERS:
-    guid: 00000000C644
     en-US: Receivers and Damagers
     es-MX: Receptores e infligidores de daño
     fr-FR: Récepteurs et émetteurs de dégâts
@@ -1495,7 +1315,6 @@ Damage Reevaluation:
     pt-BR: Receptores e Danificadores
     zh-CN: 受伤害者和伤害者
   RECEIVERS_DAMAGERS_AND_DMGPERCENT:
-    guid: 00000000C645
     en-US: Receivers Damagers and Damage Percent
     es-MX: Receptores infligidores de daño y porcentaje de daño
     fr-FR: Récepteurs de dégâts émetteurs de dégâts et pourcentage de dégâts
@@ -1504,7 +1323,6 @@ Damage Reevaluation:
     zh-CN: 受伤害者，伤害者及伤害百分比
 Healing Reevaluation:
   NONE:
-    guid: 00000000FD25
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1512,7 +1330,6 @@ Healing Reevaluation:
     pt-BR: Nenhum
     zh-CN: 全部禁用
   RECEIVERS_AND_HEALERS:
-    guid: 00000000FD26
     en-US: Receivers and Healers
     es-MX: Receptores y sanadores
     fr-FR: Récepteurs de soins et soigneurs
@@ -1520,7 +1337,6 @@ Healing Reevaluation:
     pt-BR: Receptores e Curandeiros
     zh-CN: 受治疗者和治疗者
   RECEIVERS_HEALERS_AND_HEALPERCENT:
-    guid: 00000000FD27
     en-US: Receivers Healers and Healing Percent
     es-MX: Receptores sanadores y porcentaje de sanación
     fr-FR: Récepteurs de soins soigneurs et pourcentage de soins
@@ -1529,7 +1345,6 @@ Healing Reevaluation:
     zh-CN: 受治疗者，治疗者及治疗百分比
 FacingReeval:
   DIRECTION_AND_TURN_RATE:
-    guid: 00000000BB1F
     en-US: Direction and Turn Rate
     es-MX: Dirección y velocidad de giro
     fr-FR: Direction et Taux de rotation
@@ -1537,7 +1352,6 @@ FacingReeval:
     pt-BR: Direção e Taxa de Giro
     zh-CN: 方向及角速率
   NONE:
-    guid: 00000000B8C3
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1546,7 +1360,6 @@ FacingReeval:
     zh-CN: 无
 Wait:
   ABORT_WHEN_FALSE:
-    guid: 00000000787D
     description: The execution of the action list is aborted if any condition on this
       rule becomes false.
     en-US: Abort When False
@@ -1559,7 +1372,6 @@ Wait:
     pt-BR: Anular Quando For Falso
     zh-CN: 当为“假”时中止
   IGNORE_CONDITION:
-    guid: 00000000787C
     description: The execution of the action list is never interrupted.
     en-US: Ignore Condition
     es-ES: Ignorar condición
@@ -1571,7 +1383,6 @@ Wait:
     pt-BR: Ignorar Condição
     zh-CN: 无视条件
   RESTART_WHEN_TRUE:
-    guid: 00000000787E
     description: The execution of the action list restarts from the first action if
       the condition list transitions from false to true or if the rule's event occurs
       again with true conditions.
@@ -1586,7 +1397,6 @@ Wait:
     zh-CN: 当为“真”时重新开始
 Barrier Line of Sight:
   BLOCKED_BY_ENEMY_BARRIERS:
-    guid: 00000000B1EE
     description: Line of sight is blocked by barriers created by the enemy team.
     en-US: Enemy Barriers Block LOS
     es-MX: Las barreras enemigas bloquean la LDV
@@ -1595,7 +1405,6 @@ Barrier Line of Sight:
     pt-BR: Barreiras Inimigas Bloqueiam LdV
     zh-CN: 敌方屏障阻挡视线
   BLOCKED_BY_ALL_BARRIERS:
-    guid: 00000000B1EF
     description: Line of sight is blocked by all barriers.
     en-US: All Barriers Block LOS
     es-MX: Todas las barreras bloquean la LDV
@@ -1604,7 +1413,6 @@ Barrier Line of Sight:
     pt-BR: Todas as Barreiras Bloqueiam LdV
     zh-CN: 所有屏障阻挡视线
   PASS_THROUGH_BARRIERS:
-    guid: 00000000B1ED
     description: Line of sight is not blocked by any barriers.
     en-US: Barriers Do Not Block LOS
     es-MX: Las barreras no bloquean la LDV
@@ -1614,7 +1422,6 @@ Barrier Line of Sight:
     zh-CN: 屏障不会阻挡视线
 Status:
   ASLEEP:
-    guid: 00000000B36A
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Ana's sleep dart causes this status.
     en-US: Asleep
@@ -1624,7 +1431,6 @@ Status:
     pt-BR: Dormindo
     zh-CN: 沉睡
   BURNING:
-    guid: 00000000B36C
     description: The player is burning. For example, Ashe's dynamite causes this status.
     en-US: Burning
     es-MX: En llamas
@@ -1633,7 +1439,6 @@ Status:
     pt-BR: Queimando
     zh-CN: 点燃
   FROZEN:
-    guid: 00000000B369
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Mei's endothermic blaster causes this status.
     en-US: Frozen
@@ -1643,7 +1448,6 @@ Status:
     pt-BR: Congelado
     zh-CN: 冻结
   HACKED:
-    guid: 00000000B36D
     description: The player is unable to use abilities or ultimate abilities. Weapon
       attacks are unaffected. For example, Sombra can cause this status.
     en-US: Hacked
@@ -1653,7 +1457,6 @@ Status:
     pt-BR: Hackeado
     zh-CN: 被入侵
   INVINCIBLE:
-    guid: 00000000B367
     description: The player does not take damage.
     en-US: Invincible
     es-MX: Invencible
@@ -1661,7 +1464,6 @@ Status:
     pt-BR: Invencível
     zh-CN: 无敌
   KNOCKED_DOWN:
-    guid: 00000000B36B
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Reinhardt's Earthshatter causes this status.
     en-US: Knocked Down
@@ -1671,7 +1473,6 @@ Status:
     pt-BR: Nocauteado
     zh-CN: 击倒
   PHASED_OUT:
-    guid: 00000000B366
     description: The player passes through other players and avoids all enemy attacks.
       For example, Reaper's wraith form causes this status.
     en-US: Phased Out
@@ -1681,7 +1482,6 @@ Status:
     pt-BR: Intangível
     zh-CN: 消散
   ROOTED:
-    guid: 00000000B365
     description: The player cannot move unless moved by another player or object.
       Aiming is unaffected.
     en-US: Rooted
@@ -1691,7 +1491,6 @@ Status:
     pt-BR: Enraizado
     zh-CN: 定身
   STUNNED:
-    guid: 00000000B565
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Cassidy's flashbang causes this status.
     en-US: Stunned
@@ -1701,7 +1500,6 @@ Status:
     pt-BR: Atordoado
     zh-CN: 昏迷
   UNKILLABLE:
-    guid: 00000000B368
     description: The player's health will not drop below 1.
     en-US: Unkillable
     es-MX: Inmortal
@@ -1711,7 +1509,6 @@ Status:
     zh-CN: 无法杀死
 Spectator Visibility:
   DEFAULT:
-    guid: 00000000CE55
     description: Non-team spectators can see text when all players can see it.
     en-US: Default Visibility
     es-MX: Visibilidad predeterminada
@@ -1720,7 +1517,6 @@ Spectator Visibility:
     pt-BR: Visibilidade-padrão
     zh-CN: 默认可见度
   ALWAYS:
-    guid: 00000000CE56
     description: Non-team spectators can always see text.
     en-US: Visible Always
     es-MX: Siempre visible
@@ -1729,7 +1525,6 @@ Spectator Visibility:
     pt-BR: Sempre Visível
     zh-CN: 始终可见
   NEVER:
-    guid: 00000000CE57
     description: Non-team spectators can never see text.
     en-US: Visible Never
     es-MX: Nunca visible
@@ -1739,7 +1534,6 @@ Spectator Visibility:
     zh-CN: 始终不可见
 Beam:
   BAD:
-    guid: 00000000CE85
     en-US: Bad Beam
     es-MX: Rayo malo
     fr-FR: Mauvais rayon
@@ -1747,7 +1541,6 @@ Beam:
     pt-BR: Feixe Mau
     zh-CN: 有害光束
   GOOD:
-    guid: 00000000CE84
     en-US: Good Beam
     es-MX: Rayo bueno
     fr-FR: Bon rayon
@@ -1755,7 +1548,6 @@ Beam:
     pt-BR: Feixe Bom
     zh-CN: 有益光束
   GRAPPLE:
-    guid: 00000000CE9D
     en-US: Grapple Beam
     es-MX: Rayo de arpeo
     fr-FR: Rayon du grappin
@@ -1764,7 +1556,6 @@ Beam:
     zh-CN: 抓钩光束
 Throttle:
   REPLACE_EXISTING:
-    guid: 00000000CEB0
     en-US: Replace existing throttle
     es-MX: Reemplazar aceleración preexistente
     fr-FR: Remplacer l’accélération existante
@@ -1772,7 +1563,6 @@ Throttle:
     pt-BR: Substituir a aceleração existente
     zh-CN: 替换现有阈值
   ADD_TO_EXISTING:
-    guid: 00000000CEB1
     en-US: Add to existing throttle
     es-MX: Agregar a aceleración preexistente
     fr-FR: Ajouter à l’accélération existante
@@ -1781,7 +1571,6 @@ Throttle:
     zh-CN: 添加至现有阈值
 Throttle Reevaluation:
   DIRECTION_AND_MAGNITUDE:
-    guid: 00000000CEB3
     en-US: Direction and Magnitude
     es-MX: Dirección y magnitud
     fr-FR: Direction et ampleur
@@ -1789,7 +1578,6 @@ Throttle Reevaluation:
     pt-BR: Direção e Magnitude
     zh-CN: 方向和幅度
   NONE:
-    guid: 00000000CEB2
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1798,7 +1586,6 @@ Throttle Reevaluation:
     zh-CN: 无
 Acceleration Reevaluation:
   DIRECTION_RATE_AND_MAX_SPEED:
-    guid: 00000000BB1A
     en-US: Direction Rate and Max Speed
     es-MX: Dirección aceleración y velocidad máxima
     fr-FR: Direction Taux et Vitesse maximum
@@ -1806,7 +1593,6 @@ Acceleration Reevaluation:
     pt-BR: Direção Taxa e Velocidade Máx.
     zh-CN: 方向，速率，及最大速度
   NONE:
-    guid: 00000000B8C3
     en-US: None
     es-MX: Ninguno
     fr-FR: Aucune
@@ -1815,7 +1601,6 @@ Acceleration Reevaluation:
     zh-CN: 无
 Async Behavior:
   RESTART:
-    guid: '000000010025'
     description: Restart the specified rule with new contextual values (including
       event player, attacker, victim, etc).
     en-US: Restart Rule
@@ -1825,7 +1610,6 @@ Async Behavior:
     pt-BR: Regra de reinício
     zh-CN: 重新开始规则
   NOOP:
-    guid: '000000010026'
     description: Allow the rule to finish executing without changing its contextual
       values.
     en-US: Do Nothing
@@ -1836,28 +1620,22 @@ Async Behavior:
     zh-CN: 无动作
 Operator:
   "==":
-    guid: 00000000780E
     en-US: "=="
     fr-FR: "== égal à"
     ja-JP: " =="
   "!=":
-    guid: 00000000780F
     en-US: "!="
     fr-FR: "!= différent de"
   "<=":
-    guid: 000000007811
     en-US: "<="
     fr-FR: "<= inférieur ou égal à"
   ">=":
-    guid: 000000007814
     en-US: ">="
     fr-FR: ">= supérieur ou égal à"
   "<":
-    guid: 000000007810
     en-US: "<"
     fr-FR: "< inférieur à"
   ">":
-    guid: 000000007812
     en-US: ">"
     fr-FR: "> supérieur à"
 

--- a/config/arrays/wiki/constants.yml
+++ b/config/arrays/wiki/constants.yml
@@ -3,1641 +3,555 @@ Transform:
     description: The resulting vector will be rotated to the new frame of reference.
       Use this option when the provided vector is a direction or velocity.
     en-US: Rotation
-    es-MX: Rotación
-    ja-JP: 回転
-    pt-BR: Rotação
-    zh-CN: 旋转
   ROTATION_AND_TRANSLATION:
     description: The resulting vector will be rotated and translated to the new frame
       of reference. Use this option when the provided vector is a position.
     en-US: Rotation And Translation
-    es-MX: Rotación y traslación
-    fr-FR: Rotation et Translation
-    ja-JP: 回転と平行移動
-    pt-BR: Rotação e Translação
-    zh-CN: 旋转并转换
 Team:
   '1':
     en-US: Team 1
-    es-MX: Equipo 1
-    fr-FR: Équipe 1
-    ja-JP: チーム1
-    pt-BR: Equipe 1
-    zh-CN: 队伍1
   '2':
     en-US: Team 2
-    es-MX: Equipo 2
-    fr-FR: Équipe 2
-    ja-JP: チーム2
-    pt-BR: Equipe 2
-    zh-CN: 队伍2
   ALL:
     en-US: All Teams
-    es-MX: Todos los equipos
-    fr-FR: Toutes les équipes
-    ja-JP: すべてのチーム
-    pt-BR: Todas as Equipes
-    zh-CN: 所有队伍
 Invisible:
   ALL:
     en-US: All
-    es-MX: Todos
-    fr-FR: Tous
-    ja-JP: すべて
-    pt-BR: Todos
-    zh-CN: 全部
   ENEMIES:
     en-US: Enemies
-    es-MX: Enemigos
-    fr-FR: Ennemis
-    ja-JP: 敵
-    pt-BR: Inimigos
-    zh-CN: 敌人
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Personne
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 全部禁用
 Color:
   AQUA:
     en-US: Aqua
-    es-MX: Aguamarina
-    fr-FR: Cyan
-    ja-JP: アクア
-    pt-BR: Azul-piscina
-    zh-CN: 水绿色
   BLUE:
     en-US: Blue
-    es-MX: Azul
-    fr-FR: Bleu
-    ja-JP: 青
-    pt-BR: Azul
-    zh-CN: 蓝色
   GREEN:
     en-US: Green
-    es-MX: Verde
-    fr-FR: Vert
-    ja-JP: 緑
-    pt-BR: Verde
-    zh-CN: 绿色
   LIME_GREEN:
     en-US: Lime Green
-    es-MX: Verde lima
-    fr-FR: Citron vert
-    ja-JP: ライムグリーン
-    pt-BR: Verde-limão
-    zh-CN: 灰绿色
   ORANGE:
     en-US: Orange
-    es-MX: Naranja
-    ja-JP: オレンジ
-    pt-BR: Laranja
-    zh-CN: 橙色
   PURPLE:
     en-US: Purple
-    es-MX: Morado
-    fr-FR: Violet
-    ja-JP: 紫
-    pt-BR: Roxo
-    zh-CN: 紫色
   RED:
     en-US: Red
-    es-MX: Rojo
-    fr-FR: Rouge
-    ja-JP: 赤
-    pt-BR: Vermelho
-    zh-CN: 红色
   SKY_BLUE:
     en-US: Sky Blue
-    es-MX: Azul cielo
-    fr-FR: Bleu ciel
-    ja-JP: スカイブルー
-    pt-BR: Azul-celeste
-    zh-CN: 天蓝色
   TEAM_1:
     en-US: Team 1
-    es-MX: Equipo 1
-    fr-FR: Équipe 1
-    ja-JP: チーム1
-    pt-BR: Equipe 1
-    zh-CN: 队伍1
   TEAM_2:
     en-US: Team 2
-    es-MX: Equipo 2
-    fr-FR: Équipe 2
-    ja-JP: チーム2
-    pt-BR: Equipe 2
-    zh-CN: 队伍2
   TURQUOISE:
     en-US: Turquoise
-    es-MX: Turquesa
-    ja-JP: ターコイズ
-    pt-BR: Turquesa
-    zh-CN: 青绿色
   WHITE:
     en-US: White
-    es-MX: Blanco
-    fr-FR: Blanc
-    ja-JP: 白
-    pt-BR: Branco
-    zh-CN: 白色
   YELLOW:
     en-US: Yellow
-    es-MX: Amarillo
-    fr-FR: Jaune
-    ja-JP: 黄色
-    pt-BR: Amarelo
-    zh-CN: 黄色
   BLACK:
     en-US: Black
-    es-MX: Negro
-    fr-FR: Noir
-    ja-JP: ブラック
-    pt-BR: Preto
-    zh-CN: 黑色
   GRAY:
     en-US: Gray
-    es-MX: Gris
-    fr-FR: Gris
-    ja-JP: グレー
-    pt-BR: Cinza
-    zh-CN: 灰色
   ROSE:
     en-US: Rose
-    es-MX: Rosa
-    ja-JP: ローズ
-    pt-BR: Rosa
-    zh-CN: 玫红
   VIOLET:
     en-US: Violet
-    es-MX: Violeta
-    fr-FR: Mauve
-    ja-JP: バイオレット
-    pt-BR: Violeta
-    zh-CN: 紫色
 Button:
   ABILITY_1:
     en-US: Ability 1
-    es-MX: Habilidad 1
-    fr-FR: Capacité 1
-    ja-JP: アビリティ1
-    pt-BR: Habilidade 1
-    zh-CN: 技能1
   ABILITY_2:
     en-US: Ability 2
-    es-MX: Habilidad 2
-    fr-FR: Capacité 2
-    ja-JP: アビリティ2
-    pt-BR: Habilidade 2
-    zh-CN: 技能2
   CROUCH:
     en-US: Crouch
-    es-MX: Agacharse
-    fr-FR: S’accroupir
-    ja-JP: しゃがみ
-    pt-BR: Agachar
-    zh-CN: 蹲下
   INTERACT:
     en-US: Interact
-    es-MX: Interactuar
-    fr-FR: Interaction
-    ja-JP: インタラクト
-    pt-BR: Interagir
-    zh-CN: 互动
   JUMP:
     en-US: Jump
-    es-MX: Saltar
-    fr-FR: Sauter
-    ja-JP: ジャンプ
-    pt-BR: Pular
-    zh-CN: 跳跃
   MELEE:
     en-US: Melee
-    es-MX: Melé
-    fr-FR: Mêlée
-    ja-JP: 近接
-    pt-BR: Corpo a corpo
-    zh-CN: 近身攻击
   PRIMARY_FIRE:
     en-US: Primary Fire
-    es-MX: Disparo principal
-    fr-FR: Tir principal
-    ja-JP: メイン攻撃
-    pt-BR: Disparo Primário
-    zh-CN: 主要攻击模式
   RELOAD:
     en-US: Reload
-    es-MX: Recargar
-    fr-FR: Rechargement
-    ja-JP: リロード
-    pt-BR: Recarregar
-    zh-CN: 装填
   SECONDARY_FIRE:
     en-US: Secondary Fire
-    es-MX: Disparo secundario
-    fr-FR: Tir secondaire
-    ja-JP: サブ攻撃
-    pt-BR: Disparo Secundário
-    zh-CN: 辅助攻击模式
   ULTIMATE:
     en-US: Ultimate
-    es-MX: Habilidad máxima
-    fr-FR: Capacité ultime
-    ja-JP: アルティメット
-    pt-BR: Habilidade Suprema
-    zh-CN: 终极技能
 Operation:
   __add__:
     en-US: Add
-    es-MX: Agregar
-    fr-FR: Addition
-    ja-JP: 追加
-    pt-BR: Adicionar
-    zh-CN: 加
   __appendToArray__:
     en-US: Append To Array
-    es-MX: Anexar a la matriz
-    fr-FR: Ajouter au tableau
-    ja-JP: 追加
-    pt-BR: Juntar à Matriz
-    zh-CN: 添加至数组
   __divide__:
     en-US: Divide
-    es-MX: Dividir
-    fr-FR: Division
-    ja-JP: 割る
-    pt-BR: Dividir
-    zh-CN: 除
   __max__:
     en-US: Max
-    es-MX: Máximo
-    fr-FR: Maximum
-    ja-JP: 最大
-    pt-BR: Máx.
-    zh-CN: 最大
   __min__:
     en-US: Min
-    es-MX: Mínimo
-    fr-FR: Minimum
-    ja-JP: 分
-    pt-BR: Mín.
-    zh-CN: 最小
   __modulo__:
     en-US: Modulo
-    es-MX: Módulo
-    ja-JP: 剰余
-    pt-BR: Modular
-    zh-CN: 余数
   __multiply__:
     en-US: Multiply
-    es-MX: Multiplicar
-    fr-FR: Multiplication
-    ja-JP: 掛ける
-    pt-BR: Multiplicar
-    zh-CN: 乘
   __raiseToPower__:
     en-US: Raise To Power
-    es-MX: Elevar a la potencia
-    fr-FR: 'Élévation à une puissance '
-    ja-JP: 冪乗
-    pt-BR: Elevar à Potência
-    zh-CN: 乘方
   __removeFromArrayByIndex__:
     en-US: Remove From Array By Index
-    es-MX: Eliminar de la matriz por índice
-    fr-FR: Supprimer du tableau par index
-    ja-JP: インデックスを配列から削除
-    pt-BR: Remover da Matriz por Índice
-    zh-CN: 根据索引从数组中移除
   __removeFromArrayByValue__:
     en-US: Remove From Array By Value
-    es-MX: Eliminar de la matriz por valor
-    fr-FR: Supprimer du tableau par valeur
-    ja-JP: 削除
-    pt-BR: Remover da Matriz por Valor
-    zh-CN: 根据值从数组中移除
   __subtract__:
     en-US: Subtract
-    es-MX: Restar
-    fr-FR: Soustraction
-    ja-JP: 引く
-    pt-BR: Subtrair
-    zh-CN: 减
 Dynamic Effect:
   BAD_EXPLOSION:
     en-US: Bad Explosion
-    es-MX: Mala explosión
-    fr-FR: Mauvaise explosion
-    ja-JP: 悪い爆発
-    pt-BR: Explosão Ruim
-    zh-CN: 有害爆炸
   BAD_PICKUP_EFFECT:
     en-US: Bad Pickup Effect
-    es-MX: Mal efecto de captura
-    fr-FR: Mauvais effet de ramassage
-    ja-JP: 悪いピックアップ効果
-    pt-BR: Efeito de Coleta Ruim
-    zh-CN: '有害选择效果 '
   BUFF_EXPLOSION_SOUND:
     en-US: Buff Explosion Sound
-    es-MX: Sonido de explosión de potenciamiento
-    fr-FR: Son d’explosion d’amélioration
-    ja-JP: 爆発音（バフ）
-    pt-BR: Som de Explosão para Bônus
-    zh-CN: 状态爆炸声音
   BUFF_IMPACT_SOUND:
     en-US: Buff Impact Sound
-    es-MX: Sonido de impacto de potenciamiento
-    fr-FR: Son d’impact d’amélioration
-    ja-JP: 衝撃音（バフ）
-    pt-BR: Som de Impacto para Bônus
-    zh-CN: 正面状态施加声音
   DEBUFF_IMPACT_SOUND:
     en-US: Debuff Impact Sound
-    es-MX: Sonido de impacto de despotenciamiento
-    fr-FR: Son d’impact d’affaiblissement
-    ja-JP: 衝撃音（デバフ）
-    pt-BR: Som de Impacto para Penalidade
-    zh-CN: 负面状态施加声音
   EXPLOSION_SOUND:
     en-US: Explosion Sound
-    es-MX: Sonido de explosión
-    fr-FR: Son de l’explosion
-    ja-JP: 爆発音
-    pt-BR: Som de Explosão
-    zh-CN: 爆炸声音
   GOOD_EXPLOSION:
     en-US: Good Explosion
-    es-MX: Buena explosión
-    fr-FR: Bonne explosion
-    ja-JP: いい爆発
-    pt-BR: Explosão Boa
-    zh-CN: 有益爆炸
   GOOD_PICKUP_EFFECT:
     en-US: Good Pickup Effect
-    es-MX: Buen efecto de captura
-    fr-FR: Bon effet de ramassage
-    ja-JP: いいピックアップ効果
-    pt-BR: Efeito de Coleta Bom
-    zh-CN: '有益选择效果 '
   RING_EXPLOSION:
     en-US: Ring Explosion
-    es-MX: Explosión en anillo
-    fr-FR: Explosion concentrique
-    ja-JP: リングの爆発
-    pt-BR: Explosão em Anel
-    zh-CN: 环状爆炸
   RING_EXPLOSION_SOUND:
     en-US: Ring Explosion Sound
-    es-MX: Sonido de explosión en anillo
-    fr-FR: Son d’explosion concentrique
-    ja-JP: 爆発音（リング）
-    pt-BR: Som de Explosão para Anel
-    zh-CN: 环状爆炸声音
 Effect:
   BAD_AURA:
     en-US: Bad Aura
-    es-MX: Mala Aura
-    fr-FR: Mauvaise aura
-    ja-JP: 悪いオーラ
-    pt-BR: Aura Ruim
-    zh-CN: 有害光环
   BAD_AURA_SOUND:
     en-US: Bad Aura Sound
-    es-MX: Sonido de aura mala
-    fr-FR: Son de mauvaise aura
-    ja-JP: 悪いオーラ音
-    pt-BR: Som de Aura Ruim
-    zh-CN: 负面光环音效
   BEACON_SOUND:
     en-US: Beacon Sound
-    es-MX: Sonido de baliza
-    fr-FR: Son de balise
-    ja-JP: ビーコン音
-    pt-BR: Som de Sinalizador
-    zh-CN: 信标声音
   CLOUD:
     en-US: Cloud
-    es-MX: Nube
-    fr-FR: Nuage
-    ja-JP: 雲
-    pt-BR: Nuvem
-    zh-CN: 云
   DECAL_SOUND:
     en-US: Decal Sound
-    es-MX: Sonido de calcomanía
-    fr-FR: Son de décal
-    ja-JP: デカール音
-    pt-BR: Som de Símbolo
-    zh-CN: 诱饵声音
   ENERGY_SOUND:
     en-US: Energy Sound
-    es-MX: Sonido de energía
-    fr-FR: Son de l’énergie
-    ja-JP: エネルギー音
-    pt-BR: Som de Energia
-    zh-CN: 能量声音
   GOOD_AURA:
     en-US: Good Aura
-    es-MX: Buena aura
-    fr-FR: Bonne aura
-    ja-JP: いいオーラ
-    pt-BR: Aura Boa
-    zh-CN: 有益光环
   GOOD_AURA_SOUND:
     en-US: Good Aura Sound
-    es-MX: Sonido de aura buena
-    fr-FR: Son de bonne aura
-    ja-JP: いいオーラ音
-    pt-BR: Som de Aura Boa
-    zh-CN: 有益光环声音
   LIGHT_SHAFT:
     en-US: Light Shaft
-    es-MX: Haz de luz
-    fr-FR: Puits de lumière
-    ja-JP: 光の筋
-    pt-BR: Feixe de Luz
-    zh-CN: 光柱
   ORB:
     en-US: Orb
-    es-MX: Orbe
-    fr-FR: Orbe
-    ja-JP: オーブ
-    pt-BR: Orbe
-    zh-CN: 球
   PICKUP_SOUND:
     en-US: Pick-up Sound
-    es-MX: Sonido de objeto recogido
-    fr-FR: Son de ramassage
-    ja-JP: ピックアップ音
-    pt-BR: Som de Coleta
-    zh-CN: 拾取音效
   RING:
     en-US: Ring
-    es-MX: Anillo
-    fr-FR: Anneau
-    ja-JP: リング
-    pt-BR: Anel
-    zh-CN: 环
   SMOKE_SOUND:
     en-US: Smoke Sound
-    es-MX: Sonido de humo
-    fr-FR: Son de la fumée
-    ja-JP: スモーク音
-    pt-BR: Som de Fumaça
-    zh-CN: 烟雾声音
   SPARKLES:
     en-US: Sparkles
-    es-MX: Chispas
-    fr-FR: Etincelles
-    ja-JP: スパークル
-    pt-BR: Faíscas
-    zh-CN: 火花
   SPARKLES_SOUND:
     en-US: Sparkles Sound
-    es-MX: Sonido de chispas
-    fr-FR: Son des étincelles
-    ja-JP: スパークル音
-    pt-BR: Som de Faíscas
-    zh-CN: 火花声音
   SPHERE:
     en-US: Sphere
-    es-MX: Esfera
-    fr-FR: Sphère
-    ja-JP: 球体
-    pt-BR: Esfera
-    zh-CN: 球体
 Communication:
   ACKNOWLEDGE:
     en-US: Acknowledge
-    es-MX: De acuerdo
-    fr-FR: Bien reçu
-    ja-JP: 了解
-    pt-BR: Reconhecer
-    zh-CN: 收到
   ATTACKING:
     en-US: Attacking
-    es-MX: Atacando
-    fr-FR: J’attaque
-    ja-JP: 攻撃中
-    pt-BR: Atacando
-    zh-CN: 正在进攻
   COUNTDOWN:
     en-US: Countdown
-    es-MX: Conteo regresivo
-    fr-FR: Compte à rebours
-    ja-JP: カウントダウン
-    pt-BR: Contagem Regressiva
-    zh-CN: 倒计时
   DEFENDING:
     en-US: Defending
-    es-MX: Defendiendo
-    fr-FR: Je défends
-    ja-JP: 防衛中
-    pt-BR: Defendendo
-    zh-CN: 正在防守
   EMOTE_DOWN:
     en-US: Emote Down
-    es-MX: Gesto hacia abajo
-    fr-FR: Emote bas
-    ja-JP: エモート下
-    pt-BR: Emote Abaixo
-    zh-CN: 表情（下）
   EMOTE_LEFT:
     en-US: Emote Left
-    es-MX: Gesto hacia la izquierda
-    fr-FR: Emote gauche
-    ja-JP: エモート左
-    pt-BR: Emote à Esquerda
-    zh-CN: 表情（左）
   EMOTE_RIGHT:
     en-US: Emote Right
-    es-MX: Gesto hacia la derecha
-    fr-FR: Emote droite
-    ja-JP: エモート右
-    pt-BR: Emote à Direita
-    zh-CN: 表情（右）
   EMOTE_UP:
     en-US: Emote Up
-    es-MX: Gesto hacia arriba
-    fr-FR: Emote haut
-    ja-JP: エモート上
-    pt-BR: Emote Acima
-    zh-CN: 表情（上）
   FALL_BACK:
     en-US: Fall Back
-    es-MX: Retroceder
-    fr-FR: Repli
-    ja-JP: 退却しよう
-    pt-BR: Recuar
-    zh-CN: 撤退
   GO:
     en-US: Go
-    es-MX: Vamos
-    fr-FR: On y va
-    ja-JP: 行け
-    pt-BR: Vai
-    zh-CN: 前进
   GOING_IN:
     en-US: Going In
-    es-MX: Entrando
-    fr-FR: J’y vais
-    ja-JP: 突入する
-    pt-BR: Vou Avançar
-    zh-CN: 我上了
   GOODBYE:
     en-US: Goodbye
-    es-MX: Adiós
-    fr-FR: Au revoir
-    ja-JP: さようなら
-    pt-BR: Tchau
-    zh-CN: 再见
   GROUP_UP:
     en-US: Group Up
-    es-MX: Agrúpense
-    fr-FR: Regroupement
-    ja-JP: 集合
-    pt-BR: Agrupem-se
-    zh-CN: 集合
   HELLO:
     en-US: Hello
-    es-MX: Hola
-    fr-FR: Bonjour
-    ja-JP: こんにちは
-    pt-BR: Olá
-    zh-CN: 问候
   INCOMING:
     en-US: Incoming
-    es-MX: Enemigos aproximándose
-    fr-FR: En approche
-    ja-JP: 敵接近中
-    pt-BR: Chegando
-    zh-CN: 敌人来袭
   NEED_HEALING:
     en-US: Need Healing
-    es-MX: Necesito sanación
-    fr-FR: Besoin de soins
-    ja-JP: 回復が必要
-    pt-BR: Preciso de Cura
-    zh-CN: 需要治疗
   NEED_HELP:
     en-US: Need Help
-    es-MX: Necesito ayuda
-    fr-FR: À l’aide
-    ja-JP: 手を貸して
-    pt-BR: Preciso de Ajuda
-    zh-CN: 需要帮助
   'NO':
     en-US: 'No'
-    fr-FR: Non
-    ja-JP: いいえ
-    pt-BR: Não
-    zh-CN: 不行
   ON_MY_WAY:
     en-US: On My Way
-    es-MX: En camino
-    fr-FR: J’arrive
-    ja-JP: 今向かう
-    pt-BR: A Caminho
-    zh-CN: 正在赶来
   PRESS_THE_ATTACK:
     en-US: Press the Attack
-    es-MX: Al ataque
-    fr-FR: Poursuivons l’offensive
-    ja-JP: 攻撃の手を緩めるな
-    pt-BR: Force o Ataque
-    zh-CN: 继续攻击
   PUSH_FORWARD:
     en-US: Push Forward
-    es-MX: Avancen
-    fr-FR: En avant
-    ja-JP: 前進しよう
-    pt-BR: Avançar
-    zh-CN: 推进
   READY:
     en-US: Ready
-    es-MX: Listo
-    fr-FR: Prêt
-    ja-JP: 準備完了
-    pt-BR: Pronto
-    zh-CN: 做好准备
   SORRY:
     en-US: Sorry
-    es-MX: Lo siento
-    fr-FR: Désolé
-    ja-JP: ごめん
-    pt-BR: Desculpe
-    zh-CN: 抱歉
   THANKS:
     en-US: Thanks
-    es-MX: Gracias
-    fr-FR: Merci
-    ja-JP: ありがとう
-    pt-BR: Obrigado
-    zh-CN: 感谢
   ULTIMATE_STATUS:
     en-US: Ultimate Status
-    es-MX: Estado de habilidad máxima
-    fr-FR: Statut de l’ulti
-    ja-JP: アルティメットの状態
-    pt-BR: Status da Suprema
-    zh-CN: 终极技能状态
   VOICE_LINE_DOWN:
     en-US: Voice Line Down
-    es-MX: Línea de voz hacia abajo
-    fr-FR: Réplique bas
-    ja-JP: ボイス・ライン下
-    pt-BR: Fala Abaixo
-    zh-CN: 语音（下）
   VOICE_LINE_LEFT:
     en-US: Voice Line Left
-    es-MX: Línea de voz hacia la izquierda
-    fr-FR: Réplique gauche
-    ja-JP: ボイス・ライン左
-    pt-BR: Fala à Esquerda
-    zh-CN: 语音（左）
   VOICE_LINE_RIGHT:
     en-US: Voice Line Right
-    es-MX: Línea de voz hacia la derecha
-    fr-FR: Réplique droite
-    ja-JP: ボイス・ライン右
-    pt-BR: Fala à Direita
-    zh-CN: 语音（右）
   VOICE_LINE_UP:
     en-US: Voice Line Up
-    es-MX: Línea de voz hacia arriba
-    fr-FR: Réplique haut
-    ja-JP: ボイス・ライン上
-    pt-BR: Fala Acima
-    zh-CN: 语音（上）
   WITH_YOU:
     en-US: With You
-    es-MX: Contigo
-    fr-FR: Je te suis
-    ja-JP: ついていく
-    pt-BR: Com Você
-    zh-CN: 你先上
   'YES':
     en-US: 'Yes'
-    es-MX: Sí
-    fr-FR: Oui
-    ja-JP: はい
-    pt-BR: Sim
-    zh-CN: 好的
   YOURE_WELCOME:
     en-US: You are Welcome
-    es-MX: De nada
-    fr-FR: C’est tout naturel
-    ja-JP: どういたしまして
-    pt-BR: De Nada
-    zh-CN: 不用谢
 Icon:
   ARROW_DOWN:
     en-US: 'Arrow: Down'
-    es-MX: 'Flecha: Hacia abajo'
-    fr-FR: Flèche bas
-    ja-JP: 矢印:下
-    pt-BR: 'Seta: Baixo'
-    zh-CN: 箭头：向下
   ARROW_LEFT:
     en-US: 'Arrow: Left'
-    es-MX: 'Flecha: Hacia la izquierda'
-    fr-FR: Flèche gauche
-    ja-JP: 矢印:左
-    pt-BR: 'Seta: Esquerda'
-    zh-CN: 箭头：向左
   ARROW_RIGHT:
     en-US: 'Arrow: Right'
-    es-MX: 'Flecha: Hacia la derecha'
-    fr-FR: Flèche droite
-    ja-JP: 矢印:右
-    pt-BR: 'Seta: Direita'
-    zh-CN: 箭头：向右
   ARROW_UP:
     en-US: 'Arrow: Up'
-    es-MX: 'Flecha: Hacia arriba'
-    fr-FR: Flèche haut
-    ja-JP: 矢印:上
-    pt-BR: 'Seta: Cima'
-    zh-CN: 箭头：向上
   ASTERISK:
     en-US: Asterisk
-    es-MX: Asterisco
-    fr-FR: Astérisque
-    ja-JP: アスタリスク
-    pt-BR: Asterisco
-    zh-CN: 星形
   BOLT:
     en-US: Bolt
-    es-MX: Rayo
-    fr-FR: Boulon
-    ja-JP: 雷光の弓
-    pt-BR: Raio
-    zh-CN: 箭矢
   CHECKMARK:
     en-US: Checkmark
-    es-MX: Marca de control
-    fr-FR: Point d’exclamation
-    ja-JP: チェックマーク
-    pt-BR: Marca de Verificação
-    zh-CN: 对号
   CIRCLE:
     en-US: Circle
-    es-MX: Círculo
-    fr-FR: Cercle
-    ja-JP: サークル
-    pt-BR: Círculo
-    zh-CN: 圆圈
   CLUB:
     en-US: Club
-    es-MX: Trébol
-    fr-FR: Trèfle
-    ja-JP: 棍棒
-    pt-BR: Paus
-    zh-CN: 梅花
   DIAMOND:
     en-US: Diamond
-    es-MX: Diamante
-    fr-FR: Carreau
-    ja-JP: ダイヤモンド
-    pt-BR: Ouros
-    zh-CN: 方块
   DIZZY:
     en-US: Dizzy
-    es-MX: Mareado
-    fr-FR: Étourdi
-    ja-JP: めまい
-    pt-BR: Tonto
-    zh-CN: 晕眩
   EXCLAMATION_MARK:
     en-US: Exclamation Mark
-    es-MX: Signo de exclamación
-    fr-FR: Point d’exclamation
-    ja-JP: エクスクラメーションマーク
-    pt-BR: Ponto de Exclamação
-    zh-CN: 感叹号
   EYE:
     en-US: Eye
-    es-MX: Ojo
-    fr-FR: Œil
-    ja-JP: 眼差し
-    pt-BR: Olho
-    zh-CN: 眼睛
   FIRE:
     en-US: Fire
-    es-MX: Fuego
-    fr-FR: Flamme
-    ja-JP: 砲撃
-    pt-BR: Fogo
-    zh-CN: 火焰
   FLAG:
     en-US: Flag
-    es-MX: Bandera
-    fr-FR: Drapeau
-    ja-JP: 通報
-    pt-BR: Bandeira
-    zh-CN: 旗帜
   HALO:
     en-US: Halo
-    ja-JP: 光輪
-    pt-BR: Auréola
-    zh-CN: 光晕
   HAPPY:
     en-US: Happy
-    es-MX: Feliz
-    fr-FR: Smiley content
-    ja-JP: ハッピー
-    pt-BR: Feliz
-    zh-CN: 高兴
   HEART:
     en-US: Heart
-    es-MX: Corazón
-    fr-FR: Cœur
-    ja-JP: ハート
-    pt-BR: Copas
-    zh-CN: 红桃
   MOON:
     en-US: Moon
-    es-MX: Luna
-    fr-FR: Lune
-    ja-JP: 月
-    pt-BR: Lua
-    zh-CN: 满月
   'NO':
     en-US: 'No'
-    fr-FR: Interdit
-    ja-JP: いいえ
-    pt-BR: Não
-    zh-CN: 拒绝
   PLUS:
     en-US: Plus
-    es-MX: Signo de suma
-    ja-JP: プラス
-    pt-BR: Mais
-    zh-CN: 加号
   POISON:
     en-US: Poison
-    es-MX: Veneno
-    ja-JP: ポイズン
-    pt-BR: Veneno
-    zh-CN: 剧毒
   POISON_2:
     en-US: Poison 2
-    es-MX: Veneno 2
-    fr-FR: Poison 2
-    ja-JP: ポイズン2
-    pt-BR: Veneno 2
-    zh-CN: 剧毒2
   QUESTION_MARK:
     en-US: Question Mark
-    es-MX: Signo de interrogación
-    fr-FR: Point d’interrogation
-    ja-JP: クエスチョンマーク
-    pt-BR: Ponto de Interrogação
-    zh-CN: 问号
   RADIOACTIVE:
     en-US: Radioactive
-    es-MX: Radiactivo
-    fr-FR: Radioactif
-    ja-JP: レディオアクティブ
-    pt-BR: Radiativo
-    zh-CN: 辐射
   RECYCLE:
     en-US: Recycle
-    es-MX: Reciclaje
-    fr-FR: Recyclage
-    ja-JP: リサイクル
-    pt-BR: Reciclagem
-    zh-CN: 回收
   RING_THICK:
     en-US: Ring Thick
-    es-MX: Anillo grueso
-    fr-FR: Anneau épais
-    ja-JP: リング太
-    pt-BR: Anel Grosso
-    zh-CN: 宽环
   RING_THIN:
     en-US: Ring Thin
-    es-MX: Anillo delgado
-    fr-FR: Anneau fin
-    ja-JP: リング細
-    pt-BR: Anel Fino
-    zh-CN: 细环
   SAD:
     en-US: Sad
-    es-MX: Triste
-    fr-FR: Smiley triste
-    ja-JP: サッド
-    pt-BR: Triste
-    zh-CN: 难过
   SKULL:
     en-US: Skull
-    es-MX: Cráneo
-    fr-FR: Crâne
-    ja-JP: スカル
-    pt-BR: Caveira
-    zh-CN: 骷髅
   SPADE:
     en-US: Spade
-    es-MX: Pica
-    fr-FR: Pique
-    ja-JP: スペード
-    pt-BR: Espadas
-    zh-CN: 黑桃
   SPIRAL:
     en-US: Spiral
-    es-MX: Espiral
-    fr-FR: Spirale
-    ja-JP: 螺旋を描く
-    pt-BR: Espiral
-    zh-CN: 螺旋
   STOP:
     en-US: Stop
-    es-MX: Alto
-    ja-JP: 停止
-    pt-BR: Parada
-    zh-CN: 停止
   TRASHCAN:
     en-US: Trashcan
-    es-MX: Tacho de basura
-    fr-FR: Poubelle
-    ja-JP: ゴミ箱
-    pt-BR: Lata de Lixo
-    zh-CN: 垃圾箱
   WARNING:
     en-US: Warning
-    es-MX: Advertencia
-    fr-FR: Avertissement
-    ja-JP: 警告
-    pt-BR: Aviso
-    zh-CN: 警告
   CROSS:
     en-US: X
-    fr-FR: Croix
 Relativity:
   TO_PLAYER:
     description: Relative to the player's local coordinate system (which moves and
       rotates with the player).
     en-US: To Player
-    es-MX: Al jugador
-    fr-FR: Au joueur
-    ja-JP: '対プレイヤー: '
-    pt-BR: Ao Jogador
-    zh-CN: 至玩家
   TO_WORLD:
     description: Relative to the world's coordinate system.
     en-US: To World
-    es-MX: Al mundo
-    fr-FR: Au monde
-    ja-JP: '対ワールド: '
-    pt-BR: Ao Mundo
-    zh-CN: 至地图
 Impulse:
   CANCEL_CONTRARY_MOTION:
     description: If the target is moving against the direction of the impulse, this
       relative velocity is negated before the impulse is applied.
     en-US: Cancel Contrary Motion
-    es-MX: Cancelar movimiento contrario
-    fr-FR: Annuler le mouvement contraire
-    ja-JP: 逆モーションをキャンセル
-    pt-BR: Cancelar Deslocamento Contrário
-    zh-CN: 取消相反运动
   INCORPORATE_CONTRARY_MOTION:
     description: The impulse is added directly to the velocity of the target, so if
       the target is moving against the direction of the impulse, it might seem like
       the impulse has less of an effect.
     en-US: Incorporate Contrary Motion
-    es-MX: Incorporar movimiento contrario
-    fr-FR: Incorporer un mouvement contraire
-    ja-JP: 逆モーションを組み込む
-    pt-BR: Incorporar Deslocamento Contrário
-    zh-CN: 合并相反运动
 Rounding:
   __roundUp__:
     en-US: Up
-    es-MX: Hacia arriba
-    fr-FR: Au-dessus
-    ja-JP: 上
-    pt-BR: Cima
-    zh-CN: 上
   __roundDown__:
     en-US: Down
-    es-MX: Hacia abajo
-    fr-FR: En dessous
-    ja-JP: 下
-    pt-BR: Baixo
-    zh-CN: 下
   __roundToNearest__:
     en-US: To Nearest
-    es-MX: Al más cercano
-    fr-FR: Au plus près
-    ja-JP: 最も近い数値へ
-    pt-BR: Ao Mais Próximo
-    zh-CN: 至最近
 Line of Sight Check:
   'OFF':
     description: Line of sight is never blocked, allowing results through walls.
     en-US: 'Off'
-    es-MX: Apagado
-    fr-FR: Désactivé
-    ja-JP: 'OFF'
-    pt-BR: Desligado
-    zh-CN: 关闭
   SURFACES:
     description: Line of sight is blocked by ceilings, walls, floors, platforms, and
       any fixed object that blocks projectiles.
     en-US: Surfaces
-    es-MX: Superficies
-    ja-JP: 表面
-    pt-BR: Superfícies
-    zh-CN: 表面
   SURFACES_AND_ALL_BARRIERS:
     description: Line of sight is blocked by ceilings, walls, floors, platforms, any
       fixed object that blocks projectiles, and all barriers.
     en-US: Surfaces And All Barriers
-    es-MX: Superficies y todas las barreras
-    fr-FR: Surfaces et toutes les barrières
-    ja-JP: 表面とすべてのバリア
-    pt-BR: Superfícies e Todas as Barreiras
-    zh-CN: 表面及全部屏障
   SURFACES_AND_ENEMY_BARRIERS:
     description: Line of sight is blocked by ceilings, walls, floors, platforms, any
       fixed object that blocks projectiles, and barriers created by the enemy team.
     en-US: Surfaces And Enemy Barriers
-    es-MX: Superficies y barreras enemigas
-    fr-FR: Surfaces et barrières ennemies
-    ja-JP: 表面と敵のバリア
-    pt-BR: Superfícies e Barreiras Inimigas
-    zh-CN: 表面及敌方屏障
 Clip:
   SURFACES:
     description: The text may be partially or completely obscured by walls, floors,
       ceilings, players, or other solid objects.
     en-US: Clip Against Surfaces
-    es-MX: Atravesar las superficies
-    fr-FR: Masquer derrière les surfaces
-    ja-JP: 表面に対してクリップ
-    pt-BR: Cortar nas Superfícies
-    zh-CN: 根据表面截取
   NONE:
     description: The text will always be fully visible, even if it is behind a wall
       or solid object.
     en-US: Do Not Clip
-    es-MX: No atravesar
-    fr-FR: Ne pas masquer
-    ja-JP: クリップしない
-    pt-BR: Não Cortar
-    zh-CN: 不要截取
 HUD Position:
   LEFT:
     en-US: Left
-    es-MX: Izquierda
-    fr-FR: Gauche
-    ja-JP: 左
-    pt-BR: Esquerda
-    zh-CN: 左边
   TOP:
     en-US: Top
-    es-MX: Arriba
-    fr-FR: Haut
-    ja-JP: トップ
-    pt-BR: Topo
-    zh-CN: 顶部
   RIGHT:
     en-US: Right
-    es-MX: Derecha
-    fr-FR: Droite
-    ja-JP: 右
-    pt-BR: Direita
-    zh-CN: 右边
 Icon Reevaluation:
   POSITION:
     en-US: Position
-    es-MX: Posición
-    ja-JP: 位置
-    pt-BR: Posição
-    zh-CN: 位置
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 无
   VISIBILITY:
     en-US: Visible To
-    es-MX: Visible para
-    fr-FR: Visible pour
-    ja-JP: '目視可能: '
-    pt-BR: Visível para
-    zh-CN: 可见
   VISIBILITY_AND_POSITION:
     en-US: Visible To and Position
-    es-MX: Visible para y posición
-    fr-FR: Visible pour et Position
-    ja-JP: 表示される相手、位置
-    pt-BR: Visível para e Posição
-    zh-CN: 可见和位置
 Effect Reevaluation:
   POSITION_AND_RADIUS:
     en-US: Position and Radius
-    es-MX: Posición y radio
-    fr-FR: Position et Rayon
-    ja-JP: 位置と範囲
-    pt-BR: Posição e Raio
-    zh-CN: 位置和半径
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 无
   VISIBILITY:
     en-US: Visible To
-    es-MX: Visible para
-    fr-FR: Visible pour
-    ja-JP: '目視可能: '
-    pt-BR: Visível para
-    zh-CN: 可见
   VISIBILITY_POSITION_AND_RADIUS:
     en-US: Visible To Position and Radius
-    es-MX: Visible para posición y radio
-    fr-FR: Visible pour Position et Rayon
-    ja-JP: 表示される相手、位置、範囲
-    pt-BR: Visível para Posição e Raio
-    zh-CN: 可见，位置和半径
 HUD Reevaluation:
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 无
   SORT_ORDER:
     en-US: Sort Order
-    es-MX: Orden de vista
-    fr-FR: Tri
-    ja-JP: ソート順
-    pt-BR: Ordem de Classificação
-    zh-CN: 排序
   SORT_ORDER_AND_STRING:
     en-US: Sort Order and String
-    es-MX: Clasificar orden y cadena
-    fr-FR: Tri et Chaîne de texte
-    ja-JP: ソート順、文字列
-    pt-BR: Ordem de classificação e string
-    zh-CN: 排序规则与字符串
   STRING:
     en-US: String
-    es-MX: Cadena
-    fr-FR: Chaîne de texte
-    ja-JP: 文字列
-    zh-CN: 字符串
   VISIBILITY:
     en-US: Visible To
-    es-MX: Visible para
-    fr-FR: Visible pour
-    ja-JP: '目視可能: '
-    pt-BR: Visível para
-    zh-CN: 可见
   VISIBILITY_AND_SORT_ORDER:
     en-US: Visible To and Sort Order
-    es-MX: Visible para y orden de vista
-    fr-FR: Visible pour et Tri
-    ja-JP: 表示される相手、ソート順
-    pt-BR: Visível para e Ordem de Classificação
-    zh-CN: 可见性和排序
   VISIBILITY_AND_STRING:
     en-US: Visible To and String
-    es-MX: Visible para y cadena
-    fr-FR: Visible pour et Chaîne de texte
-    ja-JP: 表示される相手、文字列
-    pt-BR: Visível para e String
-    zh-CN: 可见和字符串
   VISIBILITY_SORT_ORDER_AND_STRING:
     en-US: Visible To Sort Order and String
-    es-MX: Visible para clasificar orden y cadena
-    fr-FR: Visible pour Tri et Chaîne de texte
     it-IT: Sort Order and String
-    ja-JP: 表示される相手、ソート順、文字列
     ko-KR: Visible To Sort Order String
-    pt-BR: Visível para ordem de classificação e string
-    zh-CN: 可见性，排序规则，以及字符串
 In-World Text Reevaulation:
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 无
   STRING:
     en-US: String
-    es-MX: Cadena
-    fr-FR: Chaîne de texte
-    ja-JP: 文字列
-    zh-CN: 字符串
   VISIBILITY:
     en-US: Visible To
-    es-MX: Visible para
-    fr-FR: Visible pour
-    ja-JP: '目視可能: '
-    pt-BR: Visível para
-    zh-CN: 可见
   VISIBILITY_AND_POSITION:
     en-US: Visible To and Position
-    es-MX: Visible para y posición
-    fr-FR: Visible pour et Position
-    ja-JP: 表示される相手、位置
-    pt-BR: Visível para e Posição
-    zh-CN: 可见和位置
   VISIBILITY_AND_STRING:
     en-US: Visible To and String
-    es-MX: Visible para y cadena
-    fr-FR: Visible pour et Chaîne de texte
-    ja-JP: 表示される相手、文字列
-    pt-BR: Visível para e String
-    zh-CN: 可见和字符串
   VISIBILITY_POSITION_AND_STRING:
     en-US: Visible To Position and String
-    es-MX: Visible para posición y cadena
-    fr-FR: Visible pour Position et Chaîne de texte
-    ja-JP: 表示される相手、位置、文字列
-    pt-BR: Visível para Posição e String
-    zh-CN: 可见，位置和字符串
 Chase Reevaluation:
   DESTINATION_AND_RATE:
     en-US: Destination and Rate
-    es-MX: Destino y tasa
-    fr-FR: Destination et Taux
-    ja-JP: 目的とレート
-    pt-BR: Destino e Taxa
-    zh-CN: 速率及最终值
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Nenhuma
-    zh-CN: 全部禁用
 Chase Time Reevaluation:
   DESTINATION_AND_DURATION:
     en-US: Destination and Duration
-    es-MX: Destino y duración
-    fr-FR: Destination et Durée
-    ja-JP: 目的と持続時間
-    pt-BR: Destino e Duração
-    zh-CN: 终点及持续时间
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Nenhuma
-    zh-CN: 全部禁用
 Damage Reevaluation:
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucun
-    ja-JP: なし
-    pt-BR: Nenhuma
-    zh-CN: 无
   RECEIVERS_AND_DAMAGERS:
     en-US: Receivers and Damagers
-    es-MX: Receptores e infligidores de daño
-    fr-FR: Récepteurs et émetteurs de dégâts
-    ja-JP: レシーバーとダメージャー
-    pt-BR: Receptores e Danificadores
-    zh-CN: 受伤害者和伤害者
   RECEIVERS_DAMAGERS_AND_DMGPERCENT:
     en-US: Receivers Damagers and Damage Percent
-    es-MX: Receptores infligidores de daño y porcentaje de daño
-    fr-FR: Récepteurs de dégâts émetteurs de dégâts et pourcentage de dégâts
-    ja-JP: レシーバー、ダメージャー、ダメージのパーセンテージ
-    pt-BR: Receptores Danificadores e Porcentagem de Dano
-    zh-CN: 受伤害者，伤害者及伤害百分比
 Healing Reevaluation:
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Nenhum
-    zh-CN: 全部禁用
   RECEIVERS_AND_HEALERS:
     en-US: Receivers and Healers
-    es-MX: Receptores y sanadores
-    fr-FR: Récepteurs de soins et soigneurs
-    ja-JP: レシーバーとヒーラー
-    pt-BR: Receptores e Curandeiros
-    zh-CN: 受治疗者和治疗者
   RECEIVERS_HEALERS_AND_HEALPERCENT:
     en-US: Receivers Healers and Healing Percent
-    es-MX: Receptores sanadores y porcentaje de sanación
-    fr-FR: Récepteurs de soins soigneurs et pourcentage de soins
-    ja-JP: レシーバー、ヒーラー、回復量のパーセンテージ
-    pt-BR: Receptores Curandeiros e percentual de cura
-    zh-CN: 受治疗者，治疗者及治疗百分比
 FacingReeval:
   DIRECTION_AND_TURN_RATE:
     en-US: Direction and Turn Rate
-    es-MX: Dirección y velocidad de giro
-    fr-FR: Direction et Taux de rotation
-    ja-JP: 方向と回転レート
-    pt-BR: Direção e Taxa de Giro
-    zh-CN: 方向及角速率
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 无
 Wait:
   ABORT_WHEN_FALSE:
     description: The execution of the action list is aborted if any condition on this
       rule becomes false.
     en-US: Abort When False
     es-ES: Abortar cuando sea falso
-    es-MX: Cancelar cuando es falso
-    fr-FR: Interrompre quand faux
     it-IT: Annulla quando è False
-    ja-JP: "「FALSE」の場合中止"
     pl-PL: Przerwij kiedy to fałsz
-    pt-BR: Anular Quando For Falso
-    zh-CN: 当为“假”时中止
   IGNORE_CONDITION:
     description: The execution of the action list is never interrupted.
     en-US: Ignore Condition
     es-ES: Ignorar condición
-    es-MX: Ignorar condición
-    fr-FR: Ignorer la condition
     it-IT: Ignora condizione
-    ja-JP: 条件無視
     pl-PL: Zignoruj warunek
-    pt-BR: Ignorar Condição
-    zh-CN: 无视条件
   RESTART_WHEN_TRUE:
     description: The execution of the action list restarts from the first action if
       the condition list transitions from false to true or if the rule's event occurs
       again with true conditions.
     en-US: Restart When True
     es-ES: Reiniciar cuando sea verdadero
-    es-MX: Reiniciar cuando es verdadero
-    fr-FR: Redémarrer quand vrai
     it-IT: Riparti quando è True
-    ja-JP: "「TRUE」の場合リスタート"
     pl-PL: Zrestartuj kiedy to prawda
-    pt-BR: Reiniciar Quando For Verdadeiro
-    zh-CN: 当为“真”时重新开始
 Barrier Line of Sight:
   BLOCKED_BY_ENEMY_BARRIERS:
     description: Line of sight is blocked by barriers created by the enemy team.
     en-US: Enemy Barriers Block LOS
-    es-MX: Las barreras enemigas bloquean la LDV
-    fr-FR: Les barrières ennemies bloquent la ligne de vue
-    ja-JP: 敵のバリアが射線を妨げる
-    pt-BR: Barreiras Inimigas Bloqueiam LdV
-    zh-CN: 敌方屏障阻挡视线
   BLOCKED_BY_ALL_BARRIERS:
     description: Line of sight is blocked by all barriers.
     en-US: All Barriers Block LOS
-    es-MX: Todas las barreras bloquean la LDV
-    fr-FR: Toutes les barrières bloquent la ligne de vue
-    ja-JP: すべてのバリアが射線を妨げる
-    pt-BR: Todas as Barreiras Bloqueiam LdV
-    zh-CN: 所有屏障阻挡视线
   PASS_THROUGH_BARRIERS:
     description: Line of sight is not blocked by any barriers.
     en-US: Barriers Do Not Block LOS
-    es-MX: Las barreras no bloquean la LDV
-    fr-FR: Les barrières ne bloquent pas la ligne de vue
-    ja-JP: バリアは射線を妨げない
-    pt-BR: Barreiras Não Bloqueiam LdV
-    zh-CN: 屏障不会阻挡视线
 Status:
   ASLEEP:
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Ana's sleep dart causes this status.
     en-US: Asleep
-    es-MX: Dormido
-    fr-FR: Endormi
-    ja-JP: 眠っている
-    pt-BR: Dormindo
-    zh-CN: 沉睡
   BURNING:
     description: The player is burning. For example, Ashe's dynamite causes this status.
     en-US: Burning
-    es-MX: En llamas
-    fr-FR: Enflammé
-    ja-JP: 燃焼中
-    pt-BR: Queimando
-    zh-CN: 点燃
   FROZEN:
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Mei's endothermic blaster causes this status.
     en-US: Frozen
-    es-MX: Congelado
-    fr-FR: Gelé
-    ja-JP: 凍っている
-    pt-BR: Congelado
-    zh-CN: 冻结
   HACKED:
     description: The player is unable to use abilities or ultimate abilities. Weapon
       attacks are unaffected. For example, Sombra can cause this status.
     en-US: Hacked
-    es-MX: Hackeado
-    fr-FR: Piraté
-    ja-JP: ハックされている
-    pt-BR: Hackeado
-    zh-CN: 被入侵
   INVINCIBLE:
     description: The player does not take damage.
     en-US: Invincible
-    es-MX: Invencible
-    ja-JP: 無敵
-    pt-BR: Invencível
-    zh-CN: 无敌
   KNOCKED_DOWN:
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Reinhardt's Earthshatter causes this status.
     en-US: Knocked Down
-    es-MX: Derribado
-    fr-FR: Renversé
-    ja-JP: ノックダウンされている
-    pt-BR: Nocauteado
-    zh-CN: 击倒
   PHASED_OUT:
     description: The player passes through other players and avoids all enemy attacks.
       For example, Reaper's wraith form causes this status.
     en-US: Phased Out
-    es-MX: Forma etérea
-    fr-FR: Déphasé
-    ja-JP: フェーズアウト中
-    pt-BR: Intangível
-    zh-CN: 消散
   ROOTED:
     description: The player cannot move unless moved by another player or object.
       Aiming is unaffected.
     en-US: Rooted
-    es-MX: Arraigado
-    fr-FR: Immobilisé
-    ja-JP: 固定されている
-    pt-BR: Enraizado
-    zh-CN: 定身
   STUNNED:
     description: The player cannot move, aim, or use weapons or abilities. For example,
       Cassidy's flashbang causes this status.
     en-US: Stunned
-    es-MX: Aturdido
-    fr-FR: Étourdi
-    ja-JP: スタンされている
-    pt-BR: Atordoado
-    zh-CN: 昏迷
   UNKILLABLE:
     description: The player's health will not drop below 1.
     en-US: Unkillable
-    es-MX: Inmortal
-    fr-FR: Intuable
-    ja-JP: キル不可
-    pt-BR: Imortal
-    zh-CN: 无法杀死
 Spectator Visibility:
   DEFAULT:
     description: Non-team spectators can see text when all players can see it.
     en-US: Default Visibility
-    es-MX: Visibilidad predeterminada
-    fr-FR: Visibilité par défaut
-    ja-JP: デフォルト表示
-    pt-BR: Visibilidade-padrão
-    zh-CN: 默认可见度
   ALWAYS:
     description: Non-team spectators can always see text.
     en-US: Visible Always
-    es-MX: Siempre visible
-    fr-FR: Toujours visible
-    ja-JP: 常に表示
-    pt-BR: Sempre Visível
-    zh-CN: 始终可见
   NEVER:
     description: Non-team spectators can never see text.
     en-US: Visible Never
-    es-MX: Nunca visible
-    fr-FR: Jamais visible
-    ja-JP: 表示されない
-    pt-BR: Nunca Visível
-    zh-CN: 始终不可见
 Beam:
   BAD:
     en-US: Bad Beam
-    es-MX: Rayo malo
-    fr-FR: Mauvais rayon
-    ja-JP: マイナス効果のビーム
-    pt-BR: Feixe Mau
-    zh-CN: 有害光束
   GOOD:
     en-US: Good Beam
-    es-MX: Rayo bueno
-    fr-FR: Bon rayon
-    ja-JP: プラス効果のビーム
-    pt-BR: Feixe Bom
-    zh-CN: 有益光束
   GRAPPLE:
     en-US: Grapple Beam
-    es-MX: Rayo de arpeo
-    fr-FR: Rayon du grappin
-    ja-JP: グラップリング・ビーム
-    pt-BR: Feixe de Arpéu
-    zh-CN: 抓钩光束
 Throttle:
   REPLACE_EXISTING:
     en-US: Replace existing throttle
-    es-MX: Reemplazar aceleración preexistente
-    fr-FR: Remplacer l’accélération existante
-    ja-JP: 既存のスロットルと入れ替え
-    pt-BR: Substituir a aceleração existente
-    zh-CN: 替换现有阈值
   ADD_TO_EXISTING:
     en-US: Add to existing throttle
-    es-MX: Agregar a aceleración preexistente
-    fr-FR: Ajouter à l’accélération existante
-    ja-JP: 既存のスロットルに追加
-    pt-BR: Somar à aceleração existente
-    zh-CN: 添加至现有阈值
 Throttle Reevaluation:
   DIRECTION_AND_MAGNITUDE:
     en-US: Direction and Magnitude
-    es-MX: Dirección y magnitud
-    fr-FR: Direction et ampleur
-    ja-JP: 方向と変化の大きさ
-    pt-BR: Direção e Magnitude
-    zh-CN: 方向和幅度
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Nenhum
-    zh-CN: 无
 Acceleration Reevaluation:
   DIRECTION_RATE_AND_MAX_SPEED:
     en-US: Direction Rate and Max Speed
-    es-MX: Dirección aceleración y velocidad máxima
-    fr-FR: Direction Taux et Vitesse maximum
-    ja-JP: 方向、レート、最大の速さ
-    pt-BR: Direção Taxa e Velocidade Máx.
-    zh-CN: 方向，速率，及最大速度
   NONE:
     en-US: None
-    es-MX: Ninguno
-    fr-FR: Aucune
-    ja-JP: なし
-    pt-BR: Ninguém
-    zh-CN: 无
 Async Behavior:
   RESTART:
     description: Restart the specified rule with new contextual values (including
       event player, attacker, victim, etc).
     en-US: Restart Rule
-    es-MX: Reiniciar regla
-    fr-FR: Relancer la règle
-    ja-JP: ルールをやり直す
-    pt-BR: Regra de reinício
-    zh-CN: 重新开始规则
   NOOP:
     description: Allow the rule to finish executing without changing its contextual
       values.
     en-US: Do Nothing
-    es-MX: Hacer nada
-    fr-FR: Ne rien faire
-    ja-JP: 何もしない
-    pt-BR: Não fazer nada
-    zh-CN: 无动作
 Operator:
   "==":
     en-US: "=="
-    fr-FR: "== égal à"
-    ja-JP: " =="
   "!=":
     en-US: "!="
-    fr-FR: "!= différent de"
   "<=":
     en-US: "<="
-    fr-FR: "<= inférieur ou égal à"
   ">=":
     en-US: ">="
-    fr-FR: ">= supérieur ou égal à"
   "<":
     en-US: "<"
-    fr-FR: "< inférieur à"
   ">":
     en-US: ">"
-    fr-FR: "> supérieur à"
 
 Health:
   NORMAL:

--- a/config/arrays/wiki/events.yml
+++ b/config/arrays/wiki/events.yml
@@ -1,5 +1,4 @@
 global:
-  guid: 000000007895
   en-US: Ongoing - Global
   es-MX: En curso - Global
   fr-FR: Toute la partie - Tout le monde
@@ -7,7 +6,6 @@ global:
   pt-BR: Em andamento - Global
   zh-CN: 持续 - 全局
 eachPlayer:
-  guid: 000000007897
   en-US: Ongoing - Each Player
   es-MX: En curso - Cada jugador
   fr-FR: Toute la partie - Chaque joueur
@@ -15,7 +13,6 @@ eachPlayer:
   pt-BR: Em andamento - Cada Jogador
   zh-CN: 持续 - 每名玩家
 playerTookDamage:
-  guid: 00000000B313
   en-US: Player Took Damage
   es-MX: El jugador recibió daño
   fr-FR: Un joueur subit des dégâts
@@ -24,7 +21,6 @@ playerTookDamage:
   ru-RU: Player took damage
   zh-CN: 玩家受到伤害
 playerDealtDamage:
-  guid: 00000000B52D
   en-US: Player Dealt Damage
   es-MX: El jugador infligió daño
   fr-FR: Un joueur inflige des dégâts
@@ -33,7 +29,6 @@ playerDealtDamage:
   ru-RU: Player dealt damage
   zh-CN: 玩家造成伤害
 playerDealtFinalBlow:
-  guid: 0000000078F8
   en-US: Player Dealt Final Blow
   es-MX: El jugador asestó un golpe de gracia
   fr-FR: Un joueur inflige un coup de grâce
@@ -42,7 +37,6 @@ playerDealtFinalBlow:
   ru-RU: Player dealt final blow
   zh-CN: 玩家造成最后一击
 playerDied:
-  guid: 00000000B314
   en-US: Player Died
   es-MX: El jugador murió
   fr-FR: Un joueur meurt
@@ -50,7 +44,6 @@ playerDied:
   pt-BR: Jogador morreu
   zh-CN: 玩家阵亡
 playerEarnedElimination:
-  guid: 0000000078F7
   en-US: Player Earned Elimination
   es-MX: El jugador obtuvo una eliminación
   fr-FR: Un joueur obtient une élimination
@@ -59,7 +52,6 @@ playerEarnedElimination:
   ru-RU: Player earned elimination
   zh-CN: 玩家参与消灭
 playerDealtHealing:
-  guid: 00000000CC16
   en-US: Player Dealt Healing
   es-MX: El jugador realizó una sanación
   fr-FR: Un joueur a prodigué des soins
@@ -67,7 +59,6 @@ playerDealtHealing:
   pt-BR: Jogador Realizou Cura
   zh-CN: 玩家造成治疗
 playerReceivedHealing:
-  guid: 00000000CC17
   en-US: Player Received Healing
   es-MX: El jugador recibió una sanación
   fr-FR: Un joueur a reçu des soins
@@ -75,7 +66,6 @@ playerReceivedHealing:
   pt-BR: Jogador Recebeu Cura
   zh-CN: 玩家受到治疗
 playerJoined:
-  guid: 00000000CC18
   en-US: Player Joined Match
   es-MX: El jugador se unió a la partida
   fr-FR: Un joueur a rejoint la partie
@@ -83,7 +73,6 @@ playerJoined:
   pt-BR: Jogador Entrou na Partida
   zh-CN: 玩家加入比赛
 playerLeft:
-  guid: 00000000CC19
   en-US: Player Left Match
   es-MX: El jugador abandonó la partida
   fr-FR: Un joueur a quitté la partie
@@ -91,7 +80,6 @@ playerLeft:
   pt-BR: Jogador Saiu da Partida
   zh-CN: 玩家离开比赛
 __subroutine__:
-  guid: 00000000FFF6
   en-US: Subroutine
   es-ES: Subrutina
   es-MX: Subrutina
@@ -100,7 +88,6 @@ __subroutine__:
   pt-BR: Sub-rotina
   zh-CN: 子程序
 playerDealtKnockback:
-  guid: 0000000105BB
   en-US: Player Dealt Knockback
   es-ES: Repulsión infligida por el jugador
   es-MX: El jugador infligió un derribo
@@ -109,7 +96,6 @@ playerDealtKnockback:
   pt-BR: Jogador Causou Repulsão
   zh-CN: 玩家造成击退
 playerReceivedKnockback:
-  guid: 0000000105BC
   en-US: Player Received Knockback
   es-ES: Repulsión sufrida por el jugador
   es-MX: El jugador recibió un derribo

--- a/config/arrays/wiki/events.yml
+++ b/config/arrays/wiki/events.yml
@@ -1,105 +1,31 @@
 global:
   en-US: Ongoing - Global
-  es-MX: En curso - Global
-  fr-FR: Toute la partie - Tout le monde
-  ja-JP: 進行中 - グローバル
-  pt-BR: Em andamento - Global
-  zh-CN: 持续 - 全局
 eachPlayer:
   en-US: Ongoing - Each Player
-  es-MX: En curso - Cada jugador
-  fr-FR: Toute la partie - Chaque joueur
-  ja-JP: 進行中 - 各プレイヤー
-  pt-BR: Em andamento - Cada Jogador
-  zh-CN: 持续 - 每名玩家
 playerTookDamage:
   en-US: Player Took Damage
-  es-MX: El jugador recibió daño
-  fr-FR: Un joueur subit des dégâts
-  ja-JP: プレイヤーがダメージを受けた
-  pt-BR: Jogador Recebeu Dano
-  ru-RU: Player took damage
-  zh-CN: 玩家受到伤害
 playerDealtDamage:
   en-US: Player Dealt Damage
-  es-MX: El jugador infligió daño
-  fr-FR: Un joueur inflige des dégâts
-  ja-JP: プレイヤーがダメージを与えた
-  pt-BR: Jogador Causou Dano
-  ru-RU: Player dealt damage
-  zh-CN: 玩家造成伤害
 playerDealtFinalBlow:
   en-US: Player Dealt Final Blow
-  es-MX: El jugador asestó un golpe de gracia
-  fr-FR: Un joueur inflige un coup de grâce
-  ja-JP: ファイナル・ブロウを獲得
-  pt-BR: Jogador Desferiu Golpe Final
-  ru-RU: Player dealt final blow
-  zh-CN: 玩家造成最后一击
 playerDied:
   en-US: Player Died
-  es-MX: El jugador murió
-  fr-FR: Un joueur meurt
-  ja-JP: プレイヤーが倒れた
-  pt-BR: Jogador morreu
-  zh-CN: 玩家阵亡
 playerEarnedElimination:
   en-US: Player Earned Elimination
-  es-MX: El jugador obtuvo una eliminación
-  fr-FR: Un joueur obtient une élimination
-  ja-JP: プレイヤーがキルを獲得
-  pt-BR: Jogador Conseguiu Eliminação
-  ru-RU: Player earned elimination
-  zh-CN: 玩家参与消灭
 playerDealtHealing:
   en-US: Player Dealt Healing
-  es-MX: El jugador realizó una sanación
-  fr-FR: Un joueur a prodigué des soins
-  ja-JP: プレイヤーが回復を与えた
-  pt-BR: Jogador Realizou Cura
-  zh-CN: 玩家造成治疗
 playerReceivedHealing:
   en-US: Player Received Healing
-  es-MX: El jugador recibió una sanación
-  fr-FR: Un joueur a reçu des soins
-  ja-JP: プレイヤーが回復を受けた
-  pt-BR: Jogador Recebeu Cura
-  zh-CN: 玩家受到治疗
 playerJoined:
   en-US: Player Joined Match
-  es-MX: El jugador se unió a la partida
-  fr-FR: Un joueur a rejoint la partie
-  ja-JP: プレイヤーがマッチに参加
-  pt-BR: Jogador Entrou na Partida
-  zh-CN: 玩家加入比赛
 playerLeft:
   en-US: Player Left Match
-  es-MX: El jugador abandonó la partida
-  fr-FR: Un joueur a quitté la partie
-  ja-JP: プレイヤーがマッチから離脱
-  pt-BR: Jogador Saiu da Partida
-  zh-CN: 玩家离开比赛
 __subroutine__:
   en-US: Subroutine
   es-ES: Subrutina
-  es-MX: Subrutina
-  fr-FR: Sous-programme
-  ja-JP: サブルーチン
-  pt-BR: Sub-rotina
-  zh-CN: 子程序
 playerDealtKnockback:
   en-US: Player Dealt Knockback
   es-ES: Repulsión infligida por el jugador
-  es-MX: El jugador infligió un derribo
-  fr-FR: Un joueur a infligé un recul
-  ja-JP: プレイヤーがノックバックを与えた
-  pt-BR: Jogador Causou Repulsão
-  zh-CN: 玩家造成击退
 playerReceivedKnockback:
   en-US: Player Received Knockback
   es-ES: Repulsión sufrida por el jugador
-  es-MX: El jugador recibió un derribo
-  fr-FR: Un joueur a reçu un recul
-  ja-JP: プレイヤーがノックバックを受けた
-  pt-BR: Jogador Recebeu Repulsão
-  zh-CN: 玩家受到击退

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -219,7 +219,7 @@ angleDifference:
     description: One of the two angles between which to measure the resulting angle.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Angle Difference
 __concat__:
   description: A copy of an array with one or more values appended to the end.
@@ -245,7 +245,7 @@ acosDeg:
     description: Input value for the function.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Arccosine In Degrees
 acos:
   description: Arccosine in radians of the specified value.
@@ -254,7 +254,7 @@ acos:
     description: Input value for the function.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Arccosine In Radians
 asinDeg:
   description: Arcsine in degrees of the specified value.
@@ -263,7 +263,7 @@ asinDeg:
     description: Input value for the function.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Arcsine In Degrees
 asin:
   description: Arcsine in radians of the specified value.
@@ -272,7 +272,7 @@ asin:
     description: Input value for the function.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Arcsine In Radians
 atan2Deg:
   description: Arctangent in degrees of the specified numerator and denominator (often
@@ -286,7 +286,7 @@ atan2Deg:
     description: Denominator input for the function.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Arctangent In Degrees
 atan2:
   description: Arctangent in radians of the specified numerator and denominator (often
@@ -300,7 +300,7 @@ atan2:
     description: Denominator input for the function.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Arctangent In Radians
 __array__:
   description: An array constructed from the listed values.
@@ -434,7 +434,7 @@ cosDeg:
     description: Angle in degrees.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Cosine From Degrees
 cos:
   description: Cosine of the specified angle in radians.
@@ -443,7 +443,7 @@ cos:
     description: Angle in radians.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Cosine From Radians
 len:
   description: The number of elements in the specified array.
@@ -587,7 +587,7 @@ dotProduct:
     description: One of two vector operands of the dot product.
     type: Vector
     default: Vector
-  return: float
+  return: Float
   en-US: Dot Product
 Vector.DOWN:
   description: Shorthand for the directional vector(0, -1, 0), which points downward.
@@ -859,7 +859,7 @@ horizontalAngleFromDirection:
       degrees. The vector is unitized before calculation begins.
     type: Direction
     default: Vector
-  return: float
+  return: Float
   en-US: Horizontal Angle From Direction
 horizontalAngleTowards:
   description: The horizontal angle in degrees from a player's current forward direction
@@ -874,7 +874,7 @@ horizontalAngleTowards:
     description: The position in the world where the angle ends.
     type: Position
     default: Vector
-  return: float
+  return: Float
   en-US: Horizontal Angle Towards
 __gamemode__:
   description: A game mode constant.
@@ -894,7 +894,7 @@ _&getHorizontalFacingAngle:
     description: The player whose horizontal facing angle to acquire.
     type: Player
     default: Event Player
-  return: float
+  return: Float
   en-US: Horizontal Facing Angle Of
 _&getHorizontalSpeed:
   description: The current horizontal speed of a player in meters per second. This
@@ -1507,7 +1507,7 @@ max:
     description: The right-hand operand. May be any value that results in a number.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Max
 _&getMaxHealth:
   description: The max health of a player, including armor and shields.
@@ -1529,7 +1529,7 @@ min:
     description: The right-hand operand. May be any value that results in a number.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Min
 __modulo__:
   description: The remainder of the left-hand operand divided by the right-hand operand.
@@ -1543,7 +1543,7 @@ __modulo__:
     description: The right-hand operand. May be any value that results in a number.
     type: Float
     default: Number
-  return: float
+  return: Float
   en-US: Modulo
 __multiply__:
   description: The product of two numbers or vectors. A vector multiplied by a number
@@ -1855,7 +1855,7 @@ getCapturePercentage:
   description: The current progress towards capture for the active control point (expressed
     as a percentage).
   args: []
-  return: float
+  return: Float
   en-US: Point Capture Percentage
 _&getPosition:
   description: The current position of a player as a vector.
@@ -1906,7 +1906,7 @@ random.uniform:
     description: The largest real number allowed.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Random Real
 random.choice:
   description: A random value from the specified array.
@@ -2104,7 +2104,7 @@ sinDeg:
     description: Angle in degrees.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Sine From Degrees
 sin:
   description: Sine of the specified angle in radians.
@@ -2113,7 +2113,7 @@ sin:
     description: Angle in radians.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Sine From Radians
 _&getSlot:
   description: The slot number of the specified player. In team games, each team has
@@ -2241,7 +2241,7 @@ tanDeg:
     description: Angle in degrees.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Tangent From Degrees
 tan:
   description: Tangent of the specified angle in radians.
@@ -2250,7 +2250,7 @@ tan:
     description: Angle in radians.
     type: float
     default: Number
-  return: float
+  return: Float
   en-US: Tangent From Radians
 _&getTeam:
   description: The team of a player. If the game mode is free-for-all, the team is
@@ -2379,7 +2379,7 @@ verticalAngleOfDirection:
       The vector is unitized before calculation begins.
     type: Direction
     default: Vector
-  return: float
+  return: Float
   en-US: Vertical Angle From Direction
 verticalAngleTowards:
   description: The vertical angle in degrees from a player's current forward direction
@@ -2394,7 +2394,7 @@ verticalAngleTowards:
     description: The position in the world where the angle ends.
     type: Position
     default: Vector
-  return: float
+  return: Float
   en-US: Vertical Angle Towards
 _&getVerticalFacingAngle:
   description: The vertical angle in degrees of a player's current facing relative
@@ -2404,7 +2404,7 @@ _&getVerticalFacingAngle:
     description: The player whose vertical facing angle to acquire.
     type: Player
     default: Event Player
-  return: float
+  return: Float
   en-US: Vertical Facing Angle Of
 _&getVerticalSpeed:
   description: The current vertical speed of a player in meters per second. This measurement
@@ -2450,7 +2450,7 @@ __xComponentOf__:
     description: The vector from which to acquire the x component.
     type: Vector
     default: Vector
-  return: float
+  return: Float
   en-US: X Component Of
 __yComponentOf__:
   description: The y component of the specified vector, usually representing an upward
@@ -2460,7 +2460,7 @@ __yComponentOf__:
     description: The vector from which to acquire the y component.
     type: Vector
     default: Vector
-  return: float
+  return: Float
   en-US: Y Component Of
 __zComponentOf__:
   description: The z component of the specified vector, usually representing a forward
@@ -2470,7 +2470,7 @@ __zComponentOf__:
     description: The vector from which to acquire the z component.
     type: Vector
     default: Vector
-  return: float
+  return: Float
   en-US: Z Component Of
 _&getAbilityCharge:
   description: The ability charge count for a player associated by button.
@@ -2652,7 +2652,7 @@ workshopSettingReal:
     type: IntLiteral
     default: 0
   isConstant: true
-  return: float
+  return: Float
   en-US: Workshop Setting Real
 workshopSettingInteger:
   description: Provides the value of a new integer setting that will appear in the

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -9,7 +9,7 @@ _&getAbilityCooldown:
     description: The ability to check associated by button.
     type: Button
     default: Button
-  return: unsigned float
+  return: Float
   guid: 0000000109B3
   en-US: Ability Cooldown
   es-MX: Reutilización de habilidad
@@ -44,7 +44,7 @@ abs:
     description: The real number value whose absolute value will be computed.
     type: float
     default: Number
-  return: unsigned float
+  return: Float
   guid: 00000000C358
   en-US: Absolute Value
   es-MX: Valor absoluto
@@ -257,7 +257,7 @@ _&getAltitude:
     description: The player whose altitude to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 00000000B11D
   en-US: Altitude Of
   es-MX: Altitud de
@@ -300,7 +300,7 @@ angleBetweenVectors:
       in degrees. This vector does not need to be pre-normalized.
     type: Direction
     default: Vector
-  return: unsigned float
+  return: Float
   guid: 00000000C813
   en-US: Angle Between Vectors
   es-MX: Ángulo entre vectores
@@ -504,13 +504,13 @@ __arraySlice__:
     default: All Players
   - name: Start Index
     description: The first index of the range.
-    type: unsigned int
+    type: Integer
     default: Number
   - name: Count
     description: The number of elements in the resulting array. The resulting array
       will contain fewer elements if the specified range exceeds the bounds of the
       array.
-    type: unsigned int
+    type: Integer
     default: Number
   return:
     Array: Object
@@ -539,9 +539,9 @@ Vector.Backward:
   args:
   return:
     Direction:
-    - unsigned int
-    - unsigned int
-    - signed int
+    - Integer
+    - Integer
+    - Integer
   en-US: Backward
   es-MX: Atrás
   fr-FR: Arrière
@@ -618,7 +618,7 @@ getControlScorePercentage:
     description: The team whose score percentage to acquire.
     type: Team
     default: Team
-  return: unsigned float
+  return: Float
   guid: 00000000B37C
   en-US: Control Mode Scoring Percentage
   es-MX: Porcentaje de puntuación en el modo Control
@@ -675,7 +675,7 @@ len:
     description: The array whose elements will be counted.
     type: Array
     default: Global Variable
-  return: unsigned int
+  return: Integer
   guid: 00000000B26E
   en-US: Count Of
   es-MX: Conteo de
@@ -822,7 +822,7 @@ distance:
     description: One of the two positions used in the distance measurement.
     type: Position
     default: Vector
-  return: unsigned float
+  return: Float
   guid: 00000000B1E7
   en-US: Distance Between
   es-MX: Distancia entre
@@ -884,9 +884,9 @@ Vector.DOWN:
   args:
   return:
     Direction:
-    - unsigned int
-    - signed int
-    - unsigned int
+    - Integer
+    - Integer
+    - Integer
   en-US: Down
   es-MX: Abajo
   fr-FR: Bas
@@ -938,7 +938,7 @@ eventDamage:
   description: The amount of damage received by the victim for the event currently
     being processed by this rule.
   args:
-  return: unsigned float
+  return: Float
   guid: 00000000C635
   en-US: Event Damage
   es-MX: Daño de evento
@@ -962,7 +962,7 @@ eventHealing:
   description: The amount of healing received by the healee for the event currently
     being processed by this rule.
   args:
-  return: unsigned float
+  return: Float
   guid: 00000000CC33
   en-US: Event Healing
   es-MX: Sanación de evento
@@ -1126,9 +1126,9 @@ Vector.Forward:
   args:
   return:
     Direction:
-    - unsigned int
-    - unsigned int
-    - unsigned int
+    - Integer
+    - Integer
+    - Integer
   en-US: Forward
   es-MX: Adelante
   fr-FR: Avant
@@ -1230,7 +1230,7 @@ _&getHealth:
     description: The player whose health to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   en-US: Health
   es-MX: Salud
   fr-FR: Points de vie
@@ -1246,7 +1246,7 @@ _&getNormalizedHealth:
     description: The player whose normalized health to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 0000000081C3
   en-US: Normalized Health
   es-MX: Salud normalizada
@@ -1393,7 +1393,7 @@ _&getHorizontalSpeed:
     description: The player whose horizontal speed to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 00000000B25E
   en-US: Horizontal Speed Of
   es-MX: Velocidad horizontal de
@@ -1469,7 +1469,7 @@ __indexOfArrayValue__:
     description: The value for which to search.
     type: Object
     default: Number
-  return: int
+  return: Integer
   guid: 00000000C330
   en-US: Index Of Array Value
   es-MX: Índice del valor de la matriz
@@ -1956,7 +1956,7 @@ isObjectiveComplete:
     description: The index of the objective to consider, starting at 0 and counting
       up. Each control point, payload checkpoint, and payload destination has its
       own index.
-    type: unsigned int
+    type: Integer
     default: Number
   return: bool
   guid: 00000000B378
@@ -2272,9 +2272,9 @@ Vector.Left:
   args:
   return:
     Direction:
-    - unsigned int
-    - unsigned int
-    - unsigned int
+    - Integer
+    - Integer
+    - Integer
   en-US: Left
   es-MX: Izquierda
   fr-FR: Gauche
@@ -2330,7 +2330,7 @@ __map__:
 getMatchRound:
   description: The current round of the match, counting up from 1.
   args: []
-  return: unsigned int
+  return: Integer
   guid: 00000000B375
   en-US: Match Round
   es-MX: Ronda de la partida
@@ -2341,7 +2341,7 @@ getMatchRound:
 getMatchTime:
   description: The amount of time in seconds remaining in the current game mode phase.
   args: []
-  return: unsigned float
+  return: Float
   guid: 00000000AD3B
   en-US: Match Time
   es-MX: Tiempo de la partida
@@ -2375,7 +2375,7 @@ _&getMaxHealth:
     description: The player whose max health to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 0000000081C4
   en-US: Max Health
   es-MX: Salud máxima
@@ -2516,7 +2516,7 @@ getNumberOfDeadPlayers:
     description: The team or teams on which to count players.
     type: Team
     default: Team
-  return: unsigned int
+  return: Integer
   guid: 00000000B29A
   en-US: Number of Dead Players
   es-MX: Cantidad de jugadores muertos
@@ -2532,7 +2532,7 @@ _&getNumberOfDeaths:
     description: The player whose death count to acquire.
     type: Player
     default: Event Player
-  return: unsigned int
+  return: Integer
   guid: 00000000B103
   en-US: Number of Deaths
   es-MX: Cantidad de muertes
@@ -2548,7 +2548,7 @@ _&getNumberOfElims:
     description: The player whose elimination count to acquire.
     type: Player
     default: Event Player
-  return: unsigned int
+  return: Integer
   guid: 00000000B101
   en-US: Number of Eliminations
   es-MX: Cantidad de eliminaciones
@@ -2564,7 +2564,7 @@ _&getNumberOfFinalBlows:
     description: The player whose final blow count to acquire.
     type: Player
     default: Event Player
-  return: unsigned int
+  return: Integer
   guid: 00000000B102
   en-US: Number of Final Blows
   es-MX: Cantidad de golpes de gracia
@@ -2583,7 +2583,7 @@ getNumberOfHeroes:
     description: The team or teams on which to check for the hero being played.
     type: Team
     default: Team
-  return: unsigned int
+  return: Integer
   guid: 00000000B296
   en-US: Number of Heroes
   es-MX: Cantidad de héroes
@@ -2598,7 +2598,7 @@ getNumberOfLivingPlayers:
     description: The team or teams on which to count players.
     type: Team
     default: Team
-  return: unsigned int
+  return: Integer
   guid: 00000000B297
   en-US: Number of Living Players
   es-MX: Cantidad de jugadores vivos
@@ -2613,7 +2613,7 @@ getNumberOfPlayers:
     description: The team or teams on which to count players.
     type: Team
     default: Team
-  return: unsigned int
+  return: Integer
   guid: 00000000B295
   en-US: Number of Players
   es-MX: Cantidad de jugadores
@@ -2629,7 +2629,7 @@ getNumberOfPlayersOnObjective:
     description: The team or teams on which to count players.
     type: Team
     default: Team
-  return: unsigned int
+  return: Integer
   guid: 00000000B29B
   en-US: Number of Players On Objective
   es-MX: Cantidad de jugadores en el objetivo
@@ -2641,7 +2641,7 @@ getCurrentObjective:
   description: The control point, payload checkpoint, or payload destination currently
     active (either 0, 1, or 2). Valid in assault, assault/escort, escort, and control.
   args: []
-  return: unsigned int
+  return: Integer
   guid: 00000000B37D
   en-US: Objective Index
   es-MX: Índice de objetivo
@@ -2658,9 +2658,9 @@ getObjectivePosition:
     description: The index of the objective to consider, starting at 0 and counting
       up. Each control point, payload checkpoint, and payload destination has its
       own index.
-    type: unsigned int
+    type: Integer
     default: Number
-  return: unsigned int
+  return: Integer
   guid: 00000000B355
   en-US: Objective Position
   es-MX: Posición del objetivo
@@ -2719,7 +2719,7 @@ getPayloadProgressPercentage:
   description: The current progress towards the destination for the active payload
     (expressed as a percentage).
   args: []
-  return: unsigned float
+  return: Float
   guid: 00000000B357
   en-US: Payload Progress Percentage
   es-MX: Porcentaje de progreso de la carga
@@ -2790,7 +2790,7 @@ getPlayersInSlot:
     description: The slot number from which to acquire a player or players. In team
       games, each team has slots 0 through 5. In free-for-all games, slots are numbered
       0 through 11.
-    type: unsigned int
+    type: Integer
     default: Number
   - name: Team
     description: The team or teams from which to acquire a player or players.
@@ -2923,7 +2923,7 @@ __raiseToPower__:
     description: The right-hand operand. May be any value that results in a number.
     type: float
     default: Number
-  return: unsigned float
+  return: Float
   en-US: Raise To Power
   es-MX: Elevar a la potencia
   fr-FR: 'Élévation à une puissance '
@@ -2936,14 +2936,14 @@ random.randint:
   - name: Min
     description: The smallest integer allowed. If a real number is provided to this
       input, it is rounded to the nearest integer.
-    type: int
+    type: Integer
     default: Number
   - name: Max
     description: The largest integer allowed. If a real number is provided to this
       input, it is rounded to the nearest integer.
-    type: int
+    type: Integer
     default: Number
-  return: int
+  return: Integer
   guid: 00000000B59B
   en-US: Random Integer
   es-MX: Número entero aleatorio
@@ -3146,9 +3146,9 @@ Vector.RIGHT:
   args:
   return:
     Direction:
-    - signed int
-    - unsigned int
-    - unsigned int
+    - Integer
+    - Integer
+    - Integer
   en-US: Right
   es-MX: Derecha
   fr-FR: Droite
@@ -3166,7 +3166,7 @@ __round__:
     description: Determines the direction in which the value will be rounded.
     type: __Rounding__
     default: UP
-  return: int
+  return: Integer
   guid: 00000000C354
   en-US: Round To Integer
   es-MX: Redondear a número entero
@@ -3182,7 +3182,7 @@ _&getScore:
     description: The player whose score to acquire.
     type: Player
     default: Event Player
-  return: int
+  return: Integer
   guid: 00000000AD3C
   en-US: Score Of
   es-MX: Puntuación de
@@ -3196,7 +3196,7 @@ getServerLoad:
     instance. As this number approaches or exceeds 100, it becomes increasingly likely
     that the instance will be shut down because it is consuming too many resources.
   args: []
-  return: unsigned float
+  return: Float
   en-US: Server Load
   es-MX: Uso del servidor
   fr-FR: Charge du serveur
@@ -3210,7 +3210,7 @@ getAverageServerLoad:
     100, it becomes increasingly likely that the instance will be shut down because
     it is consuming too many resources.
   args: []
-  return: unsigned float
+  return: Float
   en-US: Server Load Average
   es-MX: Uso promedio del servidor
   fr-FR: Charge moyenne du serveur
@@ -3224,7 +3224,7 @@ getPeakServerLoad:
     100, it becomes increasingly likely that the instance will be shut down because
     it is consuming too many resources.
   args: []
-  return: unsigned float
+  return: Float
   en-US: Server Load Peak
   es-MX: Uso máximo del servidor
   fr-FR: Pic de charge du serveur
@@ -3269,7 +3269,7 @@ _&getSlot:
     description: The player whose slot number to acquire.
     type: Player
     default: Event Player
-  return: unsigned int
+  return: Integer
   guid: 00000000BB7F
   en-US: Slot Of
   es-MX: Posición de
@@ -3323,7 +3323,7 @@ _&getSpeed:
     description: The player whose speed to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 00000000B25D
   en-US: Speed Of
   es-MX: Velocidad de
@@ -3343,7 +3343,7 @@ _&getSpeedInDirection:
     description: The direction of travel in which to measure the player's speed.
     type: Direction
     default: Vector
-  return: unsigned float
+  return: Float
   guid: 00000000B260
   en-US: Speed Of In Direction
   es-MX: Velocidad de/en dirección
@@ -3359,7 +3359,7 @@ sqrt:
       values result in zero.
     type: unsigned float
     default: Number
-  return: unsigned float
+  return: Float
   guid: 00000000C356
   en-US: Square Root
   es-MX: Raíz cuadrada
@@ -3476,7 +3476,7 @@ teamScore:
     description: The team whose score to acquire.
     type: Team
     default: Team
-  return: int
+  return: Integer
   en-US: Team Score
   es-MX: Puntuación del equipo
   fr-FR: Score de l’équipe
@@ -3504,7 +3504,7 @@ getTotalTimeElapsed:
   description: The total time in seconds that have elapsed since the game instance
     was created (including setup time and transitions).
   args: []
-  return: unsigned float
+  return: Float
   guid: 00000000B361
   en-US: Total Time Elapsed
   es-MX: Tiempo total transcurrido
@@ -3528,7 +3528,7 @@ _&getUltCharge:
     description: The player whose ultimate charge percentage to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 0000000081C5
   en-US: Ultimate Charge Percent
   es-MX: Porcentaje de carga de la habilidad máxima
@@ -3542,9 +3542,9 @@ Vector.UP:
   args:
   return:
     Direction:
-    - unsigned int
-    - unsigned int
-    - unsigned int
+    - Integer
+    - Integer
+    - Integer
   en-US: Up
   es-MX: Arriba
   fr-FR: Haut
@@ -3561,7 +3561,7 @@ __valueInArray__:
     default: Global Variable
   - name: Index
     description: The index of the element to acquire.
-    type: unsigned int
+    type: Integer
     default: Number
   return:
   - Object
@@ -3694,7 +3694,7 @@ _&getVerticalSpeed:
     description: The player whose vertical speed to acquire.
     type: Player
     default: Event Player
-  return: unsigned float
+  return: Float
   guid: 00000000B25F
   en-US: Vertical Speed Of
   es-MX: Velocidad vertical de
@@ -3799,7 +3799,7 @@ _&getAbilityCharge:
     description: The ability to check associated by button.
     type: Button
     default: Button
-  return: unsigned int
+  return: Integer
   en-US: Ability Charge
 _&getAbilityResource:
   description: The ability resource percent for a player associated by button.
@@ -3812,7 +3812,7 @@ _&getAbilityResource:
     description: The ability to check associated by button.
     type: Button
     default: Button
-  return: unsigned float
+  return: Float
   en-US: Ability Resource
 _&getAmmo:
   description: The current ammo of a player.
@@ -3823,9 +3823,9 @@ _&getAmmo:
     default: Event Player
   - name: Clip
     description: The index of the clip to be acquired. 0 is the first clip, and 1 is the second. If the specified type does not exist, this will return 0.
-    type: unsigned int
+    type: Integer
     default: 0
-  return: unsigned float
+  return: Float
   en-US: Ammo
 eventWasEnvironment:
   description: Whether the elimination was due to the environment for the event currently
@@ -3846,7 +3846,7 @@ _&getHealthOfType:
     description: The type of health to acquire.
     type: Health
     default: Health
-  return: unsigned float
+  return: Float
   en-US: Health of Type
 buttonString:
   description: Converts a button parameter into a string that shows up based on the
@@ -3882,9 +3882,9 @@ _&getMaxAmmo:
     default: Event Player
   - name: Clip
     description: The index of the clip to be acquired. 0 is the first clip, and 1 is the second. If the specified type does not exist, this will return 0.
-    type: unsigned int
+    type: Integer
     default: 0
-  return: unsigned float
+  return: Float
   en-US: Max Ammo
 _&getMaxHealthOfType:
   guid: 0000000081C2
@@ -3899,7 +3899,7 @@ _&getMaxHealthOfType:
     description: The type of max health to acquire.
     type: Health
     default: Health
-  return: unsigned float
+  return: Float
   en-US: Max Health of Type
 _&getCurrentWeapon:
   description: The currently held weapon of a player. Returns 2 for Baby Dva's gun,
@@ -3909,7 +3909,7 @@ _&getCurrentWeapon:
     description: The player whose weapon to acquire.
     type: Player
     default: Event Player
-  return: unsigned int
+  return: Integer
   en-US: Weapon
 Color:
   description: A Color Constant
@@ -4007,7 +4007,7 @@ workshopSettingInteger:
     type: IntLiteral
     default: 0
   isConstant: true
-  return: int
+  return: Integer
   guid: '000000011375'
   en-US: Workshop Setting Integer
   es-MX: Número entero de la configuración del Workshop
@@ -4111,7 +4111,7 @@ MagnitudeOf:
   - name: Value
     description: The Vector operand of the magnitude operation.
     default: Vector
-  return: unsigned float
+  return: Float
   en-US: Magnitude Of
 NumberofSlots:
   description: The number of Slots on a Team or in the match.

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -2413,7 +2413,7 @@ __modulo__:
     default: Number
   - name: Value
     description: The right-hand operand. May be any value that results in a number.
-    type: unsigned float
+    type: Float
     default: Number
   return: float
   en-US: Modulo
@@ -2862,7 +2862,7 @@ getPlayersInRadius:
   - name: Radius
     description: The radius in meters inside which players must be in order to be
       included in the resulting array.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Team
     description: The team or teams to which a player must belong to be included in
@@ -2917,7 +2917,7 @@ __raiseToPower__:
   args:
   - name: Value
     description: The left-hand operand. May be any value that results in a number.
-    type: unsigned float
+    type: Float
     default: Number
   - name: Value
     description: The right-hand operand. May be any value that results in a number.
@@ -3357,7 +3357,7 @@ sqrt:
   - name: Value
     description: The real number value whose square root will be computed. Negative
       values result in zero.
-    type: unsigned float
+    type: Float
     default: Number
   return: Float
   guid: 00000000C356

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -1,14 +1,14 @@
 _&getAbilityCooldown:
   description: The ability cooldown time in seconds for a player associated by button.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ability to check.
     type: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The ability to check associated by button.
     type: Button
-    default: BUTTON
+    default: Button
   return: unsigned float
   guid: 0000000109B3
   en-US: Ability Cooldown
@@ -21,10 +21,10 @@ abilityIconString:
   description: Converts a Hero and Button parameter into a string that shows up as
     an icon (up to 4 per string).
   args:
-  - name: HERO
+  - name: Hero
     description: The hero for the ability that will be converted to an icon.
     type: Hero
-    default: HERO
+    default: Hero
   - name: Button
     description: The button for the ability that will be converted to an icon.
     type: Button
@@ -40,10 +40,10 @@ abilityIconString:
 abs:
   description: The absolute value of the specified value.
   args:
-  - name: VALUE
+  - name: Value
     description: The real number value whose absolute value will be computed.
     type: float
-    default: NUMBER
+    default: Number
   return: unsigned float
   guid: 00000000C358
   en-US: Absolute Value
@@ -57,20 +57,20 @@ __add__:
   description: The sum of two numbers or vectors.
   args_allow_null: true
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
+    default: Number
   return:
   - float
   - Vector
@@ -83,10 +83,10 @@ __add__:
 getDeadPlayers:
   description: An array containing all dead players on a team or in the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams from which players may come.
     type: Team
-    default: TEAM
+    default: Team
   return:
     Array: Player
   guid: 00000000B265
@@ -138,10 +138,10 @@ getAllHeroes:
 getLivingPlayers:
   description: An array containing all living players on a team or in the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams from which players may come.
     type: Team
-    default: TEAM
+    default: Team
   return:
     Array: Player
   guid: 00000000B264
@@ -154,10 +154,10 @@ getLivingPlayers:
 getPlayers:
   description: An array containing all players on a team or in the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams from which players may come.
     type: Team
-    default: TEAM
+    default: Team
   return:
     Array: Player
   guid: 00000000B261
@@ -171,10 +171,10 @@ getPlayersNotOnObjective:
   description: An array containing all players occupying neither a payload nor a control
     point (either on a team or in the match).
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams from which players may come.
     type: Team
-    default: TEAM
+    default: Team
   return:
     Array: Player
   guid: 00000000B267
@@ -188,10 +188,10 @@ getPlayersOnObjective:
   description: An array containing all players occupying a payload or control point
     (either on a team or in the match).
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams from which players may come.
     type: Team
-    default: TEAM
+    default: Team
   return:
     Array: Player
   guid: 00000000B266
@@ -205,10 +205,10 @@ _&getAllowedHeroes:
   description: The array of heroes from which the specified player is currently allowed
     to select.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose allowed heroes to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return:
     Array: Hero
   guid: 00000000BBA8
@@ -253,10 +253,10 @@ _&getAltitude:
   description: The player's current height in meters above a surface. Results in 0
     whenever the player is on a surface.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose altitude to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 00000000B11D
   en-US: Altitude Of
@@ -268,38 +268,38 @@ _&getAltitude:
 __and__:
   description: Whether both of the two inputs are true (or equivalent to true).
   args:
-  - name: VALUE
+  - name: Value
     description: One of the two inputs considered. If both are true (or equivalent
       to true), then the and value is true.
     type: bool
-    default: 'TRUE'
-  - name: VALUE
+    default: 'True'
+  - name: Value
     description: One of the two inputs considered. If both are true (or equivalent
       to true), then the and value is true.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: bool
   guid: 00000000B273
   en-US: And
   es-MX: Y
   fr-FR: Et
-  ja-JP: AND
+  ja-JP: And
   pt-BR: E
   zh-CN: 与
 angleBetweenVectors:
   description: The angle in degrees between two directional vectors (no normalization
     required).
   args:
-  - name: VECTOR
+  - name: Vector
     description: One of two directional vectors between which to measure the angle
       in degrees. This vector does not need to be pre-normalized.
     type: Direction
-    default: VECTOR
-  - name: VECTOR
+    default: Vector
+  - name: Vector
     description: One of two directional vectors between which to measure the angle
       in degrees. This vector does not need to be pre-normalized.
     type: Direction
-    default: VECTOR
+    default: Vector
   return: unsigned float
   guid: 00000000C813
   en-US: Angle Between Vectors
@@ -313,14 +313,14 @@ angleDifference:
     wrapped to be within +/- 180 of each other, the result is positive if the second
     angle is greater than the first angle. Otherwise, the result is zero or negative.
   args:
-  - name: ANGLE
+  - name: Angle
     description: One of the two angles between which to measure the resulting angle.
     type: float
-    default: NUMBER
-  - name: ANGLE
+    default: Number
+  - name: Angle
     description: One of the two angles between which to measure the resulting angle.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000B282
   en-US: Angle Difference
@@ -334,17 +334,17 @@ __concat__:
   description: A copy of an array with one or more values appended to the end.
   args_allow_null: true
   args:
-  - name: ARRAY
+  - name: Array
     description: The array to which to append.
     type: Array
-    default: ALL PLAYERS
-  - name: VALUE
+    default: All Players
+  - name: Value
     description: The value to append to the end of the array. If this value is itself
       an array, each element is appended.
     type:
     - Object
     - Array: Object
-    default: NUMBER
+    default: Number
   return: Array
   en-US: Append To Array
   es-MX: Anexar a la matriz
@@ -355,10 +355,10 @@ __concat__:
 acosDeg:
   description: Arccosine in degrees of the specified value.
   args:
-  - name: VALUE
+  - name: Value
     description: Input value for the function.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C809
   en-US: Arccosine In Degrees
@@ -370,10 +370,10 @@ acosDeg:
 acos:
   description: Arccosine in radians of the specified value.
   args:
-  - name: VALUE
+  - name: Value
     description: Input value for the function.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C807
   en-US: Arccosine In Radians
@@ -385,10 +385,10 @@ acos:
 asinDeg:
   description: Arcsine in degrees of the specified value.
   args:
-  - name: VALUE
+  - name: Value
     description: Input value for the function.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C805
   en-US: Arcsine In Degrees
@@ -400,10 +400,10 @@ asinDeg:
 asin:
   description: Arcsine in radians of the specified value.
   args:
-  - name: VALUE
+  - name: Value
     description: Input value for the function.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C803
   en-US: Arcsine In Radians
@@ -416,14 +416,14 @@ atan2Deg:
   description: Arctangent in degrees of the specified numerator and denominator (often
     referred to as atan2).
   args:
-  - name: NUMERATOR
+  - name: Numerator
     description: Numerator input for the function.
     type: float
-    default: NUMBER
-  - name: DENOMINATOR
+    default: Number
+  - name: Denominator
     description: Denominator input for the function.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C801
   en-US: Arctangent In Degrees
@@ -436,14 +436,14 @@ atan2:
   description: Arctangent in radians of the specified numerator and denominator (often
     referred to as atan2).
   args:
-  - name: NUMERATOR
+  - name: Numerator
     description: Numerator input for the function.
     type: float
-    default: NUMBER
-  - name: DENOMINATOR
+    default: Number
+  - name: Denominator
     description: Denominator input for the function.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C7FF
   en-US: Arctangent In Radians
@@ -461,7 +461,7 @@ __array__:
     type:
     - Object
     - Array
-    default: 'NULL'
+    default: 'Null'
   return: Array
   guid: 000000010BC0
   en-US: Array
@@ -477,14 +477,14 @@ __array__:
 __arrayContains__:
   description: Whether the specified array contains the specified value.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array in which to search for the specified value.
     type: Array
-    default: ALL PLAYERS
-  - name: VALUE
+    default: All Players
+  - name: Value
     description: The value for which to search.
     type: Object
-    default: NUMBER
+    default: Number
   return: bool
   guid: 00000000C336
   en-US: Array Contains
@@ -497,21 +497,21 @@ __arraySlice__:
   description: A copy of the specified array containing only values from a specified
     index range.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array from which to make a copy.
     type:
       Array: Object
-    default: ALL PLAYERS
-  - name: START INDEX
+    default: All Players
+  - name: Start Index
     description: The first index of the range.
     type: unsigned int
-    default: NUMBER
-  - name: COUNT
+    default: Number
+  - name: Count
     description: The number of elements in the resulting array. The resulting array
       will contain fewer elements if the specified range exceeds the bounds of the
       array.
     type: unsigned int
-    default: NUMBER
+    default: Number
   return:
     Array: Object
   guid: 00000000B597
@@ -533,7 +533,7 @@ attacker:
   ja-JP: 攻撃者
   pt-BR: Atacante
   zh-CN: 攻击方
-Vector.BACKWARD:
+Vector.Backward:
   guid: 00000000B11B
   description: Shorthand for the directional vector(0, 0, -1), which points backward.
   args:
@@ -551,7 +551,7 @@ Vector.BACKWARD:
 __button__:
   description: A button constant.
   args:
-  - name: BUTTON
+  - name: Button
     description: A button constant.
     type: ButtonLiteral
     default: Interact
@@ -566,14 +566,14 @@ __button__:
 getClosestPlayer:
   description: The player closest to a position, optionally restricted by team.
   args:
-  - name: CENTER
+  - name: Center
     description: The position from which to measure proximity.
     type: Position
-    default: VECTOR
-  - name: TEAM
+    default: Vector
+  - name: Team
     description: The team or teams from which the closest player will come.
     type: Team
-    default: TEAM
+    default: Team
   return: Player
   guid: 00000000B1DE
   en-US: Closest Player To
@@ -585,39 +585,39 @@ getClosestPlayer:
 __compare__:
   description: Whether the comparison of the two inputs is true.
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand side of the comparison. This may be any value type
       if the operation is == or !=. Otherwise, real numbers are expected.
     type:
     - Object
     - Array
-    default: NUMBER
-  - name: COMPARISON
+    default: Number
+  - name: Comparison
     description: ''
     type: __Operator__
     default: "=="
-  - name: VALUE
+  - name: Value
     description: The right-hand side of the comparison. This may be any value type
       if the operation is == or !=. Otherwise, real numbers are expected.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   return: bool
   guid: 00000000B276
   en-US: Compare
   es-MX: Comparar
   fr-FR: Comparer
-  ja-JP: COMPARE
+  ja-JP: Compare
   pt-BR: Comparar
   zh-CN: 比较
 getControlScorePercentage:
   description: The score percentage for the specified team in control mode.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose score percentage to acquire.
     type: Team
-    default: TEAM
+    default: Team
   return: unsigned float
   guid: 00000000B37C
   en-US: Control Mode Scoring Percentage
@@ -641,10 +641,10 @@ getControlScoringTeam:
 cosDeg:
   description: Cosine of the specified angle in degrees.
   args:
-  - name: ANGLE
+  - name: Angle
     description: Angle in degrees.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C33E
   en-US: Cosine From Degrees
@@ -656,10 +656,10 @@ cosDeg:
 cos:
   description: Cosine of the specified angle in radians.
   args:
-  - name: ANGLE
+  - name: Angle
     description: Angle in radians.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C342
   en-US: Cosine From Radians
@@ -671,10 +671,10 @@ cos:
 len:
   description: The number of elements in the specified array.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose elements will be counted.
     type: Array
-    default: GLOBAL VARIABLE
+    default: Global Variable
   return: unsigned int
   guid: 00000000B26E
   en-US: Count Of
@@ -686,14 +686,14 @@ len:
 crossProduct:
   description: The cross product of the specified values. (Left cross up equals forward.)
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand-side vector operand of the cross product.
     type: Vector
-    default: VECTOR
-  - name: VALUE
+    default: Vector
+  - name: Value
     description: The right-hand-side vector operand of the cross product.
     type: Vector
-    default: VECTOR
+    default: Vector
   return: Vector
   guid: 00000000C35D
   en-US: Cross Product
@@ -749,22 +749,22 @@ getCurrentMap:
 __customString__:
   description: ty magzie for adding that
   args:
-  - name: STRING
+  - name: String
     description: ''
     type: StringLiteral
     default: '"Hello"'
   - name: "{0}"
     description: The value that will be converted to text and used to replace {0}.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   - name: "{1}"
     description: The value that will be converted to text and used to replace {1}.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   - name: "{2}"
     description: The value that will be converted to text and used to replace {2}.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   return: String
   guid: 00000000CE3C
   en-US: Custom String
@@ -776,14 +776,14 @@ __customString__:
 angleToDirection:
   description: The unit-length direction vector corresponding to the specified angles.
   args:
-  - name: HORIZONTAL ANGLE
+  - name: Horizontal Angle
     description: The horizontal angle in degrees used to construct the resulting vector.
     type: float
-    default: NUMBER
-  - name: VERTICAL ANGLE
+    default: Number
+  - name: Vectical Angle
     description: The vertical angle in degrees used to construct the resulting vector.
     type: float
-    default: NUMBER
+    default: Number
   return: Direction
   guid: 00000000BB2D
   en-US: Direction From Angles
@@ -795,14 +795,14 @@ angleToDirection:
 directionTowards:
   description: The unit-length direction vector from one position to another.
   args:
-  - name: START POS
+  - name: Start Pos
     description: The position from which the resulting direction vector will point.
     type: Position
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: The position to which the resulting direction vector will point.
     type: Position
-    default: VECTOR
+    default: Vector
   return: Direction
   guid: 00000000B1EA
   en-US: Direction Towards
@@ -814,14 +814,14 @@ directionTowards:
 distance:
   description: The distance between two positions in meters.
   args:
-  - name: START POS
+  - name: Start Pos
     description: One of the two positions used in the distance measurement.
     type: Position
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: One of the two positions used in the distance measurement.
     type: Position
-    default: VECTOR
+    default: Vector
   return: unsigned float
   guid: 00000000B1E7
   en-US: Distance Between
@@ -836,20 +836,20 @@ __divide__:
     yield a scaled vector. Division by zero results in zero.
   args_allow_null: true
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
+    default: Number
   return:
   - float
   - Vector
@@ -862,14 +862,14 @@ __divide__:
 dotProduct:
   description: The dot product of the specified values.
   args:
-  - name: VALUE
+  - name: Value
     description: One of two vector operands of the dot product.
     type: Vector
-    default: VECTOR
-  - name: VALUE
+    default: Vector
+  - name: Value
     description: One of two vector operands of the dot product.
     type: Vector
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000C35A
   en-US: Dot Product
@@ -908,12 +908,12 @@ entityExists:
   description: Whether the specified player, icon entity, or effect entity still exists.
     Useful for determining if a player has left the match or an entity has been destroyed.
   args:
-  - name: ENTITY
+  - name: Entity
     description: The player, icon entity, or effect entity whose existence to check.
     type:
     - Player
     - EntityId
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B619
   en-US: Entity Exists
@@ -1010,10 +1010,10 @@ _&getEyePosition:
   guid: 00000000C595
   description: The position of a player's first person view (used for aiming)
   args:
-  - name: PLAYER
+  - name: Player
     description: The position of a player's first person view (used for aiming)
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Position
   en-US: Eye Position
   es-MX: Posición de la vista
@@ -1025,10 +1025,10 @@ _&getFacingDirection:
   description: The unit-length directional vector of a player's current facing relative
     to the world. This value includes both horizontal and vertical facing.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose facing direction to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Direction
   guid: 00000000B281
   en-US: Facing Direction Of
@@ -1049,14 +1049,14 @@ _&getFacingDirection:
 getFarthestPlayer:
   description: The player farthest from a position, optionally restricted by team.
   args:
-  - name: CENTER
+  - name: Center
     description: The position from which to measure distance.
     type: Position
-    default: VECTOR
-  - name: TEAM
+    default: Vector
+  - name: Team
     description: The team or teams from which the farthest player will come.
     type: Team
-    default: TEAM
+    default: Team
   return: Player
   guid: 00000000B1DF
   en-US: Farthest Player From
@@ -1069,16 +1069,16 @@ __filteredArray__:
   description: A copy of the specified array with any values that do not match the
     specified condition removed.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose copy will be filtered.
     type: Array
-    default: ALL PLAYERS
-  - name: CONDITION
+    default: All Players
+  - name: Condition
     description: The condition that is evaluated for each element of the copied array.
       If the condition is true, the element is kept in the copied array. Use the current
       array element value to reference the element of the array currently being considered.
     type: bool
-    default: COMPARE
+    default: Compare
   return: Array
   guid: 00000000B5B7
   en-US: Filtered Array
@@ -1091,10 +1091,10 @@ __firstOf__:
   description: The value at the start of the specified array. Results in 0 if the
     specified array is empty.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array from which the value is acquired.
     type: Array
-    default: GLOBAL VARIABLE
+    default: Global Variable
   return:
   - Object
   - Array
@@ -1108,10 +1108,10 @@ __firstOf__:
 getFlagPosition:
   description: The position of a specific team's flag in capture the flag.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose flag position to acquire.
     type: Team
-    default: TEAM
+    default: Team
   return: Position
   guid: 00000000B3A0
   en-US: Flag Position
@@ -1120,7 +1120,7 @@ getFlagPosition:
   ja-JP: フラッグの位置
   pt-BR: Posição da Bandeira
   zh-CN: 旗帜位置
-Vector.FORWARD:
+Vector.Forward:
   guid: 00000000B11A
   description: Shorthand for the directional vector(0, 0, 1), which points forward.
   args:
@@ -1149,7 +1149,7 @@ __globalVar__:
   description: The current value of a global variable, which is a variable that belongs
     to the game itself.
   args:
-  - name: VARIABLE
+  - name: Variable
     description: The variable whose value to acquire.
     type: GlobalVariable
     default: A
@@ -1165,11 +1165,11 @@ _&hasSpawned:
   description: Whether an entity has spawned in the world. Results in false for players
     who have not chosen a hero yet.
   args:
-  - name: ENTITY
+  - name: Entity
     description: The player, icon entity, or effect entity whose presence in world
       to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000C192
   en-US: Has Spawned
@@ -1182,14 +1182,14 @@ _&hasStatusEffect:
   description: Whether the specified player has the specified status, either from
     the set status action or from a non-scripted game mechanic.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose status to check.
     type: Player
-    default: EVENT PLAYER
-  - name: STATUS
+    default: Event Player
+  - name: Status
     description: The status to check for.
     type: Status
-    default: HACKED
+    default: Hacked
   return: bool
   guid: 00000000B363
   en-US: Has Status
@@ -1226,10 +1226,10 @@ _&getHealth:
   guid: 0000000081C2
   description: The current health of a player, including armor and shields.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose health to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   en-US: Health
   es-MX: Salud
@@ -1242,10 +1242,10 @@ _&getNormalizedHealth:
     between 0 and 1. (for example, 0 is no health, 0.5 is half health, 1 is full health,
     etc.)
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose normalized health to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 0000000081C3
   en-US: Normalized Health
@@ -1258,7 +1258,7 @@ __hero__:
   guid: 00000000ACAA
   description: A hero constant.
   args:
-  - name: HERO
+  - name: Hero
     description: A hero constant.
     type: HeroLiteral
     default: ANA
@@ -1273,10 +1273,10 @@ _&getHeroOfDuplication:
   description: The hero currently being duplicated by the specified player. If no
     hero is being duplicated, the resulting value is 0.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player performing the duplication.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Hero
   guid: 000000010E6A
   en-US: Hero Being Duplicated
@@ -1288,10 +1288,10 @@ _&getHeroOfDuplication:
 heroIcon:
   description: Converts a hero parameter into a string that shows up as an icon.
   args:
-  - name: VALUE
+  - name: Value
     description: The hero that will be converted to an icon.
     type: Hero
-    default: HERO
+    default: Hero
   return: String
   guid: 00000000C1FE
   en-US: Hero Icon String
@@ -1303,10 +1303,10 @@ heroIcon:
 _&getCurrentHero:
   description: The current hero of a player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose hero to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Hero
   guid: 00000000ACA9
   en-US: Hero Of
@@ -1319,11 +1319,11 @@ horizontalAngleFromDirection:
   description: The horizontal angle in degrees corresponding to the specified direction
     vector.
   args:
-  - name: DIRECTION
+  - name: Direction
     description: The direction vector from which to acquire a horizontal angle in
       degrees. The vector is unitized before calculation begins.
     type: Direction
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000BB2C
   en-US: Horizontal Angle From Direction
@@ -1337,14 +1337,14 @@ horizontalAngleTowards:
     to the specified position. The result is positive if the position is on the player's
     left. Otherwise, the result is zero or negative.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player from whose current facing the angle begins.
     type: Player
-    default: EVENT PLAYER
-  - name: POSITION
+    default: Event Player
+  - name: Position
     description: The position in the world where the angle ends.
     type: Position
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000B27D
   en-US: Horizontal Angle Towards
@@ -1373,10 +1373,10 @@ _&getHorizontalFacingAngle:
     to the world. This value increases as the player rotates to the left (wrapping
     around at +/- 180).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose horizontal facing angle to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: float
   guid: 00000000B27F
   en-US: Horizontal Facing Angle Of
@@ -1389,10 +1389,10 @@ _&getHorizontalSpeed:
   description: The current horizontal speed of a player in meters per second. This
     measurement excludes all vertical motion.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose horizontal speed to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 00000000B25E
   en-US: Horizontal Speed Of
@@ -1419,7 +1419,7 @@ iconString:
   - name: Icon
     description: The icon to display.
     type: Icon
-    default: 'ARROW: DOWN'
+    default: 'Arrow: Down'
   return: String
   guid: 00000000CCDC
   en-US: Icon String
@@ -1432,43 +1432,43 @@ __ifThenElse__:
   description: Results in the Then value when the If condition is true; otherwise,
     results in the Else value.
   args:
-  - name: IF
+  - name: If
     description: If this condition evaluates to true, the result of the value is then;
       otherwise, the result is else.
     type: bool
-    default: 'TRUE'
-  - name: THEN
+    default: 'True'
+  - name: Then
     description: The result of the value when the if condition evaluates to true.
     type:
     - Object
     - Array
-    default: NUMBER
-  - name: ELSE
+    default: Number
+  - name: Else
     description: The result of the value when the if condition evaluates to false.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   return:
   - Object
   - Array
   guid: 000000010BC7
   en-US: If-Then-Else
   fr-FR: Si-Alors-Sinon
-  ja-JP: IF-THEN-ELSE
+  ja-JP: If-Then-Else
 __indexOfArrayValue__:
   description: The index of a value within an array or -1 if no such value can be
     found.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array in which to search for the specified value.
     type:
       Array: Object
-    default: ALL PLAYERS
-  - name: VALUE
+    default: All Players
+  - name: Value
     description: The value for which to search.
     type: Object
-    default: NUMBER
+    default: Number
   return: int
   guid: 00000000C330
   en-US: Index Of Array Value
@@ -1480,10 +1480,10 @@ __indexOfArrayValue__:
 _&isAlive:
   description: Whether a player is alive.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose life to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B278
   en-US: Is Alive
@@ -1517,14 +1517,14 @@ isMatchBetweenRounds:
 _&isHoldingButton:
   description: Whether a player is holding a specific button.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose button to check.
     type: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The button to check.
     type: ButtonLiteral
-    default: PRIMARY FIRE
+    default: Primary Fire
   return: bool
   guid: 00000000B2F3
   en-US: Is Button Held
@@ -1537,16 +1537,16 @@ _&isCommunicating:
   description: Whether a player is using a specific communication type (such as emoting,
     using a voice line, etc.).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose communication status to check.
     type: Player
-    default: EVENT PLAYER
-  - name: TYPE
+    default: Event Player
+  - name: Type
     description: The type of communication to consider. The duration of emotes is
       exact, the duration of voice lines is assumed to be 4 seconds, and all other
       durations are assumed to be 2 seconds.
     type: Comms
-    default: VOICE LINE UP
+    default: Voice Line Up
   return: bool
   guid: 00000000B268
   en-US: Is Communicating
@@ -1559,10 +1559,10 @@ _&isCommunicatingAnything:
   description: Whether a player is using any communication type (such as emoting,
     using a voice line, etc.).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose communication status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B9E5
   en-US: Is Communicating Any
@@ -1574,10 +1574,10 @@ _&isCommunicatingAnything:
 _&isCommunicatingEmote:
   description: Whether a player is using an emote.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose emoting status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B9E8
   en-US: Is Communicating Any Emote
@@ -1590,10 +1590,10 @@ _&isCommunicatingVoiceline:
   description: Whether a player is using a voice line. (The duration of voice lines
     is assumed to be 4 seconds.)
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose voice line status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B9E7
   en-US: Is Communicating Any Voice line
@@ -1616,10 +1616,10 @@ isControlPointLocked:
 _&isCrouching:
   description: Whether a player is crouching.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose crouching status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B289
   en-US: Is Crouching
@@ -1634,10 +1634,10 @@ _&isInAlternateForm:
     Lucio's speed song\n- Mercy's pistol\n- Torbjorn's hammer\n\nFor Echo duplication,
     use the Is Duplicating value instead."
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose form to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 000000010E62
   en-US: Is In Alternate Form
@@ -1660,10 +1660,10 @@ isInSuddenDeath:
 _&isDead:
   description: Whether a player is dead.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose death to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B277
   en-US: Is Dead
@@ -1675,10 +1675,10 @@ _&isDead:
 _&isDummy:
   description: Whether a player is a dummy bot.
   args:
-  - name: PLAYER
+  - name: Player
     description: Player to consider.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000CEDF
   en-US: Is Dummy Bot
@@ -1691,10 +1691,10 @@ _&isDuplicatingAHero:
   description: Whether the specified player is duplicating another hero. To check
     which hero, use the Hero Being Duplicated value.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose duplication status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 000000010E65
   en-US: Is Duplicating
@@ -1706,10 +1706,10 @@ _&isDuplicatingAHero:
 _&isFiringPrimaryFire:
   description: Whether the specified player's primary weapon attack is being used.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose primary weapon attack usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000C3E7
   en-US: Is Firing Primary
@@ -1721,10 +1721,10 @@ _&isFiringPrimaryFire:
 _&isFiringSecondaryFire:
   description: Whether the specified player's secondary weapon attack is being used.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose secondary weapon attack usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000C3E9
   en-US: Is Firing Secondary
@@ -1736,10 +1736,10 @@ _&isFiringSecondaryFire:
 isFlagAtBase:
   description: Whether a specific team's flag is at its base in capture the flag.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose flag to check.
     type: Team
-    default: TEAM
+    default: Team
   return: bool
   guid: 00000000B3A1
   en-US: Is Flag At Base
@@ -1752,10 +1752,10 @@ isFlagBeingCarried:
   description: Whether a specific team's flag is being carried by a member of the
     opposing team in capture the flag.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose flag to check.
     type: Team
-    default: TEAM
+    default: Team
   return: bool
   guid: 00000000B3A2
   en-US: Is Flag Being Carried
@@ -1780,14 +1780,14 @@ teamHasHero:
   description: Whether a specific hero is being played (either on a team or in the
     match).
   args:
-  - name: HERO
+  - name: Hero
     description: The hero to check for play.
     type: Hero
-    default: HERO
-  - name: TEAM
+    default: Hero
+  - name: Team
     description: The team or teams on which to check for the hero being played.
     type: Team
-    default: TEAM
+    default: Team
   return: bool
   guid: 00000000B292
   en-US: Is Hero Being Played
@@ -1799,10 +1799,10 @@ teamHasHero:
 _&isInAir:
   description: Whether a player is airborne.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose airborne status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B28B
   en-US: Is In Air
@@ -1814,26 +1814,26 @@ _&isInAir:
 isInLoS:
   description: Whether two positions have line of sight with each other.
   args:
-  - name: START POS
+  - name: Start Pos
     description: The start position for the line-of-sight check. If a player is provided,
       a position 2 meters above the player's feet is used.
     type:
     - Position
     - Player
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: The end position for the line-of-sight check. If a player is provided,
       a position 2 meters above the player's feet is used.
     type:
     - Position
     - Player
-    default: VECTOR
-  - name: BARRIERS
+    default: Vector
+  - name: Barriers
     description: Defines how barriers affect line of sight. When considering whether
       a barrier belongs to an enemy, the allegiance of the player provided to start
       pos (if any) is used.
     type: BarrierLos
-    default: BARRIERS DO NOT BLOCK LOS
+    default: Barriers DO NOT BLOCK LOS
   return: bool
   guid: 00000000B1EC
   en-US: Is In Line of Sight
@@ -1857,10 +1857,10 @@ _&isInSpawnRoom:
   description: Whether a specific player is in the spawn room (and is thus being healed
     and able to change heroes).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose spawn room status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B3B1
   en-US: Is In Spawn Room
@@ -1872,18 +1872,18 @@ _&isInSpawnRoom:
 _&isInViewAngle:
   description: Whether a location is within view of a player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose view to use for the check.
     type: Player
-    default: EVENT PLAYER
-  - name: LOCATION
+    default: Event Player
+  - name: Location
     description: The location to test if it's within view.
     type: Position
-    default: VECTOR
-  - name: VIEW ANGLE
+    default: Vector
+  - name: View Angle
     description: The view angle to compare against in degrees.
     type: float
-    default: NUMBER
+    default: Number
   return: bool
   guid: 00000000BF7C
   en-US: Is In View Angle
@@ -1895,10 +1895,10 @@ _&isInViewAngle:
 _&isJumping:
   description: Whether the specified player is jumping.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose jump usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 0000000105A0
   en-US: Is Jumping
@@ -1921,10 +1921,10 @@ isMatchComplete:
 _&isMeleeing:
   description: Whether the specified player is meleeing.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose melee usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000001059A
   en-US: Is Meleeing
@@ -1936,10 +1936,10 @@ _&isMeleeing:
 _&isMoving:
   description: Whether a player is moving (defined as having a nonzero current speed).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose moving status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B288
   en-US: Is Moving
@@ -1952,12 +1952,12 @@ isObjectiveComplete:
   description: Whether the specified objective has been completed. Results in false
     if the game mode is not assault, escort, or assault/escort.
   args:
-  - name: NUMBER
+  - name: Number
     description: The index of the objective to consider, starting at 0 and counting
       up. Each control point, payload checkpoint, and payload destination has its
       own index.
     type: unsigned int
-    default: NUMBER
+    default: Number
   return: bool
   guid: 00000000B378
   en-US: Is Objective Complete
@@ -1969,10 +1969,10 @@ isObjectiveComplete:
 _&isOnGround:
   description: Whether a player is on the ground (or other walkable surface).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ground status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000BF70
   en-US: Is On Ground
@@ -1985,10 +1985,10 @@ _&isOnObjective:
   description: Whether a specific player is currently occupying a payload or capture
     point.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose objective status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B3B2
   en-US: Is On Objective
@@ -2000,10 +2000,10 @@ _&isOnObjective:
 _&isOnWall:
   description: Whether a player is on a wall (climbing or riding).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose wall status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000BB0B
   en-US: Is On Wall
@@ -2015,10 +2015,10 @@ _&isOnWall:
 _&isOnFire:
   description: Whether a specific player's portrait is on fire.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose portrait to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B3B3
   en-US: Is Portrait On Fire
@@ -2031,10 +2031,10 @@ _&isStanding:
   description: Whether a player is standing (defined as both not moving and not in
     the air).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose standing status to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B287
   en-US: Is Standing
@@ -2047,10 +2047,10 @@ isTeamOnDefense:
   description: Whether the specified team is currently on defense. Results in false
     if the game mode is not assault, escort, or assault/escort.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose role to check.
     type: Team
-    default: TEAM
+    default: Team
   return: bool
   guid: 00000000B359
   en-US: Is Team On Defense
@@ -2063,10 +2063,10 @@ isTeamOnOffense:
   description: Whether the specified team is currently on offense. Results in false
     if the game mode is not assault, escort, or assault/escort.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose role to check.
     type: Team
-    default: TEAM
+    default: Team
   return: bool
   guid: 00000000B354
   en-US: Is Team On Offense
@@ -2079,53 +2079,53 @@ __all__:
   description: Whether the specified condition evaluates to true for every value in
     the specified array.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose values will be considered.
     type: Array
-    default: GLOBAL VARIABLE
-  - name: CONDITION
+    default: Global Variable
+  - name: Condition
     description: The condition that is evaluated for each element of the specified
       array. Use the current array element value to reference the element of the array
       currently being considered.
     type: bool
-    default: COMPARE
+    default: Compare
   return: bool
   guid: 00000000B5BA
   en-US: Is True For All
   es-MX: Es verdadero para todos
   fr-FR: Vrai pour tous
-  ja-JP: すべてに対して「TRUE」
+  ja-JP: すべてに対して「True」
   pt-BR: É Verdadeiro para Todos
   zh-CN: 对全部为”真“
 __any__:
   description: Whether the specified condition evaluates to true for any value in
     the specified array.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose values will be considered.
     type: Array
-    default: GLOBAL VARIABLE
-  - name: CONDITION
+    default: Global Variable
+  - name: Condition
     description: The condition that is evaluated for each element of the specified
       array. Use the current array element value to reference the element of the array
       currently being considered.
     type: bool
-    default: COMPARE
+    default: Compare
   return: bool
   guid: 00000000B5BB
   en-US: Is True For Any
   es-MX: Es verdadero para cualquiera
   fr-FR: Vrai pour n’importe qui
-  ja-JP: いずれに対しても「TRUE」
+  ja-JP: いずれに対しても「True」
   pt-BR: É Verdadeiro para Qualquer
   zh-CN: 对任意为”真“
 _&isUsingAbility1:
   description: Whether the specified player is using ability 1.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ability 1 usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000C3EB
   en-US: Is Using Ability 1
@@ -2137,10 +2137,10 @@ _&isUsingAbility1:
 _&isUsingAbility2:
   description: Whether the specified player is using ability 2.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ability 2 usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000C3ED
   en-US: Is Using Ability 2
@@ -2152,10 +2152,10 @@ _&isUsingAbility2:
 _&isUsingUltimate:
   description: Whether a player is using an ultimate ability.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ultimate ability usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   guid: 00000000B9D4
   en-US: Is Using Ultimate
@@ -2239,10 +2239,10 @@ __lastOf__:
   description: The value at the end of the specified array. Results in 0 if the specified
     array is empty.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array from which the value is acquired.
     type: Array
-    default: GLOBAL VARIABLE
+    default: Global Variable
   return:
   - Object
   - Array
@@ -2265,7 +2265,7 @@ getLastCreatedText:
   ja-JP: 最新のテキストID
   pt-BR: ID de Texto Mais Recente
   zh-CN: 上一个文本ID
-Vector.LEFT:
+Vector.Left:
   guid: 00000000B116
   description: Shorthand for the directional vector(1, 0, 0), which points to the
     left.
@@ -2285,14 +2285,14 @@ localVector:
   description: The vector in local coordinates corresponding to the provided vector
     in world coordinates.
   args:
-  - name: WORLD VECTOR
+  - name: WORLD Vector
     description: The vector in world coordinates that will be converted to local coordinates.
     type: Vector
-    default: VECTOR
-  - name: RELATIVE PLAYER
+    default: Vector
+  - name: Relative Player
     description: The player to whom the resulting vector will be relative.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: TRANSFORMATION
     description: Specifies whether the vector should receive a rotation and a translation
       (usually applied to positions) or only a rotation (usually applied to directions
@@ -2353,14 +2353,14 @@ max:
   guid: 00000000C418
   description: The greater of two numbers.
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number.
     type: float
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   en-US: Max
   es-MX: Máximo
@@ -2371,10 +2371,10 @@ max:
 _&getMaxHealth:
   description: The max health of a player, including armor and shields.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose max health to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 0000000081C4
   en-US: Max Health
@@ -2387,14 +2387,14 @@ min:
   guid: 00000000C416
   description: The lesser of two numbers.
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number.
     type: float
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   en-US: Min
   es-MX: Mínimo
@@ -2407,14 +2407,14 @@ __modulo__:
   description: The remainder of the left-hand operand divided by the right-hand operand.
     Any number modulo zero results in zero.
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number.
     type: float
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number.
     type: unsigned float
-    default: NUMBER
+    default: Number
   return: float
   en-US: Modulo
   es-MX: Módulo
@@ -2427,20 +2427,20 @@ __multiply__:
     will yield a scaled vector.
   args_allow_null: true
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
+    default: Number
   return:
   - float
   - Vector
@@ -2454,10 +2454,10 @@ nearestWalkablePosition:
   description: The position closest to the specified position that can be stood on
     and is accessible from a spawn point.
   args:
-  - name: POSITION
+  - name: Position
     description: The position from which to search for the nearest walkable position.
     type: Position
-    default: VECTOR
+    default: Vector
   return: Position
   guid: 00000000C324
   en-US: Nearest Walkable Position
@@ -2469,10 +2469,10 @@ nearestWalkablePosition:
 normalize:
   description: The unit-length normalization of a vector.
   args:
-  - name: VECTOR
+  - name: Vector
     description: The vector to normalize.
     type: Vector
-    default: VECTOR
+    default: Vector
   return: Vector
   guid: 00000000C344
   en-US: Normalize
@@ -2485,11 +2485,11 @@ __not__:
   guid: 00000000B275
   description: Whether the input is false (or equivalent to false).
   args:
-  - name: VALUE
+  - name: Value
     description: When this input is false (or equivalent to false), then the not value
       is true. Otherwise, the not value is false.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: bool
   en-US: Not
   es-MX: 'No'
@@ -2506,16 +2506,16 @@ __not__:
   en-US: 'Null'
   es-MX: Nulo
   fr-FR: Non applicable
-  ja-JP: 'NULL'
+  ja-JP: 'Null'
   pt-BR: Nulo
   zh-CN: 无
 getNumberOfDeadPlayers:
   description: The number of dead players on a team or in the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams on which to count players.
     type: Team
-    default: TEAM
+    default: Team
   return: unsigned int
   guid: 00000000B29A
   en-US: Number of Dead Players
@@ -2528,10 +2528,10 @@ _&getNumberOfDeaths:
   description: The number of deaths a specific player has earned. This value only
     accumulates while a game is in progress.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose death count to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned int
   guid: 00000000B103
   en-US: Number of Deaths
@@ -2544,10 +2544,10 @@ _&getNumberOfElims:
   description: The number of eliminations a specific player has earned. This value
     only accumulates while a game is in progress.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose elimination count to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned int
   guid: 00000000B101
   en-US: Number of Eliminations
@@ -2560,10 +2560,10 @@ _&getNumberOfFinalBlows:
   description: The number of final blows a specific player has earned. This value
     only accumulates while a game is in progress.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose final blow count to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned int
   guid: 00000000B102
   en-US: Number of Final Blows
@@ -2575,14 +2575,14 @@ _&getNumberOfFinalBlows:
 getNumberOfHeroes:
   description: The number of players playing a specific hero on a team or in the match.
   args:
-  - name: HERO
+  - name: Hero
     description: The hero to check for play.
     type: Hero
-    default: HERO
-  - name: TEAM
+    default: Hero
+  - name: Team
     description: The team or teams on which to check for the hero being played.
     type: Team
-    default: TEAM
+    default: Team
   return: unsigned int
   guid: 00000000B296
   en-US: Number of Heroes
@@ -2594,10 +2594,10 @@ getNumberOfHeroes:
 getNumberOfLivingPlayers:
   description: The number of living players on a team or in the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams on which to count players.
     type: Team
-    default: TEAM
+    default: Team
   return: unsigned int
   guid: 00000000B297
   en-US: Number of Living Players
@@ -2609,10 +2609,10 @@ getNumberOfLivingPlayers:
 getNumberOfPlayers:
   description: The number of players on a team or in the match.
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams on which to count players.
     type: Team
-    default: TEAM
+    default: Team
   return: unsigned int
   guid: 00000000B295
   en-US: Number of Players
@@ -2625,10 +2625,10 @@ getNumberOfPlayersOnObjective:
   description: The number of players occupying a payload or control point (either
     on a team or in the match).
   args:
-  - name: TEAM
+  - name: Team
     description: The team or teams on which to count players.
     type: Team
-    default: TEAM
+    default: Team
   return: unsigned int
   guid: 00000000B29B
   en-US: Number of Players On Objective
@@ -2654,12 +2654,12 @@ getObjectivePosition:
     point, a payload checkpoint, or a payload destination). Valid in assault, assault/escort,
     escort, and control.
   args:
-  - name: NUMBER
+  - name: Number
     description: The index of the objective to consider, starting at 0 and counting
       up. Each control point, payload checkpoint, and payload destination has its
       own index.
     type: unsigned int
-    default: NUMBER
+    default: Number
   return: unsigned int
   guid: 00000000B355
   en-US: Objective Position
@@ -2671,10 +2671,10 @@ getObjectivePosition:
 getOppositeTeam:
   description: The team opposite the specified team.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose opposite to acquire. If all, the result will be all.
     type: Team
-    default: TEAM
+    default: Team
   return: Team
   guid: 00000000BB0A
   en-US: Opposite Team Of
@@ -2687,16 +2687,16 @@ __or__:
   guid: 00000000B274
   description: Whether either of the two inputs are true (or equivalent to true).
   args:
-  - name: VALUE
+  - name: Value
     description: One of the two inputs considered. If either one is true (or equivalent
       to true), then the or value is true.
     type: bool
-    default: 'TRUE'
-  - name: VALUE
+    default: 'True'
+  - name: Value
     description: One of the two inputs considered. If either one is true (or equivalent
       to true), then the or value is true.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: bool
   en-US: Or
   es-MX: O
@@ -2731,10 +2731,10 @@ getFlagCarrier:
   description: The player carrying a particular team's flag in capture the flag. Results
     in null if no player is carrying the flag.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose flag to check.
     type: Team
-    default: TEAM
+    default: Team
   return: Player
   guid: 00000000B3A3
   en-US: Player Carrying Flag
@@ -2747,14 +2747,14 @@ _&getPlayerClosestToReticle:
   description: The player closest to the reticle of the specified player, optionally
     restricted by team.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player from whose reticle to search for the closest player.
     type: Player
-    default: EVENT PLAYER
-  - name: TEAM
+    default: Event Player
+  - name: Team
     description: The team or teams on which to search for the closest player.
     type: Team
-    default: TEAM
+    default: Team
   return: Player
   guid: 00000000C328
   en-US: Player Closest To Reticle
@@ -2767,11 +2767,11 @@ __playerVar__:
   description: The current value of a player variable, which is a variable that belongs
     to a specific player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose variable value to acquire.
     type: Player
-    default: EVENT PLAYER
-  - name: VARIABLE
+    default: Event Player
+  - name: Variable
     description: The variable whose value to acquire.
     type: PlayerVariable
     default: A
@@ -2786,16 +2786,16 @@ __playerVar__:
 getPlayersInSlot:
   description: The player or array of players who occupy a specific slot in the game.
   args:
-  - name: SLOT
+  - name: Slot
     description: The slot number from which to acquire a player or players. In team
       games, each team has slots 0 through 5. In free-for-all games, slots are numbered
       0 through 11.
     type: unsigned int
-    default: NUMBER
-  - name: TEAM
+    default: Number
+  - name: Team
     description: The team or teams from which to acquire a player or players.
     type: Team
-    default: TEAM
+    default: Team
   return:
   - Player
   - Array: Player
@@ -2810,18 +2810,18 @@ _&getPlayersInViewAngle:
   description: The players who are within a specific view angle of a specific player's
     reticle, optionally restricted by team.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose view to use for the check.
     type: Player
-    default: EVENT PLAYER
-  - name: TEAM
+    default: Event Player
+  - name: Team
     description: The team or teams on which to consider players.
     type: Team
-    default: TEAM
-  - name: VIEW ANGLE
+    default: Team
+  - name: View Angle
     description: The view angle to compare against in degrees.
     type: float
-    default: NUMBER
+    default: Number
   return:
     Array: Player
   guid: 00000000C32F
@@ -2834,14 +2834,14 @@ _&getPlayersInViewAngle:
 getPlayersOnHero:
   description: The array of players playing a specific hero on a team or in the match.
   args:
-  - name: HERO
+  - name: Hero
     description: The hero to check for play.
     type: Hero
-    default: HERO
-  - name: TEAM
+    default: Hero
+  - name: Team
     description: The team or teams on which to check for the hero being played.
     type: Team
-    default: TEAM
+    default: Team
   return:
     Array: Player
   guid: 00000000B338
@@ -2855,20 +2855,20 @@ getPlayersInRadius:
   description: An array containing all players within a certain distance of a position,
     optionally restricted by team and line of sight.
   args:
-  - name: CENTER
+  - name: Center
     description: The center position from which to measure distance.
     type: Position
-    default: VECTOR
-  - name: RADIUS
+    default: Vector
+  - name: Radius
     description: The radius in meters inside which players must be in order to be
       included in the resulting array.
     type: unsigned float
-    default: NUMBER
-  - name: TEAM
+    default: Number
+  - name: Team
     description: The team or teams to which a player must belong to be included in
       the resulting array.
     type: Team
-    default: TEAM
+    default: Team
   - name: LOS CHECK
     description: Specifies whether and how a player must pass a line-of-sight check
       to be included in the resulting array.
@@ -2898,10 +2898,10 @@ getCapturePercentage:
 _&getPosition:
   description: The current position of a player as a vector.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose position to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Position
   guid: 00000000B11C
   en-US: Position Of
@@ -2915,14 +2915,14 @@ __raiseToPower__:
   description: The left-hand operand raised to the power of the right-hand operand.
     If the left-hand operand is negative, the result is always zero.
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number.
     type: unsigned float
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number.
     type: float
-    default: NUMBER
+    default: Number
   return: unsigned float
   en-US: Raise To Power
   es-MX: Elevar a la potencia
@@ -2933,16 +2933,16 @@ __raiseToPower__:
 random.randint:
   description: A random integer between the specified min and max, inclusive.
   args:
-  - name: MIN
+  - name: Min
     description: The smallest integer allowed. If a real number is provided to this
       input, it is rounded to the nearest integer.
     type: int
-    default: NUMBER
-  - name: MAX
+    default: Number
+  - name: Max
     description: The largest integer allowed. If a real number is provided to this
       input, it is rounded to the nearest integer.
     type: int
-    default: NUMBER
+    default: Number
   return: int
   guid: 00000000B59B
   en-US: Random Integer
@@ -2954,14 +2954,14 @@ random.randint:
 random.uniform:
   description: A random real number between the specified min and max.
   args:
-  - name: MIN
+  - name: Min
     description: The smallest real number allowed.
     type: float
-    default: NUMBER
-  - name: MAX
+    default: Number
+  - name: Max
     description: The largest real number allowed.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000B59A
   en-US: Random Real
@@ -2973,11 +2973,11 @@ random.uniform:
 random.choice:
   description: A random value from the specified array.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array from which to randomly take a value. If a non-array value
       is provided, the result is simply the provided value.
     type: Array
-    default: GLOBAL VARIABLE
+    default: Global Variable
   return:
   - Object
   - Array
@@ -2991,10 +2991,10 @@ random.choice:
 random.shuffle:
   description: A copy of the specified array with the values in a random order.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose copy will be randomized.
     type: Array
-    default: GLOBAL VARIABLE
+    default: Global Variable
   return: Array
   guid: 00000000B598
   en-US: Randomized Array
@@ -3007,32 +3007,32 @@ __raycastHitNormal__:
   description: The surface normal at the ray cast hit position (or from end pos to
     start pos if no hit occurs).
   args:
-  - name: START POS
+  - name: Start Pos
     description: The start position for the ray cast. If a player is provided, a position
       2 meters above the player's feet is used.
     type: Position
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: The end position for the ray cast. If a player is provided, a position
       2 meters above the player's feet is used.
     type: Position
-    default: VECTOR
-  - name: PLAYERS TO INCLUDE
+    default: Vector
+  - name: Players To Include
     description: Which players can be hit by this ray cast.
     type:
       Array: Player
-    default: ALL PLAYERS
-  - name: PLAYERS TO EXCLUDE
+    default: All Players
+  - name: Players To Exclude
     description: Which players cannot be hit by this ray cast. This list takes precedence
       over players to include.
     type:
       Array: Player
-    default: EVENT PLAYER
-  - name: INCLUDE PLAYER OWNED OBJECTS
+    default: Event Player
+  - name: Include Player Owned Objects
     description: Whether player-owned objects (such as barriers or turrets) should
       be included in the ray cast.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: Direction
   guid: 00000000C613
   en-US: Ray Cast Hit Normal
@@ -3044,32 +3044,32 @@ __raycastHitNormal__:
 __raycastHitPlayer__:
   description: The player hit by the ray cast (or null if no player is hit).
   args:
-  - name: START POS
+  - name: Start Pos
     description: The start position for the ray cast. If a player is provided, a position
       2 meters above the player's feet is used.
     type: Position
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: The end position for the ray cast. If a player is provided, a position
       2 meters above the player's feet is used.
     type: Position
-    default: VECTOR
-  - name: PLAYERS TO INCLUDE
+    default: Vector
+  - name: Players To Include
     description: Which players can be hit by this ray cast.
     type:
       Array: Player
-    default: ALL PLAYERS
-  - name: PLAYERS TO EXCLUDE
+    default: All Players
+  - name: Players To Exclude
     description: Which players cannot be hit by this ray cast. This list takes precedence
       over players to include.
     type:
       Array: Player
-    default: EVENT PLAYER
-  - name: INCLUDE PLAYER OWNED OBJECTS
+    default: Event Player
+  - name: Include Player Owned Objects
     description: Whether player-owned objects (such as barriers or turrets) should
       be included in the ray cast.
     type: bool
-    default: 'TRUE'
+    default: 'True'
   return: Player
   guid: 00000000C611
   en-US: Ray Cast Hit Player
@@ -3082,32 +3082,32 @@ __raycastHitPosition__:
   description: The position where the ray cast hits a surface, object, or player (or
     the end pos if no hit occurs).
   args:
-  - name: START POS
+  - name: Start Pos
     description: The start position for the ray cast. If a player is provided, a position
       2 meters above the player's feet is used.
     type: Position
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: The end position for the ray cast. If a player is provided, a position
       2 meters above the player's feet is used.
     type: Position
-    default: VECTOR
-  - name: PLAYERS TO INCLUDE
+    default: Vector
+  - name: Players To Include
     description: Which players can be hit by this ray cast.
     type:
       Array: Player
-    default: ALL PLAYERS
-  - name: PLAYERS TO EXCLUDE
+    default: All Players
+  - name: Players To Exclude
     description: Which players cannot be hit by this ray cast. This list takes precedence
       over players to include.
     type:
       Array: Player
-    default: EVENT PLAYER
-  - name: INCLUDE PLAYER OWNED OBJECTS
+    default: Event Player
+  - name: Include Player Owned Objects
     description: Whether player-owned objects (such as barriers or turrets) should
       be included in the ray cast.
     type: BooleanValue
-    default: 'TRUE'
+    default: 'True'
   return: Position
   guid: 00000000C597
   en-US: Ray Cast Hit Position
@@ -3120,17 +3120,17 @@ __removeFromArray__:
   description: A copy of an array with one or more values removed (if found).
   args_allow_null: true
   args:
-  - name: ARRAY
+  - name: Array
     description: The array from which to remove values.
     type: Array
-    default: ALL PLAYERS
-  - name: VALUE
+    default: All Players
+  - name: Value
     description: The value to remove from the array (if found). If this value is itself
       an array, each matching element is removed.
     type:
     - Object
     - Array
-    default: NUMBER
+    default: Number
   return: Array
   guid: 00000000C421
   en-US: Remove From Array
@@ -3158,11 +3158,11 @@ Vector.RIGHT:
 __round__:
   description: The integer to which the specified value rounds.
   args:
-  - name: VALUE
+  - name: Value
     description: The real number to round.
     type: float
-    default: NUMBER
-  - name: ROUNDING TYPE
+    default: Number
+  - name: Rounding Type
     description: Determines the direction in which the value will be rounded.
     type: __Rounding__
     default: UP
@@ -3178,10 +3178,10 @@ _&getScore:
   description: The current score of a player. Results in 0 if the game mode is not
     free-for-all.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose score to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: int
   guid: 00000000AD3C
   en-US: Score Of
@@ -3234,10 +3234,10 @@ getPeakServerLoad:
 sinDeg:
   description: Sine of the specified angle in degrees.
   args:
-  - name: ANGLE
+  - name: Angle
     description: Angle in degrees.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C33C
   en-US: Sine From Degrees
@@ -3249,10 +3249,10 @@ sinDeg:
 sin:
   description: Sine of the specified angle in radians.
   args:
-  - name: ANGLE
+  - name: Angle
     description: Angle in radians.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C340
   en-US: Sine From Radians
@@ -3265,10 +3265,10 @@ _&getSlot:
   description: The slot number of the specified player. In team games, each team has
     slots 0 through 5. In free-for-all games, slots are numbered 0 through 11.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose slot number to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned int
   guid: 00000000BB7F
   en-US: Slot Of
@@ -3281,17 +3281,17 @@ __sortedArray__:
   description: A copy of the specified array with the values sorted according to the
     value rank that is evaluated for each element.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose copy will be sorted.
     type:
       Array: Object
-    default: GLOBAL VARIABLE
-  - name: VALUE RANK
+    default: Global Variable
+  - name: Value Rank
     description: The value that is evaluated for each element of the copied array.
       The array is sorted by this rank in ascending order. Use the current array element
       value to reference the element of the array currently being considered.
     type: Object
-    default: CURRENT ARRAY ELEMENT
+    default: Current Array Element
   return:
     Array: Object
   guid: 00000000B5C0
@@ -3304,25 +3304,25 @@ __sortedArray__:
 __mappedArray__:
   description: A copy of the specified array with the values mapped according to the Mapping Expression that is evaluated for each element.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose copy will be sorted.
     type:
       Array: Object
-    default: GLOBAL VARIABLE
+    default: Global Variable
   - name: Mapping expression
     description: The mapping expression that is evaluated for each element of the copied array. Use the Current Array Element value to reference the element of the array currently being considered.
     type: Object
-    default: CURRENT ARRAY ELEMENT
+    default: Current Array Element
   return:
     Array: Object
   en-US: Mapped Array
 _&getSpeed:
   description: The current speed of a player in meters per second.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose speed to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 00000000B25D
   en-US: Speed Of
@@ -3335,14 +3335,14 @@ _&getSpeedInDirection:
   description: The current speed of a player in a specific direction in meters per
     second.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose speed to acquire.
     type: Player
-    default: EVENT PLAYER
-  - name: DIRECTION
+    default: Event Player
+  - name: Direction
     description: The direction of travel in which to measure the player's speed.
     type: Direction
-    default: VECTOR
+    default: Vector
   return: unsigned float
   guid: 00000000B260
   en-US: Speed Of In Direction
@@ -3354,11 +3354,11 @@ _&getSpeedInDirection:
 sqrt:
   description: The square root of the specified value.
   args:
-  - name: VALUE
+  - name: Value
     description: The real number value whose square root will be computed. Negative
       values result in zero.
     type: unsigned float
-    default: NUMBER
+    default: Number
   return: unsigned float
   guid: 00000000C356
   en-US: Square Root
@@ -3371,22 +3371,22 @@ __localizedString__:
   guid: 00000000BA60
   description: Text formed from a selection of strings and specified values.
   args:
-  - name: STRING
+  - name: String
     description: ''
     type: LocalizedStringLiteral
-    default: HELLO
+    default: Hello
   - name: "{0}"
     description: The value that will be converted to text and used to replace {0}.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   - name: "{1}"
     description: The value that will be converted to text and used to replace {1}.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   - name: "{2}"
     description: The value that will be converted to text and used to replace {2}.
     type: Object
-    default: 'NULL'
+    default: 'Null'
   return: String
   en-US: String
   es-MX: Cadena
@@ -3398,20 +3398,20 @@ __subtract__:
   description: The difference between two numbers or vectors.
   args_allow_null: true
   args:
-  - name: VALUE
+  - name: Value
     description: The left-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
-  - name: VALUE
+    default: Number
+  - name: Value
     description: The right-hand operand. May be any value that results in a number
       or a vector.
     type:
     - float
     - Vector
-    default: NUMBER
+    default: Number
   return:
   - float
   - Vector
@@ -3424,10 +3424,10 @@ __subtract__:
 tanDeg:
   description: Tangent of the specified angle in degrees.
   args:
-  - name: ANGLE
+  - name: Angle
     description: Angle in degrees.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C7F8
   en-US: Tangent From Degrees
@@ -3439,10 +3439,10 @@ tanDeg:
 tan:
   description: Tangent of the specified angle in radians.
   args:
-  - name: ANGLE
+  - name: Angle
     description: Angle in radians.
     type: float
-    default: NUMBER
+    default: Number
   return: float
   guid: 00000000C7FD
   en-US: Tangent From Radians
@@ -3455,10 +3455,10 @@ _&getTeam:
   description: The team of a player. If the game mode is free-for-all, the team is
     considered to be all.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose team to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Team
   guid: 00000000B279
   en-US: Team Of
@@ -3472,10 +3472,10 @@ teamScore:
   description: The current score for the specified team. Results in 0 in free-for-all
     game modes.
   args:
-  - name: TEAM
+  - name: Team
     description: The team whose score to acquire.
     type: Team
-    default: TEAM
+    default: Team
   return: int
   en-US: Team Score
   es-MX: Puntuación del equipo
@@ -3488,10 +3488,10 @@ _&getThrottle:
     input on the x component (positive to the left) and vertical input on the z component
     (positive upward).
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose directional input to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Direction
   guid: 00000000B2F5
   en-US: Throttle Of
@@ -3524,10 +3524,10 @@ getTotalTimeElapsed:
 _&getUltCharge:
   description: The current ultimate ability charge percentage of a player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ultimate charge percentage to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 0000000081C5
   en-US: Ultimate Charge Percent
@@ -3555,14 +3555,14 @@ __valueInArray__:
   description: The value found at a specific element of an array. Results in 0 if
     the element does not exist.
   args:
-  - name: ARRAY
+  - name: Array
     description: The array whose element to acquire.
     type: Array
-    default: GLOBAL VARIABLE
-  - name: INDEX
+    default: Global Variable
+  - name: Index
     description: The index of the element to acquire.
     type: unsigned int
-    default: NUMBER
+    default: Number
   return:
   - Object
   - Array
@@ -3581,15 +3581,15 @@ vect:
   - name: X
     description: The x value of the vector.
     type: float
-    default: NUMBER
+    default: Number
   - name: Y
     description: The y value of the vector.
     type: float
-    default: NUMBER
+    default: Number
   - name: Z
     description: The z value of the vector.
     type: float
-    default: NUMBER
+    default: Number
   return: Vector
   en-US: Vector
   fr-FR: Vecteur
@@ -3599,14 +3599,14 @@ vect:
 vectorTowards:
   description: The displacement vector from one position to another.
   args:
-  - name: START POS
+  - name: Start Pos
     description: The position from which the resulting displacement vector begins.
     type: Position
-    default: VECTOR
-  - name: END POS
+    default: Vector
+  - name: End Pos
     description: The position at which the resulting displacement vector ends.
     type: Position
-    default: VECTOR
+    default: Vector
   return: Direction
   guid: 00000000B1EB
   en-US: Vector Towards
@@ -3620,10 +3620,10 @@ _&getVelocity:
     surface, the y component of this velocity will be 0, even when traveling up or
     down a slope.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose velocity to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: Velocity
   guid: 00000000B25C
   en-US: Velocity Of
@@ -3636,11 +3636,11 @@ verticalAngleOfDirection:
   description: The vertical angle in degrees corresponding to the specified direction
     vector.
   args:
-  - name: DIRECTION
+  - name: Direction
     description: The direction vector from which to acquire a vertical angle in degrees.
       The vector is unitized before calculation begins.
     type: Direction
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000BB2B
   en-US: Vertical Angle From Direction
@@ -3654,14 +3654,14 @@ verticalAngleTowards:
     to the specified position. The result is positive if the position is below the
     player. Otherwise, the result is zero or negative.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player from whose current facing the angle begins.
     type: Player
-    default: EVENT PLAYER
-  - name: POSITION
+    default: Event Player
+  - name: Position
     description: The position in the world where the angle ends.
     type: Position
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000B27E
   en-US: Vertical Angle Towards
@@ -3674,10 +3674,10 @@ _&getVerticalFacingAngle:
   description: The vertical angle in degrees of a player's current facing relative
     to the world. This value increases as the player looks down.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose vertical facing angle to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: float
   guid: 00000000B280
   en-US: Vertical Facing Angle Of
@@ -3690,10 +3690,10 @@ _&getVerticalSpeed:
   description: The current vertical speed of a player in meters per second. This measurement
     excludes all horizontal motion, including motion while traveling up and down slopes.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose vertical speed to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned float
   guid: 00000000B25F
   en-US: Vertical Speed Of
@@ -3718,14 +3718,14 @@ worldVector:
   description: The vector in world coordinates corresponding to the provided vector
     in local coordinates.
   args:
-  - name: LOCAL VECTOR
+  - name: Local Vector
     description: The vector in local coordinates that will be converted to world coordinates.
     type: Vector
-    default: VECTOR
-  - name: RELATIVE PLAYER
+    default: Vector
+  - name: Relative Player
     description: The player to whom the local vector is relative.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   - name: TRANSFORMATION
     description: Specifies whether the vector should receive a rotation and a translation
       (usually applied to positions) or only a rotation (usually applied to directions
@@ -3744,10 +3744,10 @@ __xComponentOf__:
   description: The x component of the specified vector, usually representing a leftward
     amount.
   args:
-  - name: VALUE
+  - name: Value
     description: The vector from which to acquire the x component.
     type: Vector
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000B26F
   en-US: X Component Of
@@ -3760,10 +3760,10 @@ __yComponentOf__:
   description: The y component of the specified vector, usually representing an upward
     amount.
   args:
-  - name: VALUE
+  - name: Value
     description: The vector from which to acquire the y component.
     type: Vector
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000B270
   en-US: Y Component Of
@@ -3776,10 +3776,10 @@ __zComponentOf__:
   description: The z component of the specified vector, usually representing a forward
     amount.
   args:
-  - name: VALUE
+  - name: Value
     description: The vector from which to acquire the z component.
     type: Vector
-    default: VECTOR
+    default: Vector
   return: float
   guid: 00000000B272
   en-US: Z Component Of
@@ -3791,37 +3791,37 @@ __zComponentOf__:
 _&getAbilityCharge:
   description: The ability charge count for a player associated by button.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ability to check.
     type: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The ability to check associated by button.
     type: Button
-    default: BUTTON
+    default: Button
   return: unsigned int
   en-US: Ability Charge
 _&getAbilityResource:
   description: The ability resource percent for a player associated by button.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ability to check.
     type: Player
-    default: EVENT PLAYER
-  - name: BUTTON
+    default: Event Player
+  - name: Button
     description: The ability to check associated by button.
     type: Button
-    default: BUTTON
+    default: Button
   return: unsigned float
   en-US: Ability Resource
 _&getAmmo:
   description: The current ammo of a player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose ammo to acquire.
     type: Player
-    default: EVENT PLAYER
-  - name: CLIP
+    default: Event Player
+  - name: Clip
     description: The index of the clip to be acquired. 0 is the first clip, and 1 is the second. If the specified type does not exist, this will return 0.
     type: unsigned int
     default: 0
@@ -3838,21 +3838,21 @@ _&getHealthOfType:
   description: The current health of the specified player, filtered by the given health
     type.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose health to acquire.
     type: Player
-    default: EVENT PLAYER
-  - name: HEALTH
+    default: Event Player
+  - name: Health
     description: The type of health to acquire.
     type: Health
-    default: HEALTH
+    default: Health
   return: unsigned float
   en-US: Health of Type
 buttonString:
   description: Converts a button parameter into a string that shows up based on the
     player's input bindings. This value cannot be stored in variables.
   args:
-  - name: BUTTON
+  - name: Button
     description: The button for the input binding that will be converted to a string.
     type: Button
     default: Button
@@ -3861,10 +3861,10 @@ buttonString:
 _&isReloading:
   description: Whether the specified player is reloading.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose reload usage to check.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: bool
   en-US: Is Reloading
 getLastCreatedHealthPool:
@@ -3876,11 +3876,11 @@ getLastCreatedHealthPool:
 _&getMaxAmmo:
   description: The current max ammo of a player.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose max ammo to acquire.
     type: Player
-    default: EVENT PLAYER
-  - name: CLIP
+    default: Event Player
+  - name: Clip
     description: The index of the clip to be acquired. 0 is the first clip, and 1 is the second. If the specified type does not exist, this will return 0.
     type: unsigned int
     default: 0
@@ -3891,24 +3891,24 @@ _&getMaxHealthOfType:
   description: The max health of the specified player, filtered by the given health
     type.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose max health to acquire.
     type: Player
-    default: EVENT PLAYER
-  - name: HEALTH
+    default: Event Player
+  - name: Health
     description: The type of max health to acquire.
     type: Health
-    default: HEALTH
+    default: Health
   return: unsigned float
   en-US: Max Health of Type
 _&getCurrentWeapon:
   description: The currently held weapon of a player. Returns 2 for Baby Dva's gun,
     Torbjorn's hammer, and Mercy's pistol; 1 otherwise.
   args:
-  - name: PLAYER
+  - name: Player
     description: The player whose weapon to acquire.
     type: Player
-    default: EVENT PLAYER
+    default: Event Player
   return: unsigned int
   en-US: Weapon
 Color:
@@ -3948,11 +3948,11 @@ workshopSettingReal:
   - name: Category
     description: The name of the category in which this setting will be found.
     type: CustomStringLiteral
-    default: CUSTOM STRING
+    default: Custom String
   - name: Name
     description: The name of this setting.
     type: CustomStringLiteral
-    default: CUSTOM STRING
+    default: Custom String
   - name: Default
     description: The default value for this setting.
     type: FloatLiteral
@@ -3985,11 +3985,11 @@ workshopSettingInteger:
   - name: Category
     description: The name of the category in which this setting will be found.
     type: CustomStringLiteral
-    default: CUSTOM STRING
+    default: Custom String
   - name: Name
     description: The name of this setting.
     type: CustomStringLiteral
-    default: CUSTOM STRING
+    default: Custom String
   - name: Default
     description: The default value for this setting.
     type: FloatLiteral
@@ -4022,11 +4022,11 @@ workshopSettingToggle:
   - name: Category
     description: The name of the category in which this setting will be found.
     type: CustomStringLiteral
-    default: CUSTOM STRING
+    default: Custom String
   - name: Name
     description: The name of this setting.
     type: CustomStringLiteral
-    default: CUSTOM STRING
+    default: Custom String
   - name: Default
     description: The default value for this setting.
     type: BoolLiteral

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -10,7 +10,6 @@ _&getAbilityCooldown:
     type: Button
     default: Button
   return: Float
-  guid: 0000000109B3
   en-US: Ability Cooldown
   es-MX: Reutilización de habilidad
   fr-FR: Temps de recharge de la capacité
@@ -30,7 +29,6 @@ abilityIconString:
     type: Button
     default: Button
   return: String
-  guid: 000000010B52
   en-US: Ability Icon String
   es-MX: Cadena de ícono de habilidad
   fr-FR: Chaîne d’icône de la capacité
@@ -45,7 +43,6 @@ abs:
     type: float
     default: Number
   return: Float
-  guid: 00000000C358
   en-US: Absolute Value
   es-MX: Valor absoluto
   fr-FR: Valeur absolue
@@ -53,7 +50,6 @@ abs:
   pt-BR: Valor Absoluto
   zh-CN: 绝对值
 __add__:
-  guid: 00000000C408
   description: The sum of two numbers or vectors.
   args_allow_null: true
   args:
@@ -89,7 +85,6 @@ getDeadPlayers:
     default: Team
   return:
     Array: Player
-  guid: 00000000B265
   en-US: All Dead Players
   es-MX: Todos los jugadores muertos
   fr-FR: Tous les joueurs morts
@@ -106,7 +101,6 @@ getDamageHeroes:
   args: []
   return:
     Array: Hero
-  guid: 00000000D40A
   en-US: All Damage Heroes
   de-DE: Alle Schadenshelden
   es-MX: Todos los héroes de daño
@@ -115,7 +109,6 @@ getDamageHeroes:
   pt-BR: Todos os Heróis de Dano
   zh-CN: 所有输出英雄
 getAllHeroes:
-  guid: 00000000BF58
   description: "The array of all heroes in overwatch. The order is as follows:\n        \n
     \       0. Reaper   \n        1. Tracer   \n        2. Mercy    \n        3. Hanzo
     \   \n        4. Torbjorn \n        5. Reinhardt\n        6. Pharah   \n        7.
@@ -144,7 +137,6 @@ getLivingPlayers:
     default: Team
   return:
     Array: Player
-  guid: 00000000B264
   en-US: All Living Players
   es-MX: Todos los jugadores vivos
   fr-FR: Tous les joueurs en vie
@@ -160,7 +152,6 @@ getPlayers:
     default: Team
   return:
     Array: Player
-  guid: 00000000B261
   en-US: All Players
   es-MX: Todos los jugadores
   fr-FR: Tous les joueurs
@@ -177,7 +168,6 @@ getPlayersNotOnObjective:
     default: Team
   return:
     Array: Player
-  guid: 00000000B267
   en-US: All Players Not On Objective
   es-MX: Todos los jugadores que no están en el objetivo
   fr-FR: Tous les joueurs éloignés de l’objectif
@@ -194,7 +184,6 @@ getPlayersOnObjective:
     default: Team
   return:
     Array: Player
-  guid: 00000000B266
   en-US: All Players On Objective
   es-MX: Todos los jugadores que están en el objetivo
   fr-FR: Tous les joueurs sur l’objectif
@@ -211,7 +200,6 @@ _&getAllowedHeroes:
     default: Event Player
   return:
     Array: Hero
-  guid: 00000000BBA8
   en-US: Allowed Heroes
   es-MX: Héroes permitidos
   fr-FR: Héros autorisés
@@ -225,7 +213,6 @@ getSupportHeroes:
   args: []
   return:
     Array: Hero
-  guid: 00000000D40B
   en-US: All Support Heroes
   de-DE: Alle Unterstützungshelden
   es-MX: Todos los héroes de apoyo
@@ -241,7 +228,6 @@ getTankHeroes:
   args: []
   return:
     Array: Hero
-  guid: 00000000D40C
   en-US: All Tank Heroes
   de-DE: Alle Tankhelden
   es-MX: Todos los héroes tanques
@@ -258,7 +244,6 @@ _&getAltitude:
     type: Player
     default: Event Player
   return: Float
-  guid: 00000000B11D
   en-US: Altitude Of
   es-MX: Altitud de
   fr-FR: Altitude de
@@ -279,7 +264,6 @@ __and__:
     type: bool
     default: 'True'
   return: bool
-  guid: 00000000B273
   en-US: And
   es-MX: Y
   fr-FR: Et
@@ -301,7 +285,6 @@ angleBetweenVectors:
     type: Direction
     default: Vector
   return: Float
-  guid: 00000000C813
   en-US: Angle Between Vectors
   es-MX: Ángulo entre vectores
   fr-FR: Angle entre deux vecteurs
@@ -322,7 +305,6 @@ angleDifference:
     type: float
     default: Number
   return: float
-  guid: 00000000B282
   en-US: Angle Difference
   es-MX: Diferencia de ángulo
   fr-FR: Différence entre angles
@@ -330,7 +312,6 @@ angleDifference:
   pt-BR: Diferença de Ângulo
   zh-CN: 角度差
 __concat__:
-  guid: 00000000C41A
   description: A copy of an array with one or more values appended to the end.
   args_allow_null: true
   args:
@@ -360,7 +341,6 @@ acosDeg:
     type: float
     default: Number
   return: float
-  guid: 00000000C809
   en-US: Arccosine In Degrees
   es-MX: Arcocoseno en grados
   fr-FR: Arc cosinus en degrés
@@ -375,7 +355,6 @@ acos:
     type: float
     default: Number
   return: float
-  guid: 00000000C807
   en-US: Arccosine In Radians
   es-MX: Arcocoseno en radianes
   fr-FR: Arc cosinus en radians
@@ -390,7 +369,6 @@ asinDeg:
     type: float
     default: Number
   return: float
-  guid: 00000000C805
   en-US: Arcsine In Degrees
   es-MX: Arcoseno en grados
   fr-FR: Arc sinus en degrés
@@ -405,7 +383,6 @@ asin:
     type: float
     default: Number
   return: float
-  guid: 00000000C803
   en-US: Arcsine In Radians
   es-MX: Arcoseno en radianes
   fr-FR: Arc sinus en radians
@@ -425,7 +402,6 @@ atan2Deg:
     type: float
     default: Number
   return: float
-  guid: 00000000C801
   en-US: Arctangent In Degrees
   es-MX: Arcotangente en grados
   fr-FR: Arc tangente en degrés
@@ -445,7 +421,6 @@ atan2:
     type: float
     default: Number
   return: float
-  guid: 00000000C7FF
   en-US: Arctangent In Radians
   es-MX: Arcotangente en radianes
   fr-FR: Arc tangente en radians
@@ -463,7 +438,6 @@ __array__:
     - Array
     default: 'Null'
   return: Array
-  guid: 000000010BC0
   en-US: Array
   es-ES: Matriz
   es-MX: Matriz
@@ -486,7 +460,6 @@ __arrayContains__:
     type: Object
     default: Number
   return: bool
-  guid: 00000000C336
   en-US: Array Contains
   es-MX: La matriz contiene
   fr-FR: Contenu du tableau
@@ -514,7 +487,6 @@ __arraySlice__:
     default: Number
   return:
     Array: Object
-  guid: 00000000B597
   en-US: Array Slice
   es-MX: Extracción de matriz
   fr-FR: Section de tableau
@@ -522,7 +494,6 @@ __arraySlice__:
   pt-BR: Fatia da Matriz
   zh-CN: 数组分割
 attacker:
-  guid: 00000000B32F
   description: The player that dealt the damage for the event currently being processed
     by this rule. May be the same as the victim or the event player.
   args:
@@ -534,7 +505,6 @@ attacker:
   pt-BR: Atacante
   zh-CN: 攻击方
 Vector.Backward:
-  guid: 00000000B11B
   description: Shorthand for the directional vector(0, 0, -1), which points backward.
   args:
   return:
@@ -556,7 +526,6 @@ __button__:
     type: ButtonLiteral
     default: Interact
   return: Button
-  guid: 000000010B3B
   en-US: Button
   es-MX: Botón
   fr-FR: Bouton
@@ -575,7 +544,6 @@ getClosestPlayer:
     type: Team
     default: Team
   return: Player
-  guid: 00000000B1DE
   en-US: Closest Player To
   es-MX: Jugador más cercano a
   fr-FR: Joueur le plus proche de
@@ -604,7 +572,6 @@ __compare__:
     - Array
     default: Number
   return: bool
-  guid: 00000000B276
   en-US: Compare
   es-MX: Comparar
   fr-FR: Comparer
@@ -619,7 +586,6 @@ getControlScorePercentage:
     type: Team
     default: Team
   return: Float
-  guid: 00000000B37C
   en-US: Control Mode Scoring Percentage
   es-MX: Porcentaje de puntuación en el modo Control
   fr-FR: Pourcentage du score en mode Contrôle
@@ -631,7 +597,6 @@ getControlScoringTeam:
     mode. Results in all if neither team is accumulating score.
   args: []
   return: Team
-  guid: 00000000B39A
   en-US: Control Mode Scoring Team
   es-MX: Equipo que anota en el modo Control
   fr-FR: Équipe contrôlant le point en mode Contrôle
@@ -646,7 +611,6 @@ cosDeg:
     type: float
     default: Number
   return: float
-  guid: 00000000C33E
   en-US: Cosine From Degrees
   es-MX: Coseno en grados
   fr-FR: Cosinus en degrés
@@ -661,7 +625,6 @@ cos:
     type: float
     default: Number
   return: float
-  guid: 00000000C342
   en-US: Cosine From Radians
   es-MX: Coseno en radianes
   fr-FR: Cosinus en radians
@@ -676,7 +639,6 @@ len:
     type: Array
     default: Global Variable
   return: Integer
-  guid: 00000000B26E
   en-US: Count Of
   es-MX: Conteo de
   fr-FR: Décompte de
@@ -695,7 +657,6 @@ crossProduct:
     type: Vector
     default: Vector
   return: Vector
-  guid: 00000000C35D
   en-US: Cross Product
   es-MX: Producto vectorial
   fr-FR: Produit croisé
@@ -709,7 +670,6 @@ __currentArrayElement__:
   return:
   - Object
   - Array
-  guid: 00000000B5B9
   en-US: Current Array Element
   es-MX: Elemento de matriz actual
   fr-FR: Élément de tableau actuel
@@ -728,7 +688,6 @@ getCurrentGamemode:
   description: The current game mode of the custom game.
   args: []
   return: Gamemode
-  guid: 00000000F163
   en-US: Current Game Mode
   es-MX: Modo de juego actual
   fr-FR: Mode de jeu actuel
@@ -736,7 +695,6 @@ getCurrentGamemode:
   pt-BR: Modo de jogo atual
   zh-CN: 当前比赛模式
 getCurrentMap:
-  guid: 00000000D418
   description: The current map of the custom game.
   args: []
   return: Map
@@ -766,7 +724,6 @@ __customString__:
     type: Object
     default: 'Null'
   return: String
-  guid: 00000000CE3C
   en-US: Custom String
   es-MX: Cadena personalizada
   fr-FR: Chaîne personnalisée
@@ -785,7 +742,6 @@ angleToDirection:
     type: float
     default: Number
   return: Direction
-  guid: 00000000BB2D
   en-US: Direction From Angles
   es-MX: Dirección desde los ángulos
   fr-FR: Direction depuis des angles
@@ -804,7 +760,6 @@ directionTowards:
     type: Position
     default: Vector
   return: Direction
-  guid: 00000000B1EA
   en-US: Direction Towards
   es-MX: Dirección hacia
   fr-FR: Direction
@@ -823,7 +778,6 @@ distance:
     type: Position
     default: Vector
   return: Float
-  guid: 00000000B1E7
   en-US: Distance Between
   es-MX: Distancia entre
   fr-FR: Distance entre
@@ -831,7 +785,6 @@ distance:
   pt-BR: Distância entre
   zh-CN: 相距距离
 __divide__:
-  guid: 00000000C40F
   description: The ratio of two numbers or vectors. A vector divided by a number will
     yield a scaled vector. Division by zero results in zero.
   args_allow_null: true
@@ -871,7 +824,6 @@ dotProduct:
     type: Vector
     default: Vector
   return: float
-  guid: 00000000C35A
   en-US: Dot Product
   es-MX: Producto escalar
   fr-FR: Produit scalaire
@@ -879,7 +831,6 @@ dotProduct:
   pt-BR: Produto Escalar
   zh-CN: 标量积
 Vector.DOWN:
-  guid: 00000000B119
   description: Shorthand for the directional vector(0, -1, 0), which points downward.
   args:
   return:
@@ -897,7 +848,6 @@ __emptyArray__:
   description: An array with no elements.
   args: []
   return: Array
-  guid: 00000000BF5A
   en-US: Empty Array
   es-MX: Matriz vacía
   fr-FR: Tableau vide
@@ -915,7 +865,6 @@ entityExists:
     - EntityId
     default: Event Player
   return: bool
-  guid: 00000000B619
   en-US: Entity Exists
   es-MX: La entidad existe
   fr-FR: Existence de l’entité
@@ -927,7 +876,6 @@ eventAbility:
     by button.
   args:
   return: Button
-  guid: 0000000109CF
   en-US: Event Ability
   es-MX: Evento de habilidad
   fr-FR: Capacité d’évènement
@@ -939,7 +887,6 @@ eventDamage:
     being processed by this rule.
   args:
   return: Float
-  guid: 00000000C635
   en-US: Event Damage
   es-MX: Daño de evento
   fr-FR: Dégâts d’évènement
@@ -951,7 +898,6 @@ eventDirection:
     rule.
   args:
   return: Direction
-  guid: 0000000107D5
   en-US: Event Direction
   es-MX: Dirección del evento
   fr-FR: Direction de l’évènement
@@ -963,7 +909,6 @@ eventHealing:
     being processed by this rule.
   args:
   return: Float
-  guid: 00000000CC33
   en-US: Event Healing
   es-MX: Sanación de evento
   fr-FR: Évènement soin
@@ -975,7 +920,6 @@ eventPlayer:
     same as the attacker or victim.
   args:
   return: Player
-  guid: 00000000B331
   en-US: Event Player
   es-MX: Jugador del evento
   fr-FR: Joueur exécutant
@@ -987,7 +931,6 @@ eventWasCriticalHit:
     event currently being processed by this rule.
   args:
   return: bool
-  guid: 00000000C637
   en-US: Event Was Critical Hit
   es-MX: El evento fue un golpe crítico
   fr-FR: L’évènement était un coup critique
@@ -999,7 +942,6 @@ eventWasHealthPack:
     processed by this rule.
   args:
   return: bool
-  guid: 00000000FC80
   en-US: Event Was Health Pack
   es-MX: Evento fue suministro de salud
   fr-FR: L’évènement était un kit de soins
@@ -1007,7 +949,6 @@ eventWasHealthPack:
   pt-BR: Evento foi kit Médico
   zh-CN: 事件为急救包
 _&getEyePosition:
-  guid: 00000000C595
   description: The position of a player's first person view (used for aiming)
   args:
   - name: Player
@@ -1030,7 +971,6 @@ _&getFacingDirection:
     type: Player
     default: Event Player
   return: Direction
-  guid: 00000000B281
   en-US: Facing Direction Of
   es-MX: Dirección de orientación de
   fr-FR: Regard en direction de
@@ -1041,7 +981,6 @@ _&getFacingDirection:
   description: The boolean value of false.
   args:
   return: bool
-  guid: 00000000AC3A
   en-US: 'False'
   es-MX: Falso
   fr-FR: Faux
@@ -1058,7 +997,6 @@ getFarthestPlayer:
     type: Team
     default: Team
   return: Player
-  guid: 00000000B1DF
   en-US: Farthest Player From
   es-MX: Jugador más lejos de
   fr-FR: Joueur le plus éloigné de
@@ -1080,7 +1018,6 @@ __filteredArray__:
     type: bool
     default: Compare
   return: Array
-  guid: 00000000B5B7
   en-US: Filtered Array
   es-MX: Matriz filtrada
   fr-FR: Tableau filtré
@@ -1098,7 +1035,6 @@ __firstOf__:
   return:
   - Object
   - Array
-  guid: 00000000B5C2
   en-US: First Of
   es-MX: Primero de
   fr-FR: Premier de
@@ -1113,7 +1049,6 @@ getFlagPosition:
     type: Team
     default: Team
   return: Position
-  guid: 00000000B3A0
   en-US: Flag Position
   es-MX: Posición de la bandera
   fr-FR: Position du drapeau
@@ -1121,7 +1056,6 @@ getFlagPosition:
   pt-BR: Posição da Bandeira
   zh-CN: 旗帜位置
 Vector.Forward:
-  guid: 00000000B11A
   description: Shorthand for the directional vector(0, 0, 1), which points forward.
   args:
   return:
@@ -1137,7 +1071,6 @@ Vector.Forward:
   zh-CN: 前
 __global__:
   return: GlobalVariable
-  guid: 00000000EAFB
   en-US: Global
   it-IT: Globale
   ja-JP: グローバル
@@ -1154,7 +1087,6 @@ __globalVar__:
     type: GlobalVariable
     default: A
   return: Value
-  guid: 00000000B0F9
   en-US: Global Variable
   es-MX: Variable global
   fr-FR: Variable globale
@@ -1171,7 +1103,6 @@ _&hasSpawned:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000C192
   en-US: Has Spawned
   es-MX: Ha aparecido
   fr-FR: Apparition
@@ -1191,7 +1122,6 @@ _&hasStatusEffect:
     type: Status
     default: Hacked
   return: bool
-  guid: 00000000B363
   en-US: Has Status
   es-MX: Tiene estado
   fr-FR: Statut
@@ -1203,7 +1133,6 @@ healee:
     processed by this rule. May be the same as the healer or the event player.
   args:
   return: Player
-  guid: 00000000CC1C
   en-US: Healee
   es-MX: Sanado
   fr-FR: Soigné
@@ -1211,7 +1140,6 @@ healee:
   pt-BR: Curado
   zh-CN: 受治疗者
 healer:
-  guid: 00000000CC1A
   description: The player that dealt the healing for the event currently being processed
     by this rule. May be the same as the healee or the event player.
   args:
@@ -1223,7 +1151,6 @@ healer:
   pt-BR: Curandeiro
   zh-CN: 治疗者
 _&getHealth:
-  guid: 0000000081C2
   description: The current health of a player, including armor and shields.
   args:
   - name: Player
@@ -1247,7 +1174,6 @@ _&getNormalizedHealth:
     type: Player
     default: Event Player
   return: Float
-  guid: 0000000081C3
   en-US: Normalized Health
   es-MX: Salud normalizada
   fr-FR: Points de vie normalisés
@@ -1255,7 +1181,6 @@ _&getNormalizedHealth:
   pt-BR: Vida Normalizada
   zh-CN: 标准化生命值
 __hero__:
-  guid: 00000000ACAA
   description: A hero constant.
   args:
   - name: Hero
@@ -1278,7 +1203,6 @@ _&getHeroOfDuplication:
     type: Player
     default: Event Player
   return: Hero
-  guid: 000000010E6A
   en-US: Hero Being Duplicated
   es-MX: Héroe que está siendo copiado
   fr-FR: Héros dupliqué
@@ -1293,7 +1217,6 @@ heroIcon:
     type: Hero
     default: Hero
   return: String
-  guid: 00000000C1FE
   en-US: Hero Icon String
   es-MX: Cadena de ícono de héroe
   fr-FR: Chaîne d’icône du héros
@@ -1308,7 +1231,6 @@ _&getCurrentHero:
     type: Player
     default: Event Player
   return: Hero
-  guid: 00000000ACA9
   en-US: Hero Of
   es-MX: Héroe de
   fr-FR: Héros de
@@ -1325,7 +1247,6 @@ horizontalAngleFromDirection:
     type: Direction
     default: Vector
   return: float
-  guid: 00000000BB2C
   en-US: Horizontal Angle From Direction
   es-MX: Ángulo horizontal desde la dirección
   fr-FR: Angle horizontal depuis une direction
@@ -1346,7 +1267,6 @@ horizontalAngleTowards:
     type: Position
     default: Vector
   return: float
-  guid: 00000000B27D
   en-US: Horizontal Angle Towards
   es-MX: Ángulo horizontal en dirección a
   fr-FR: Angle horizontal vers
@@ -1354,7 +1274,6 @@ horizontalAngleTowards:
   pt-BR: Ângulo Horizontal Rumo a
   zh-CN: 水平方向夹角
 __gamemode__:
-  guid: 00000000F161
   description: A game mode constant.
   args:
   - name: GAME MODE
@@ -1378,7 +1297,6 @@ _&getHorizontalFacingAngle:
     type: Player
     default: Event Player
   return: float
-  guid: 00000000B27F
   en-US: Horizontal Facing Angle Of
   es-MX: Ángulo horizontal de orientación de
   fr-FR: Angle horizontal du regard de
@@ -1394,7 +1312,6 @@ _&getHorizontalSpeed:
     type: Player
     default: Event Player
   return: Float
-  guid: 00000000B25E
   en-US: Horizontal Speed Of
   es-MX: Velocidad horizontal de
   fr-FR: Vitesse horizontale de
@@ -1406,7 +1323,6 @@ hostPlayer:
     will change if the current host player leaves the match.
   args:
   return: Player
-  guid: 00000000CC1E
   en-US: Host Player
   es-MX: Jugador anfitrión
   fr-FR: Joueur hôte
@@ -1421,7 +1337,6 @@ iconString:
     type: Icon
     default: 'Arrow: Down'
   return: String
-  guid: 00000000CCDC
   en-US: Icon String
   es-MX: Cadena de ícono
   fr-FR: Chaîne d’icône
@@ -1452,7 +1367,6 @@ __ifThenElse__:
   return:
   - Object
   - Array
-  guid: 000000010BC7
   en-US: If-Then-Else
   fr-FR: Si-Alors-Sinon
   ja-JP: If-Then-Else
@@ -1470,7 +1384,6 @@ __indexOfArrayValue__:
     type: Object
     default: Number
   return: Integer
-  guid: 00000000C330
   en-US: Index Of Array Value
   es-MX: Índice del valor de la matriz
   fr-FR: Index de la valeur de tableau
@@ -1485,7 +1398,6 @@ _&isAlive:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B278
   en-US: Is Alive
   es-MX: Está vivo
   fr-FR: En vie
@@ -1496,7 +1408,6 @@ isAssemblingHeroes:
   description: Whether the match is currently in its assemble heroes phase.
   args: []
   return: bool
-  guid: 00000000B35C
   en-US: Is Assembling Heroes
   es-MX: En Forma tu equipo
   fr-FR: Phase de choix de héros
@@ -1507,7 +1418,6 @@ isMatchBetweenRounds:
   description: Whether the match is between rounds.
   args: []
   return: bool
-  guid: 00000000B35F
   en-US: Is Between Rounds
   es-MX: Entre rondas
   fr-FR: Entre deux manches
@@ -1526,7 +1436,6 @@ _&isHoldingButton:
     type: ButtonLiteral
     default: Primary Fire
   return: bool
-  guid: 00000000B2F3
   en-US: Is Button Held
   es-MX: Botón presionado
   fr-FR: Bouton maintenu enfoncé
@@ -1548,7 +1457,6 @@ _&isCommunicating:
     type: Comms
     default: Voice Line Up
   return: bool
-  guid: 00000000B268
   en-US: Is Communicating
   es-MX: Se está comunicando
   fr-FR: Communication
@@ -1564,7 +1472,6 @@ _&isCommunicatingAnything:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B9E5
   en-US: Is Communicating Any
   es-MX: Comunica algo
   fr-FR: N’importe quelle communication
@@ -1579,7 +1486,6 @@ _&isCommunicatingEmote:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B9E8
   en-US: Is Communicating Any Emote
   es-MX: Comunica un gesto
   fr-FR: Communication par emote
@@ -1595,7 +1501,6 @@ _&isCommunicatingVoiceline:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B9E7
   en-US: Is Communicating Any Voice line
   es-MX: Comunica una línea de voz
   fr-FR: Communication par réplique
@@ -1606,7 +1511,6 @@ isControlPointLocked:
   description: Whether the point is locked in control mode.
   args: []
   return: bool
-  guid: 00000000B37B
   en-US: Is Control Mode Point Locked
   es-MX: Punto bloqueado en el modo Control
   fr-FR: Point de contrôle verrouillé
@@ -1621,7 +1525,6 @@ _&isCrouching:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B289
   en-US: Is Crouching
   es-MX: Agachado
   fr-FR: Accroupi
@@ -1639,7 +1542,6 @@ _&isInAlternateForm:
     type: Player
     default: Event Player
   return: bool
-  guid: 000000010E62
   en-US: Is In Alternate Form
   es-MX: Está en su forma alterna
   fr-FR: Est dans une forme alternative
@@ -1650,7 +1552,6 @@ isInSuddenDeath:
   description: Whether the current game of capture the flag is in sudden death.
   args: []
   return: bool
-  guid: 00000000B3A4
   en-US: Is CTF Mode In Sudden Death
   es-MX: Modo CLB en muerte súbita
   fr-FR: Capture du drapeau en mort subite
@@ -1665,7 +1566,6 @@ _&isDead:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B277
   en-US: Is Dead
   es-MX: Está muerto
   fr-FR: Mort
@@ -1680,7 +1580,6 @@ _&isDummy:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000CEDF
   en-US: Is Dummy Bot
   es-MX: Robot de entrenamiento
   fr-FR: Est une I.A.
@@ -1696,7 +1595,6 @@ _&isDuplicatingAHero:
     type: Player
     default: Event Player
   return: bool
-  guid: 000000010E65
   en-US: Is Duplicating
   es-MX: Está copiando
   fr-FR: Effectue une duplication
@@ -1711,7 +1609,6 @@ _&isFiringPrimaryFire:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000C3E7
   en-US: Is Firing Primary
   es-MX: Está usando el disparo principal
   fr-FR: Tir principal
@@ -1726,7 +1623,6 @@ _&isFiringSecondaryFire:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000C3E9
   en-US: Is Firing Secondary
   es-MX: Está usando el disparo secundario
   fr-FR: Tir secondaire
@@ -1741,7 +1637,6 @@ isFlagAtBase:
     type: Team
     default: Team
   return: bool
-  guid: 00000000B3A1
   en-US: Is Flag At Base
   es-MX: La bandera está en la base
   fr-FR: Drapeau à la base
@@ -1757,7 +1652,6 @@ isFlagBeingCarried:
     type: Team
     default: Team
   return: bool
-  guid: 00000000B3A2
   en-US: Is Flag Being Carried
   es-MX: La bandera está siendo transportada
   fr-FR: Drapeau transporté
@@ -1769,7 +1663,6 @@ isGameInProgress:
     combat and scoring are allowed).
   args: []
   return: bool
-  guid: 00000000B35E
   en-US: Is Game In Progress
   es-MX: Partida en curso
   fr-FR: Partie en cours
@@ -1789,7 +1682,6 @@ teamHasHero:
     type: Team
     default: Team
   return: bool
-  guid: 00000000B292
   en-US: Is Hero Being Played
   es-MX: Jugando con el héroe
   fr-FR: Héros joué
@@ -1804,7 +1696,6 @@ _&isInAir:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B28B
   en-US: Is In Air
   es-MX: En el aire
   fr-FR: Dans les airs
@@ -1835,7 +1726,6 @@ isInLoS:
     type: BarrierLos
     default: Barriers DO NOT BLOCK LOS
   return: bool
-  guid: 00000000B1EC
   en-US: Is In Line of Sight
   es-MX: En la línea de visión
   fr-FR: Dans la ligne de vue
@@ -1846,7 +1736,6 @@ isInSetup:
   description: Whether the match is currently in its setup phase.
   args: []
   return: bool
-  guid: 00000000B35D
   en-US: Is In Setup
   es-MX: En preparación
   fr-FR: Dans les paramètres
@@ -1862,7 +1751,6 @@ _&isInSpawnRoom:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B3B1
   en-US: Is In Spawn Room
   es-MX: En el cuarto de reaparición
   fr-FR: Dans la salle d’apparition
@@ -1885,7 +1773,6 @@ _&isInViewAngle:
     type: float
     default: Number
   return: bool
-  guid: 00000000BF7C
   en-US: Is In View Angle
   es-MX: En el ángulo de vista
   fr-FR: Dans le champ de vision
@@ -1900,7 +1787,6 @@ _&isJumping:
     type: Player
     default: Event Player
   return: bool
-  guid: 0000000105A0
   en-US: Is Jumping
   es-MX: Está saltando
   fr-FR: Utilise Saut
@@ -1911,7 +1797,6 @@ isMatchComplete:
   description: Whether the match has finished.
   args: []
   return: bool
-  guid: 00000000B360
   en-US: Is Match Complete
   es-MX: Partida Completada
   fr-FR: Partie terminée
@@ -1926,7 +1811,6 @@ _&isMeleeing:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000001059A
   en-US: Is Meleeing
   es-MX: Está usando un ataque melé
   fr-FR: Utilise Mêlée
@@ -1941,7 +1825,6 @@ _&isMoving:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B288
   en-US: Is Moving
   es-MX: En movimiento
   fr-FR: Se déplace
@@ -1959,7 +1842,6 @@ isObjectiveComplete:
     type: Integer
     default: Number
   return: bool
-  guid: 00000000B378
   en-US: Is Objective Complete
   es-MX: Objetivo completado
   fr-FR: Objectif accompli
@@ -1974,7 +1856,6 @@ _&isOnGround:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000BF70
   en-US: Is On Ground
   es-MX: En el suelo
   fr-FR: Au sol
@@ -1990,7 +1871,6 @@ _&isOnObjective:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B3B2
   en-US: Is On Objective
   es-MX: En el objetivo
   fr-FR: Sur l’objectif
@@ -2005,7 +1885,6 @@ _&isOnWall:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000BB0B
   en-US: Is On Wall
   es-MX: En el muro
   fr-FR: Sur le mur
@@ -2020,7 +1899,6 @@ _&isOnFire:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B3B3
   en-US: Is Portrait On Fire
   es-MX: Retrato en llamas
   fr-FR: Portrait « en feu »
@@ -2036,7 +1914,6 @@ _&isStanding:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B287
   en-US: Is Standing
   es-MX: De pie
   fr-FR: Debout
@@ -2052,7 +1929,6 @@ isTeamOnDefense:
     type: Team
     default: Team
   return: bool
-  guid: 00000000B359
   en-US: Is Team On Defense
   es-MX: Equipo defensor
   fr-FR: Équipe en défense
@@ -2068,7 +1944,6 @@ isTeamOnOffense:
     type: Team
     default: Team
   return: bool
-  guid: 00000000B354
   en-US: Is Team On Offense
   es-MX: Equipo atacante
   fr-FR: Équipe en attaque
@@ -2090,7 +1965,6 @@ __all__:
     type: bool
     default: Compare
   return: bool
-  guid: 00000000B5BA
   en-US: Is True For All
   es-MX: Es verdadero para todos
   fr-FR: Vrai pour tous
@@ -2112,7 +1986,6 @@ __any__:
     type: bool
     default: Compare
   return: bool
-  guid: 00000000B5BB
   en-US: Is True For Any
   es-MX: Es verdadero para cualquiera
   fr-FR: Vrai pour n’importe qui
@@ -2127,7 +2000,6 @@ _&isUsingAbility1:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000C3EB
   en-US: Is Using Ability 1
   es-MX: Está utilizando la habilidad 1
   fr-FR: Capacité 1 utilisée
@@ -2142,7 +2014,6 @@ _&isUsingAbility2:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000C3ED
   en-US: Is Using Ability 2
   es-MX: Está utilizando la habilidad 2
   fr-FR: Capacité 2 utilisée
@@ -2157,7 +2028,6 @@ _&isUsingUltimate:
     type: Player
     default: Event Player
   return: bool
-  guid: 00000000B9D4
   en-US: Is Using Ultimate
   es-MX: Está usando la habilidad máxima
   fr-FR: Capacité ultime utilisée
@@ -2168,7 +2038,6 @@ isWaitingForPlayers:
   description: Whether the match is waiting for players to join before starting.
   args: []
   return: bool
-  guid: 00000000B35B
   en-US: Is Waiting For Players
   es-MX: Esperando jugadores
   fr-FR: En attente de joueurs
@@ -2180,7 +2049,6 @@ getLastCreatedEntity:
     player (or created at the global level).
   args: []
   return: EntityId
-  guid: 00000000B362
   en-US: Last Created Entity
   es-MX: Última entidad creada
   fr-FR: Dernière entité créée
@@ -2192,7 +2060,6 @@ getLastDamageModification:
     that was executed by the event player (or executed at the global level).
   args: []
   return: DamageModificationId
-  guid: 00000000C64A
   en-US: Last Damage Modification ID
   es-MX: ID de modificación de daño anterior
   fr-FR: Dernier identifiant de modification de dégâts
@@ -2204,7 +2071,6 @@ getLastDoT:
     executed by the event player (or executed at the global level).
   args: []
   return: DotId
-  guid: 00000000B263
   en-US: Last Damage Over Time ID
   es-MX: ID de daño con el tiempo anterior
   fr-FR: Dernier identifiant de dégâts sur la durée
@@ -2216,7 +2082,6 @@ getLastHoT:
     by the event player (or executed at the global level).
   args: []
   return: HotId
-  guid: 00000000B262
   en-US: Last Heal Over Time ID
   es-MX: ID de sanación con el tiempo anterior
   fr-FR: Dernier identifiant de soins sur la durée
@@ -2228,7 +2093,6 @@ getLastHealingModification:
     that was executed by the event player (or executed at the global level).
   args: []
   return: HealingModificationId
-  guid: 00000000FD2A
   en-US: Last Healing Modification ID
   es-MX: ID de modificación de sanación anterior
   fr-FR: Dernier identifiant de modification de soins
@@ -2246,7 +2110,6 @@ __lastOf__:
   return:
   - Object
   - Array
-  guid: 00000000B5C1
   en-US: Last Of
   es-MX: Último de
   fr-FR: Dernier
@@ -2258,7 +2121,6 @@ getLastCreatedText:
     created at the global level) via the create hud text or create in-world text action.
   args: []
   return: TextId
-  guid: 00000000BAFE
   en-US: Last Text ID
   es-MX: ID de texto anterior
   fr-FR: Dernier identifiant de texte
@@ -2266,7 +2128,6 @@ getLastCreatedText:
   pt-BR: ID de Texto Mais Recente
   zh-CN: 上一个文本ID
 Vector.Left:
-  guid: 00000000B116
   description: Shorthand for the directional vector(1, 0, 0), which points to the
     left.
   args:
@@ -2300,7 +2161,6 @@ localVector:
     type: Transform
     default: ROTATION
   return: Vector
-  guid: 00000000B342
   en-US: Local Vector Of
   es-MX: Vector local de
   fr-FR: Vecteur local de
@@ -2308,7 +2168,6 @@ localVector:
   pt-BR: Vetor Local de
   zh-CN: 本地矢量
 __map__:
-  guid: 00000000D411
   description: A map constant.
   args:
   - name: MAP
@@ -2331,7 +2190,6 @@ getMatchRound:
   description: The current round of the match, counting up from 1.
   args: []
   return: Integer
-  guid: 00000000B375
   en-US: Match Round
   es-MX: Ronda de la partida
   fr-FR: Manche de la partie
@@ -2342,7 +2200,6 @@ getMatchTime:
   description: The amount of time in seconds remaining in the current game mode phase.
   args: []
   return: Float
-  guid: 00000000AD3B
   en-US: Match Time
   es-MX: Tiempo de la partida
   fr-FR: Temps de jeu
@@ -2350,7 +2207,6 @@ getMatchTime:
   pt-BR: Tempo da Partida
   zh-CN: 比赛时间
 max:
-  guid: 00000000C418
   description: The greater of two numbers.
   args:
   - name: Value
@@ -2376,7 +2232,6 @@ _&getMaxHealth:
     type: Player
     default: Event Player
   return: Float
-  guid: 0000000081C4
   en-US: Max Health
   es-MX: Salud máxima
   fr-FR: Points de vie maximum
@@ -2384,7 +2239,6 @@ _&getMaxHealth:
   pt-BR: Vida Máxima
   zh-CN: 最大生命值
 min:
-  guid: 00000000C416
   description: The lesser of two numbers.
   args:
   - name: Value
@@ -2403,7 +2257,6 @@ min:
   pt-BR: Mín.
   zh-CN: 较小
 __modulo__:
-  guid: 00000000C410
   description: The remainder of the left-hand operand divided by the right-hand operand.
     Any number modulo zero results in zero.
   args:
@@ -2422,7 +2275,6 @@ __modulo__:
   pt-BR: Modular
   zh-CN: 余数
 __multiply__:
-  guid: 00000000C40D
   description: The product of two numbers or vectors. A vector multiplied by a number
     will yield a scaled vector.
   args_allow_null: true
@@ -2459,7 +2311,6 @@ nearestWalkablePosition:
     type: Position
     default: Vector
   return: Position
-  guid: 00000000C324
   en-US: Nearest Walkable Position
   es-MX: Posición caminable más cercana
   fr-FR: Position la plus proche en marchant
@@ -2474,7 +2325,6 @@ normalize:
     type: Vector
     default: Vector
   return: Vector
-  guid: 00000000C344
   en-US: Normalize
   es-MX: Normalizar
   fr-FR: Normalisation
@@ -2482,7 +2332,6 @@ normalize:
   pt-BR: Normalizar
   zh-CN: 归一化
 __not__:
-  guid: 00000000B275
   description: Whether the input is false (or equivalent to false).
   args:
   - name: Value
@@ -2502,7 +2351,6 @@ __not__:
     input. Equivalent to the real number 0 for the purposes of comparison and debugging.
   args:
   return: Player
-  guid: 00000000B594
   en-US: 'Null'
   es-MX: Nulo
   fr-FR: Non applicable
@@ -2517,7 +2365,6 @@ getNumberOfDeadPlayers:
     type: Team
     default: Team
   return: Integer
-  guid: 00000000B29A
   en-US: Number of Dead Players
   es-MX: Cantidad de jugadores muertos
   fr-FR: Nombre de joueurs morts
@@ -2533,7 +2380,6 @@ _&getNumberOfDeaths:
     type: Player
     default: Event Player
   return: Integer
-  guid: 00000000B103
   en-US: Number of Deaths
   es-MX: Cantidad de muertes
   fr-FR: Nombre de morts
@@ -2549,7 +2395,6 @@ _&getNumberOfElims:
     type: Player
     default: Event Player
   return: Integer
-  guid: 00000000B101
   en-US: Number of Eliminations
   es-MX: Cantidad de eliminaciones
   fr-FR: Nombre d’éliminations
@@ -2565,7 +2410,6 @@ _&getNumberOfFinalBlows:
     type: Player
     default: Event Player
   return: Integer
-  guid: 00000000B102
   en-US: Number of Final Blows
   es-MX: Cantidad de golpes de gracia
   fr-FR: Nombre de coups de grâce
@@ -2584,7 +2428,6 @@ getNumberOfHeroes:
     type: Team
     default: Team
   return: Integer
-  guid: 00000000B296
   en-US: Number of Heroes
   es-MX: Cantidad de héroes
   fr-FR: Nombre de héros
@@ -2599,7 +2442,6 @@ getNumberOfLivingPlayers:
     type: Team
     default: Team
   return: Integer
-  guid: 00000000B297
   en-US: Number of Living Players
   es-MX: Cantidad de jugadores vivos
   fr-FR: Nombre de joueurs en vie
@@ -2614,7 +2456,6 @@ getNumberOfPlayers:
     type: Team
     default: Team
   return: Integer
-  guid: 00000000B295
   en-US: Number of Players
   es-MX: Cantidad de jugadores
   fr-FR: Nombre de joueurs
@@ -2630,7 +2471,6 @@ getNumberOfPlayersOnObjective:
     type: Team
     default: Team
   return: Integer
-  guid: 00000000B29B
   en-US: Number of Players On Objective
   es-MX: Cantidad de jugadores en el objetivo
   fr-FR: Nombre de joueurs sur l’objectif
@@ -2642,7 +2482,6 @@ getCurrentObjective:
     active (either 0, 1, or 2). Valid in assault, assault/escort, escort, and control.
   args: []
   return: Integer
-  guid: 00000000B37D
   en-US: Objective Index
   es-MX: Índice de objetivo
   fr-FR: Index de l’objectif
@@ -2661,7 +2500,6 @@ getObjectivePosition:
     type: Integer
     default: Number
   return: Integer
-  guid: 00000000B355
   en-US: Objective Position
   es-MX: Posición del objetivo
   fr-FR: Position de l’objectif
@@ -2676,7 +2514,6 @@ getOppositeTeam:
     type: Team
     default: Team
   return: Team
-  guid: 00000000BB0A
   en-US: Opposite Team Of
   es-MX: Equipo contrario de
   fr-FR: Équipe opposée à
@@ -2684,7 +2521,6 @@ getOppositeTeam:
   pt-BR: Equipe Adversária de
   zh-CN: 对方队伍
 __or__:
-  guid: 00000000B274
   description: Whether either of the two inputs are true (or equivalent to true).
   args:
   - name: Value
@@ -2708,7 +2544,6 @@ getPayloadPosition:
   description: The position in the world of the active payload.
   args: []
   return: Position
-  guid: 00000000B356
   en-US: Payload Position
   es-MX: Posición de la carga
   fr-FR: Position du convoi
@@ -2720,7 +2555,6 @@ getPayloadProgressPercentage:
     (expressed as a percentage).
   args: []
   return: Float
-  guid: 00000000B357
   en-US: Payload Progress Percentage
   es-MX: Porcentaje de progreso de la carga
   fr-FR: Pourcentage de progression du convoi
@@ -2736,7 +2570,6 @@ getFlagCarrier:
     type: Team
     default: Team
   return: Player
-  guid: 00000000B3A3
   en-US: Player Carrying Flag
   es-MX: Jugador que transporta la bandera
   fr-FR: Joueur portant le drapeau
@@ -2756,7 +2589,6 @@ _&getPlayerClosestToReticle:
     type: Team
     default: Team
   return: Player
-  guid: 00000000C328
   en-US: Player Closest To Reticle
   es-MX: Jugador más cercano al retículo
   fr-FR: Joueur le plus proche du réticule
@@ -2776,7 +2608,6 @@ __playerVar__:
     type: PlayerVariable
     default: A
   return: Value
-  guid: 00000000B0FD
   en-US: Player Variable
   es-MX: Variable de jugador
   fr-FR: Variable de joueur
@@ -2799,7 +2630,6 @@ getPlayersInSlot:
   return:
   - Player
   - Array: Player
-  guid: 00000000B334
   en-US: Players In Slot
   es-MX: Jugadores en la posición
   fr-FR: Joueurs dans l’emplacement
@@ -2824,7 +2654,6 @@ _&getPlayersInViewAngle:
     default: Number
   return:
     Array: Player
-  guid: 00000000C32F
   en-US: Players in View Angle
   es-MX: Jugadores en el ángulo de vista
   fr-FR: Joueurs dans le champ de vision
@@ -2844,7 +2673,6 @@ getPlayersOnHero:
     default: Team
   return:
     Array: Player
-  guid: 00000000B338
   en-US: Players On Hero
   es-MX: Jugadores con el héroe
   fr-FR: Joueurs sur le héros
@@ -2876,7 +2704,6 @@ getPlayersInRadius:
     default: 'OFF'
   return:
     Array: Player
-  guid: 00000000B1E0
   en-US: Players Within Radius
   es-MX: Jugadores dentro del radio
   fr-FR: Joueurs dans un rayon
@@ -2888,7 +2715,6 @@ getCapturePercentage:
     as a percentage).
   args: []
   return: float
-  guid: 00000000B358
   en-US: Point Capture Percentage
   es-MX: Porcentaje de captura de punto
   fr-FR: Pourcentage de capture du point
@@ -2903,7 +2729,6 @@ _&getPosition:
     type: Player
     default: Event Player
   return: Position
-  guid: 00000000B11C
   en-US: Position Of
   es-MX: Posición de
   fr-FR: Position de
@@ -2911,7 +2736,6 @@ _&getPosition:
   pt-BR: Posição de
   zh-CN: 所选位置
 __raiseToPower__:
-  guid: 00000000C414
   description: The left-hand operand raised to the power of the right-hand operand.
     If the left-hand operand is negative, the result is always zero.
   args:
@@ -2944,7 +2768,6 @@ random.randint:
     type: Integer
     default: Number
   return: Integer
-  guid: 00000000B59B
   en-US: Random Integer
   es-MX: Número entero aleatorio
   fr-FR: Nombre entier aléatoire
@@ -2963,7 +2786,6 @@ random.uniform:
     type: float
     default: Number
   return: float
-  guid: 00000000B59A
   en-US: Random Real
   es-MX: Número real aleatorio
   fr-FR: Nombre réel aléatoire
@@ -2981,7 +2803,6 @@ random.choice:
   return:
   - Object
   - Array
-  guid: 00000000B599
   en-US: Random Value In Array
   es-MX: Valor aleatorio en matriz
   fr-FR: Valeur aléatoire dans le tableau
@@ -2996,7 +2817,6 @@ random.shuffle:
     type: Array
     default: Global Variable
   return: Array
-  guid: 00000000B598
   en-US: Randomized Array
   es-MX: Matriz aleatorizada
   fr-FR: Tableau aléatoire
@@ -3034,7 +2854,6 @@ __raycastHitNormal__:
     type: bool
     default: 'True'
   return: Direction
-  guid: 00000000C613
   en-US: Ray Cast Hit Normal
   es-MX: Estándar de impacto de lanzamiento de rayo
   fr-FR: Surface intersectée par le rayon émis
@@ -3071,7 +2890,6 @@ __raycastHitPlayer__:
     type: bool
     default: 'True'
   return: Player
-  guid: 00000000C611
   en-US: Ray Cast Hit Player
   es-MX: Jugador de impacto de lanzamiento de rayo
   fr-FR: Joueur intersecté par le rayon émis
@@ -3109,7 +2927,6 @@ __raycastHitPosition__:
     type: BooleanValue
     default: 'True'
   return: Position
-  guid: 00000000C597
   en-US: Ray Cast Hit Position
   es-MX: Posición de impacto de lanzamiento de rayo
   fr-FR: Position d’impact du rayon émis
@@ -3132,7 +2949,6 @@ __removeFromArray__:
     - Array
     default: Number
   return: Array
-  guid: 00000000C421
   en-US: Remove From Array
   es-MX: Eliminar de la matriz
   fr-FR: Supprimer du tableau
@@ -3140,7 +2956,6 @@ __removeFromArray__:
   pt-BR: Remover da Matriz
   zh-CN: 从数组中移除
 Vector.RIGHT:
-  guid: 00000000B117
   description: Shorthand for the directional vector(-1, 0, 0), which points to the
     right.
   args:
@@ -3167,7 +2982,6 @@ __round__:
     type: __Rounding__
     default: UP
   return: Integer
-  guid: 00000000C354
   en-US: Round To Integer
   es-MX: Redondear a número entero
   fr-FR: Arrondir à l’entier
@@ -3183,7 +2997,6 @@ _&getScore:
     type: Player
     default: Event Player
   return: Integer
-  guid: 00000000AD3C
   en-US: Score Of
   es-MX: Puntuación de
   fr-FR: Score de
@@ -3191,7 +3004,6 @@ _&getScore:
   pt-BR: Pontuação de
   zh-CN: 分数
 getServerLoad:
-  guid: 00000000C961
   description: Provides a percentage representing the CPU load of the current game
     instance. As this number approaches or exceeds 100, it becomes increasingly likely
     that the instance will be shut down because it is consuming too many resources.
@@ -3204,7 +3016,6 @@ getServerLoad:
   pt-BR: Uso do Servidor
   zh-CN: 服务器负载
 getAverageServerLoad:
-  guid: 00000000C997
   description: Provides a percentage representing the average CPU load of the current
     game instance over the last two seconds. As this number approaches or exceeds
     100, it becomes increasingly likely that the instance will be shut down because
@@ -3218,7 +3029,6 @@ getAverageServerLoad:
   pt-BR: Média de Uso do Servidor
   zh-CN: 服务器负载平均值
 getPeakServerLoad:
-  guid: 00000000C996
   description: Provides a percentage representing the highest CPU load of the current
     game instance over the last two seconds. As this number approaches or exceeds
     100, it becomes increasingly likely that the instance will be shut down because
@@ -3239,7 +3049,6 @@ sinDeg:
     type: float
     default: Number
   return: float
-  guid: 00000000C33C
   en-US: Sine From Degrees
   es-MX: Seno en grados
   fr-FR: Sinus en degrés
@@ -3254,7 +3063,6 @@ sin:
     type: float
     default: Number
   return: float
-  guid: 00000000C340
   en-US: Sine From Radians
   es-MX: Seno en radianes
   fr-FR: Sinus en radians
@@ -3270,7 +3078,6 @@ _&getSlot:
     type: Player
     default: Event Player
   return: Integer
-  guid: 00000000BB7F
   en-US: Slot Of
   es-MX: Posición de
   fr-FR: Emplacement de
@@ -3294,7 +3101,6 @@ __sortedArray__:
     default: Current Array Element
   return:
     Array: Object
-  guid: 00000000B5C0
   en-US: Sorted Array
   es-MX: Matriz ordenada
   fr-FR: Tableau trié
@@ -3324,7 +3130,6 @@ _&getSpeed:
     type: Player
     default: Event Player
   return: Float
-  guid: 00000000B25D
   en-US: Speed Of
   es-MX: Velocidad de
   fr-FR: Vitesse de
@@ -3344,7 +3149,6 @@ _&getSpeedInDirection:
     type: Direction
     default: Vector
   return: Float
-  guid: 00000000B260
   en-US: Speed Of In Direction
   es-MX: Velocidad de/en dirección
   fr-FR: Vitesse dans la direction donnée de
@@ -3360,7 +3164,6 @@ sqrt:
     type: Float
     default: Number
   return: Float
-  guid: 00000000C356
   en-US: Square Root
   es-MX: Raíz cuadrada
   fr-FR: Racine carrée
@@ -3368,7 +3171,6 @@ sqrt:
   pt-BR: Raiz Quadrada
   zh-CN: 平方根
 __localizedString__:
-  guid: 00000000BA60
   description: Text formed from a selection of strings and specified values.
   args:
   - name: String
@@ -3394,7 +3196,6 @@ __localizedString__:
   ja-JP: 文字列
   zh-CN: 字符串
 __subtract__:
-  guid: 00000000C40A
   description: The difference between two numbers or vectors.
   args_allow_null: true
   args:
@@ -3429,7 +3230,6 @@ tanDeg:
     type: float
     default: Number
   return: float
-  guid: 00000000C7F8
   en-US: Tangent From Degrees
   es-MX: Tangente en grados
   fr-FR: Tangente en degrés
@@ -3444,7 +3244,6 @@ tan:
     type: float
     default: Number
   return: float
-  guid: 00000000C7FD
   en-US: Tangent From Radians
   es-MX: Tangente en radianes
   fr-FR: Tangente en radians
@@ -3460,7 +3259,6 @@ _&getTeam:
     type: Player
     default: Event Player
   return: Team
-  guid: 00000000B279
   en-US: Team Of
   es-MX: Equipo de
   fr-FR: Équipe de
@@ -3468,7 +3266,6 @@ _&getTeam:
   pt-BR: Equipe de
   zh-CN: 所在队伍
 teamScore:
-  guid: 00000000B353
   description: The current score for the specified team. Results in 0 in free-for-all
     game modes.
   args:
@@ -3493,7 +3290,6 @@ _&getThrottle:
     type: Player
     default: Event Player
   return: Direction
-  guid: 00000000B2F5
   en-US: Throttle Of
   es-MX: Aceleración de
   fr-FR: Accélération de
@@ -3505,7 +3301,6 @@ getTotalTimeElapsed:
     was created (including setup time and transitions).
   args: []
   return: Float
-  guid: 00000000B361
   en-US: Total Time Elapsed
   es-MX: Tiempo total transcurrido
   fr-FR: Temps total écoulé
@@ -3516,7 +3311,6 @@ getTotalTimeElapsed:
   description: The boolean value of true.
   args:
   return: bool
-  guid: 00000000AC39
   en-US: 'True'
   es-MX: Verdadero
   fr-FR: Vrai
@@ -3529,7 +3323,6 @@ _&getUltCharge:
     type: Player
     default: Event Player
   return: Float
-  guid: 0000000081C5
   en-US: Ultimate Charge Percent
   es-MX: Porcentaje de carga de la habilidad máxima
   fr-FR: Pourcentage de charge de la capacité ultime
@@ -3537,7 +3330,6 @@ _&getUltCharge:
   pt-BR: Percentual de Carga da Suprema
   zh-CN: 终极技能充能百分比
 Vector.UP:
-  guid: 00000000B118
   description: Shorthand for the directional vector(0, 1, 0), which points upward.
   args:
   return:
@@ -3566,7 +3358,6 @@ __valueInArray__:
   return:
   - Object
   - Array
-  guid: 00000000B52A
   en-US: Value In Array
   es-MX: Valor en la matriz
   fr-FR: Valeur dans le tableau
@@ -3574,7 +3365,6 @@ __valueInArray__:
   pt-BR: Valor na Matriz
   zh-CN: 数组中的值
 vect:
-  guid: 00000000B0F1
   description: A vector composed of three real numbers (x, y, z) where x is left,
     y is up, and z is forward. Vectors are used for position, direction, and velocity.
   args:
@@ -3608,7 +3398,6 @@ vectorTowards:
     type: Position
     default: Vector
   return: Direction
-  guid: 00000000B1EB
   en-US: Vector Towards
   es-MX: Vector hacia
   fr-FR: Vecteur vers
@@ -3625,7 +3414,6 @@ _&getVelocity:
     type: Player
     default: Event Player
   return: Velocity
-  guid: 00000000B25C
   en-US: Velocity Of
   es-MX: Velocidad de
   fr-FR: Vélocité de
@@ -3642,7 +3430,6 @@ verticalAngleOfDirection:
     type: Direction
     default: Vector
   return: float
-  guid: 00000000BB2B
   en-US: Vertical Angle From Direction
   es-MX: Ángulo vertical desde la dirección
   fr-FR: Angle vertical depuis une direction
@@ -3663,7 +3450,6 @@ verticalAngleTowards:
     type: Position
     default: Vector
   return: float
-  guid: 00000000B27E
   en-US: Vertical Angle Towards
   es-MX: Ángulo vertical en dirección a
   fr-FR: Angle vertical vers
@@ -3679,7 +3465,6 @@ _&getVerticalFacingAngle:
     type: Player
     default: Event Player
   return: float
-  guid: 00000000B280
   en-US: Vertical Facing Angle Of
   es-MX: Ángulo vertical de orientación de
   fr-FR: Angle vertical du regard de
@@ -3695,7 +3480,6 @@ _&getVerticalSpeed:
     type: Player
     default: Event Player
   return: Float
-  guid: 00000000B25F
   en-US: Vertical Speed Of
   es-MX: Velocidad vertical de
   fr-FR: Vitesse verticale de
@@ -3703,7 +3487,6 @@ _&getVerticalSpeed:
   pt-BR: Velocidade Vertical de
   zh-CN: 垂直速度
 victim:
-  guid: 00000000B330
   description: The player that received the damage for the event currently being processed
     by this rule. May be the same as the attacker or the event player.
   args:
@@ -3733,7 +3516,6 @@ worldVector:
     type: Transform
     default: ROTATION
   return: Vector
-  guid: 00000000B33A
   en-US: World Vector Of
   es-MX: Vector global de
   fr-FR: Vecteur mondial de
@@ -3749,7 +3531,6 @@ __xComponentOf__:
     type: Vector
     default: Vector
   return: float
-  guid: 00000000B26F
   en-US: X Component Of
   es-MX: Componente X de
   fr-FR: Composante X de
@@ -3765,7 +3546,6 @@ __yComponentOf__:
     type: Vector
     default: Vector
   return: float
-  guid: 00000000B270
   en-US: Y Component Of
   es-MX: Componente Y de
   fr-FR: Composante Y de
@@ -3781,7 +3561,6 @@ __zComponentOf__:
     type: Vector
     default: Vector
   return: float
-  guid: 00000000B272
   en-US: Z Component Of
   es-MX: Componente Z de
   fr-FR: Composante Z de
@@ -3834,7 +3613,6 @@ eventWasEnvironment:
   return: bool
   en-US: Event Was Environment
 _&getHealthOfType:
-  guid: 0000000081C2
   description: The current health of the specified player, filtered by the given health
     type.
   args:
@@ -3887,7 +3665,6 @@ _&getMaxAmmo:
   return: Float
   en-US: Max Ammo
 _&getMaxHealthOfType:
-  guid: 0000000081C2
   description: The max health of the specified player, filtered by the given health
     type.
   args:
@@ -3971,7 +3748,6 @@ workshopSettingReal:
     default: 0
   isConstant: true
   return: float
-  guid: 00000001137B
   en-US: Workshop Setting Real
   es-MX: Configuración del Workshop real
   fr-FR: Paramètre réel de la Forge
@@ -4008,7 +3784,6 @@ workshopSettingInteger:
     default: 0
   isConstant: true
   return: Integer
-  guid: '000000011375'
   en-US: Workshop Setting Integer
   es-MX: Número entero de la configuración del Workshop
   fr-FR: Paramètre entier de la Forge
@@ -4036,7 +3811,6 @@ workshopSettingToggle:
     type: IntLiteral
     default: 0
   return: bool
-  guid: 00000001136B
   en-US: Workshop Setting Toggle
   es-MX: Alternado de configuración del Workshop
   fr-FR: Activerdésactiver le paramètre de la Forge

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -11,11 +11,6 @@ _&getAbilityCooldown:
     default: Button
   return: Float
   en-US: Ability Cooldown
-  es-MX: Reutilización de habilidad
-  fr-FR: Temps de recharge de la capacité
-  ja-JP: アビリティのクールダウン
-  pt-BR: Tempo de Recarga da Habilidade
-  zh-CN: 技能冷却时间
 abilityIconString:
   description: Converts a Hero and Button parameter into a string that shows up as
     an icon (up to 4 per string).
@@ -30,11 +25,6 @@ abilityIconString:
     default: Button
   return: String
   en-US: Ability Icon String
-  es-MX: Cadena de ícono de habilidad
-  fr-FR: Chaîne d’icône de la capacité
-  ja-JP: アビリティアイコンストリング
-  pt-BR: String de Ícone de Habilidade
-  zh-CN: 技能图标字符串
 abs:
   description: The absolute value of the specified value.
   args:
@@ -44,11 +34,6 @@ abs:
     default: Number
   return: Float
   en-US: Absolute Value
-  es-MX: Valor absoluto
-  fr-FR: Valeur absolue
-  ja-JP: 絶対値
-  pt-BR: Valor Absoluto
-  zh-CN: 绝对值
 __add__:
   description: The sum of two numbers or vectors.
   args_allow_null: true
@@ -71,11 +56,6 @@ __add__:
   - float
   - Vector
   en-US: Add
-  es-MX: Sumar
-  fr-FR: Addition
-  ja-JP: 追加
-  pt-BR: Somar
-  zh-CN: 加
 getDeadPlayers:
   description: An array containing all dead players on a team or in the match.
   args:
@@ -86,11 +66,6 @@ getDeadPlayers:
   return:
     Array: Player
   en-US: All Dead Players
-  es-MX: Todos los jugadores muertos
-  fr-FR: Tous les joueurs morts
-  ja-JP: 倒れたプレイヤー全員
-  pt-BR: Todos os Jogadores Mortos
-  zh-CN: 所有死亡玩家
 getDamageHeroes:
   description: "The array of all damage heroes in overwatch. The order is as follows:\n
     \       \n        0. Reaper\n        1. Tracer\n        2. Hanzo\n        3. Torbjorn\n
@@ -103,11 +78,6 @@ getDamageHeroes:
     Array: Hero
   en-US: All Damage Heroes
   de-DE: Alle Schadenshelden
-  es-MX: Todos los héroes de daño
-  fr-FR: Tous les héros de dégâts
-  ja-JP: 全ダメージヒーロー
-  pt-BR: Todos os Heróis de Dano
-  zh-CN: 所有输出英雄
 getAllHeroes:
   description: "The array of all heroes in overwatch. The order is as follows:\n        \n
     \       0. Reaper   \n        1. Tracer   \n        2. Mercy    \n        3. Hanzo
@@ -123,11 +93,6 @@ getAllHeroes:
   return:
     Array: Hero
   en-US: All Heroes
-  es-MX: Todos los héroes
-  fr-FR: Tous les héros
-  ja-JP: 全ヒーロー
-  pt-BR: Todos os Heróis
-  zh-CN: 全部英雄
 getLivingPlayers:
   description: An array containing all living players on a team or in the match.
   args:
@@ -138,11 +103,6 @@ getLivingPlayers:
   return:
     Array: Player
   en-US: All Living Players
-  es-MX: Todos los jugadores vivos
-  fr-FR: Tous les joueurs en vie
-  ja-JP: 生存プレイヤー全員
-  pt-BR: Todos os Jogadores Vivos
-  zh-CN: 所有存活玩家
 getPlayers:
   description: An array containing all players on a team or in the match.
   args:
@@ -153,11 +113,6 @@ getPlayers:
   return:
     Array: Player
   en-US: All Players
-  es-MX: Todos los jugadores
-  fr-FR: Tous les joueurs
-  ja-JP: すべてのプレイヤー
-  pt-BR: Todos os Jogadores
-  zh-CN: 所有玩家
 getPlayersNotOnObjective:
   description: An array containing all players occupying neither a payload nor a control
     point (either on a team or in the match).
@@ -169,11 +124,6 @@ getPlayersNotOnObjective:
   return:
     Array: Player
   en-US: All Players Not On Objective
-  es-MX: Todos los jugadores que no están en el objetivo
-  fr-FR: Tous les joueurs éloignés de l’objectif
-  ja-JP: プレイヤー全員が目標を確保中ではない
-  pt-BR: Todos os Jogadores Fora do Objetivo
-  zh-CN: 所有目标点外玩家
 getPlayersOnObjective:
   description: An array containing all players occupying a payload or control point
     (either on a team or in the match).
@@ -185,11 +135,6 @@ getPlayersOnObjective:
   return:
     Array: Player
   en-US: All Players On Objective
-  es-MX: Todos los jugadores que están en el objetivo
-  fr-FR: Tous les joueurs sur l’objectif
-  ja-JP: プレイヤー全員が目標を確保中
-  pt-BR: Todos os Jogadores no Objetivo
-  zh-CN: 所有目标点内玩家
 _&getAllowedHeroes:
   description: The array of heroes from which the specified player is currently allowed
     to select.
@@ -201,11 +146,6 @@ _&getAllowedHeroes:
   return:
     Array: Hero
   en-US: Allowed Heroes
-  es-MX: Héroes permitidos
-  fr-FR: Héros autorisés
-  ja-JP: 許可されたヒーロー
-  pt-BR: Heróis Permitidos
-  zh-CN: 可用英雄
 getSupportHeroes:
   description: "The array of all support heroes in overwatch. The order is as follows:\n
     \       \n        0. Mercy\n        1. Zenyatta\n        2. Lucio\n        3.
@@ -215,11 +155,6 @@ getSupportHeroes:
     Array: Hero
   en-US: All Support Heroes
   de-DE: Alle Unterstützungshelden
-  es-MX: Todos los héroes de apoyo
-  fr-FR: Tous les héros de soutien
-  ja-JP: 全サポートヒーロー
-  pt-BR: Todos os Heróis de Suporte
-  zh-CN: 所有支援英雄
 getTankHeroes:
   description: "The array of all tank heroes in overwatch. The order is as follows:\n
     \       \n        0. Reinhardt\n        1. Winston\n        2. Roadhog\n        3.
@@ -230,11 +165,6 @@ getTankHeroes:
     Array: Hero
   en-US: All Tank Heroes
   de-DE: Alle Tankhelden
-  es-MX: Todos los héroes tanques
-  fr-FR: Tous les héros tanks
-  ja-JP: 全タンクヒーロー
-  pt-BR: Todos os Heróis de Tanque
-  zh-CN: 所有重装英雄
 _&getAltitude:
   description: The player's current height in meters above a surface. Results in 0
     whenever the player is on a surface.
@@ -245,11 +175,6 @@ _&getAltitude:
     default: Event Player
   return: Float
   en-US: Altitude Of
-  es-MX: Altitud de
-  fr-FR: Altitude de
-  ja-JP: '高度: '
-  pt-BR: Altitude de
-  zh-CN: 高度
 __and__:
   description: Whether both of the two inputs are true (or equivalent to true).
   args:
@@ -265,11 +190,6 @@ __and__:
     default: 'True'
   return: bool
   en-US: And
-  es-MX: Y
-  fr-FR: Et
-  ja-JP: And
-  pt-BR: E
-  zh-CN: 与
 angleBetweenVectors:
   description: The angle in degrees between two directional vectors (no normalization
     required).
@@ -286,11 +206,6 @@ angleBetweenVectors:
     default: Vector
   return: Float
   en-US: Angle Between Vectors
-  es-MX: Ángulo entre vectores
-  fr-FR: Angle entre deux vecteurs
-  ja-JP: ベクトル間角度
-  pt-BR: Ângulo entre Vetores
-  zh-CN: 矢量间夹角
 angleDifference:
   description: The difference in degrees between two angles. After the angles are
     wrapped to be within +/- 180 of each other, the result is positive if the second
@@ -306,11 +221,6 @@ angleDifference:
     default: Number
   return: float
   en-US: Angle Difference
-  es-MX: Diferencia de ángulo
-  fr-FR: Différence entre angles
-  ja-JP: 角度差
-  pt-BR: Diferença de Ângulo
-  zh-CN: 角度差
 __concat__:
   description: A copy of an array with one or more values appended to the end.
   args_allow_null: true
@@ -328,11 +238,6 @@ __concat__:
     default: Number
   return: Array
   en-US: Append To Array
-  es-MX: Anexar a la matriz
-  fr-FR: Ajouter au tableau
-  ja-JP: 配列に追加
-  pt-BR: Juntar à Matriz
-  zh-CN: 添加至数组
 acosDeg:
   description: Arccosine in degrees of the specified value.
   args:
@@ -342,11 +247,6 @@ acosDeg:
     default: Number
   return: float
   en-US: Arccosine In Degrees
-  es-MX: Arcocoseno en grados
-  fr-FR: Arc cosinus en degrés
-  ja-JP: 度単位のアークコサイン
-  pt-BR: Arco Cosseno em Graus
-  zh-CN: 以角度为单位的反余弦值
 acos:
   description: Arccosine in radians of the specified value.
   args:
@@ -356,11 +256,6 @@ acos:
     default: Number
   return: float
   en-US: Arccosine In Radians
-  es-MX: Arcocoseno en radianes
-  fr-FR: Arc cosinus en radians
-  ja-JP: ラジアンのアークコサイン
-  pt-BR: Arco Cosseno em Radianos
-  zh-CN: 以弧度为单位的反余弦值
 asinDeg:
   description: Arcsine in degrees of the specified value.
   args:
@@ -370,11 +265,6 @@ asinDeg:
     default: Number
   return: float
   en-US: Arcsine In Degrees
-  es-MX: Arcoseno en grados
-  fr-FR: Arc sinus en degrés
-  ja-JP: 度単位のアークサイン
-  pt-BR: Arco Seno em Graus
-  zh-CN: 以角度为单位的反正弦值
 asin:
   description: Arcsine in radians of the specified value.
   args:
@@ -384,11 +274,6 @@ asin:
     default: Number
   return: float
   en-US: Arcsine In Radians
-  es-MX: Arcoseno en radianes
-  fr-FR: Arc sinus en radians
-  ja-JP: ラジアンのアークサイン
-  pt-BR: Arco Seno em Radianos
-  zh-CN: 以弧度为单位的反正弦值
 atan2Deg:
   description: Arctangent in degrees of the specified numerator and denominator (often
     referred to as atan2).
@@ -403,11 +288,6 @@ atan2Deg:
     default: Number
   return: float
   en-US: Arctangent In Degrees
-  es-MX: Arcotangente en grados
-  fr-FR: Arc tangente en degrés
-  ja-JP: 度単位のアークタンジェント
-  pt-BR: Arco Tangente em Graus
-  zh-CN: 以角度为单位的反正切值
 atan2:
   description: Arctangent in radians of the specified numerator and denominator (often
     referred to as atan2).
@@ -422,11 +302,6 @@ atan2:
     default: Number
   return: float
   en-US: Arctangent In Radians
-  es-MX: Arcotangente en radianes
-  fr-FR: Arc tangente en radians
-  ja-JP: ラジアンのアークタンジェント
-  pt-BR: Arco Tangente em Radianos
-  zh-CN: 以弧度为单位的反正切值
 __array__:
   description: An array constructed from the listed values.
   args_unlimited: true
@@ -440,13 +315,7 @@ __array__:
   return: Array
   en-US: Array
   es-ES: Matriz
-  es-MX: Matriz
-  fr-FR: Tableau
-  ja-JP: 配列
   pl-PL: Tabela
-  pt-BR: Matriz
-  ru-RU: Массив
-  zh-CN: 数组
   zh-TW: 陣列
 __arrayContains__:
   description: Whether the specified array contains the specified value.
@@ -461,11 +330,6 @@ __arrayContains__:
     default: Number
   return: bool
   en-US: Array Contains
-  es-MX: La matriz contiene
-  fr-FR: Contenu du tableau
-  ja-JP: 含む配列
-  pt-BR: Matriz Contém
-  zh-CN: 数组包含
 __arraySlice__:
   description: A copy of the specified array containing only values from a specified
     index range.
@@ -488,22 +352,12 @@ __arraySlice__:
   return:
     Array: Object
   en-US: Array Slice
-  es-MX: Extracción de matriz
-  fr-FR: Section de tableau
-  ja-JP: 配列のスライス
-  pt-BR: Fatia da Matriz
-  zh-CN: 数组分割
 attacker:
   description: The player that dealt the damage for the event currently being processed
     by this rule. May be the same as the victim or the event player.
   args:
   return: Player
   en-US: Attacker
-  es-MX: Atacante
-  fr-FR: Attaquant
-  ja-JP: 攻撃者
-  pt-BR: Atacante
-  zh-CN: 攻击方
 Vector.Backward:
   description: Shorthand for the directional vector(0, 0, -1), which points backward.
   args:
@@ -513,11 +367,6 @@ Vector.Backward:
     - Integer
     - Integer
   en-US: Backward
-  es-MX: Atrás
-  fr-FR: Arrière
-  ja-JP: 後方
-  pt-BR: Para Trás
-  zh-CN: 后
 __button__:
   description: A button constant.
   args:
@@ -527,11 +376,6 @@ __button__:
     default: Interact
   return: Button
   en-US: Button
-  es-MX: Botón
-  fr-FR: Bouton
-  ja-JP: ボタン
-  pt-BR: Botão
-  zh-CN: 按钮
 getClosestPlayer:
   description: The player closest to a position, optionally restricted by team.
   args:
@@ -545,11 +389,6 @@ getClosestPlayer:
     default: Team
   return: Player
   en-US: Closest Player To
-  es-MX: Jugador más cercano a
-  fr-FR: Joueur le plus proche de
-  ja-JP: '最も近いプレイヤー。基準: '
-  pt-BR: Jogador Mais Próximo a
-  zh-CN: 距离最近的玩家
 __compare__:
   description: Whether the comparison of the two inputs is true.
   args:
@@ -573,11 +412,6 @@ __compare__:
     default: Number
   return: bool
   en-US: Compare
-  es-MX: Comparar
-  fr-FR: Comparer
-  ja-JP: Compare
-  pt-BR: Comparar
-  zh-CN: 比较
 getControlScorePercentage:
   description: The score percentage for the specified team in control mode.
   args:
@@ -587,22 +421,12 @@ getControlScorePercentage:
     default: Team
   return: Float
   en-US: Control Mode Scoring Percentage
-  es-MX: Porcentaje de puntuación en el modo Control
-  fr-FR: Pourcentage du score en mode Contrôle
-  ja-JP: コントロール・モードのスコア・パーセンテージ
-  pt-BR: Percentual de Pontuação no Modo de Controle
-  zh-CN: 占领要点模式得分百分比
 getControlScoringTeam:
   description: The team that is currently accumulating score percentage in control
     mode. Results in all if neither team is accumulating score.
   args: []
   return: Team
   en-US: Control Mode Scoring Team
-  es-MX: Equipo que anota en el modo Control
-  fr-FR: Équipe contrôlant le point en mode Contrôle
-  ja-JP: コントロール・モードの得点チーム
-  pt-BR: Equipe Pontuando no Modo de Controle
-  zh-CN: 占领要点模式正在得分的队伍
 cosDeg:
   description: Cosine of the specified angle in degrees.
   args:
@@ -612,11 +436,6 @@ cosDeg:
     default: Number
   return: float
   en-US: Cosine From Degrees
-  es-MX: Coseno en grados
-  fr-FR: Cosinus en degrés
-  ja-JP: 度のコサイン
-  pt-BR: Cosseno de Graus
-  zh-CN: 角度的余弦值
 cos:
   description: Cosine of the specified angle in radians.
   args:
@@ -626,11 +445,6 @@ cos:
     default: Number
   return: float
   en-US: Cosine From Radians
-  es-MX: Coseno en radianes
-  fr-FR: Cosinus en radians
-  ja-JP: ラジアンのコサイン
-  pt-BR: Cosseno de Radianos
-  zh-CN: 弧度的余弦值
 len:
   description: The number of elements in the specified array.
   args:
@@ -640,11 +454,6 @@ len:
     default: Global Variable
   return: Integer
   en-US: Count Of
-  es-MX: Conteo de
-  fr-FR: Décompte de
-  ja-JP: 'カウント: '
-  pt-BR: Contagem de
-  zh-CN: 数量
 crossProduct:
   description: The cross product of the specified values. (Left cross up equals forward.)
   args:
@@ -658,11 +467,6 @@ crossProduct:
     default: Vector
   return: Vector
   en-US: Cross Product
-  es-MX: Producto vectorial
-  fr-FR: Produit croisé
-  ja-JP: クロス積
-  pt-BR: Produto Vetorial
-  zh-CN: 矢量积
 __currentArrayElement__:
   description: The current array element being considered. Only meaningful during
     the evaluation of values such as filtered array and sorted array.
@@ -671,11 +475,6 @@ __currentArrayElement__:
   - Object
   - Array
   en-US: Current Array Element
-  es-MX: Elemento de matriz actual
-  fr-FR: Élément de tableau actuel
-  ja-JP: 現在の配列の要素
-  pt-BR: Elemento da Matriz Atual
-  zh-CN: 当前数组元素
 __currentArrayIndex__:
   description: The current array index being considered. Only meaningful during
     the evaluation of values such as filtered array and sorted array.
@@ -689,21 +488,11 @@ getCurrentGamemode:
   args: []
   return: Gamemode
   en-US: Current Game Mode
-  es-MX: Modo de juego actual
-  fr-FR: Mode de jeu actuel
-  ja-JP: 現在のゲーム・モード
-  pt-BR: Modo de jogo atual
-  zh-CN: 当前比赛模式
 getCurrentMap:
   description: The current map of the custom game.
   args: []
   return: Map
   en-US: Current Map
-  es-MX: Mapa actual
-  fr-FR: Carte actuelle
-  ja-JP: 現在のマップ
-  pt-BR: Mapa Atual
-  zh-CN: 当前地图
 __customString__:
   description: ty magzie for adding that
   args:
@@ -725,11 +514,6 @@ __customString__:
     default: 'Null'
   return: String
   en-US: Custom String
-  es-MX: Cadena personalizada
-  fr-FR: Chaîne personnalisée
-  ja-JP: カスタムストリング
-  pt-BR: String Personalizada
-  zh-CN: 自定义字符串
 angleToDirection:
   description: The unit-length direction vector corresponding to the specified angles.
   args:
@@ -743,11 +527,6 @@ angleToDirection:
     default: Number
   return: Direction
   en-US: Direction From Angles
-  es-MX: Dirección desde los ángulos
-  fr-FR: Direction depuis des angles
-  ja-JP: 角度による方向
-  pt-BR: Direção a partir dos Ângulos
-  zh-CN: 与此角度的相对方向
 directionTowards:
   description: The unit-length direction vector from one position to another.
   args:
@@ -761,11 +540,6 @@ directionTowards:
     default: Vector
   return: Direction
   en-US: Direction Towards
-  es-MX: Dirección hacia
-  fr-FR: Direction
-  ja-JP: '指す方向: '
-  pt-BR: Direção Rumo a
-  zh-CN: 方向
 distance:
   description: The distance between two positions in meters.
   args:
@@ -779,11 +553,6 @@ distance:
     default: Vector
   return: Float
   en-US: Distance Between
-  es-MX: Distancia entre
-  fr-FR: Distance entre
-  ja-JP: 2点間の距離
-  pt-BR: Distância entre
-  zh-CN: 相距距离
 __divide__:
   description: The ratio of two numbers or vectors. A vector divided by a number will
     yield a scaled vector. Division by zero results in zero.
@@ -807,11 +576,6 @@ __divide__:
   - float
   - Vector
   en-US: Divide
-  es-MX: Dividir
-  fr-FR: Division
-  ja-JP: 除算
-  pt-BR: Dividir
-  zh-CN: 除
 dotProduct:
   description: The dot product of the specified values.
   args:
@@ -825,11 +589,6 @@ dotProduct:
     default: Vector
   return: float
   en-US: Dot Product
-  es-MX: Producto escalar
-  fr-FR: Produit scalaire
-  ja-JP: ドット積
-  pt-BR: Produto Escalar
-  zh-CN: 标量积
 Vector.DOWN:
   description: Shorthand for the directional vector(0, -1, 0), which points downward.
   args:
@@ -839,21 +598,11 @@ Vector.DOWN:
     - Integer
     - Integer
   en-US: Down
-  es-MX: Abajo
-  fr-FR: Bas
-  ja-JP: 下
-  pt-BR: Baixo
-  zh-CN: 下
 __emptyArray__:
   description: An array with no elements.
   args: []
   return: Array
   en-US: Empty Array
-  es-MX: Matriz vacía
-  fr-FR: Tableau vide
-  ja-JP: 空の配列
-  pt-BR: Matriz Vazia
-  zh-CN: 空数组
 entityExists:
   description: Whether the specified player, icon entity, or effect entity still exists.
     Useful for determining if a player has left the match or an entity has been destroyed.
@@ -866,88 +615,48 @@ entityExists:
     default: Event Player
   return: bool
   en-US: Entity Exists
-  es-MX: La entidad existe
-  fr-FR: Existence de l’entité
-  ja-JP: エンティティが存在している
-  pt-BR: Entidade Existe
-  zh-CN: 实体存在
 eventAbility:
   description: The ability for the event currently being processed by this rule associated
     by button.
   args:
   return: Button
   en-US: Event Ability
-  es-MX: Evento de habilidad
-  fr-FR: Capacité d’évènement
-  ja-JP: イベントアビリティ
-  pt-BR: Habilidade do Evento
-  zh-CN: 事件技能
 eventDamage:
   description: The amount of damage received by the victim for the event currently
     being processed by this rule.
   args:
   return: Float
   en-US: Event Damage
-  es-MX: Daño de evento
-  fr-FR: Dégâts d’évènement
-  ja-JP: イベント・ダメージ
-  pt-BR: Dano do Evento
-  zh-CN: 事件伤害
 eventDirection:
   description: The incoming direction for the event currently being processed by this
     rule.
   args:
   return: Direction
   en-US: Event Direction
-  es-MX: Dirección del evento
-  fr-FR: Direction de l’évènement
-  ja-JP: イベント方向
-  pt-BR: Direção do Evento
-  zh-CN: 事件方向
 eventHealing:
   description: The amount of healing received by the healee for the event currently
     being processed by this rule.
   args:
   return: Float
   en-US: Event Healing
-  es-MX: Sanación de evento
-  fr-FR: Évènement soin
-  ja-JP: イベント回復
-  pt-BR: Cura no Evento
-  zh-CN: 事件治疗
 eventPlayer:
   description: The player executing this rule, as specified by the event. May be the
     same as the attacker or victim.
   args:
   return: Player
   en-US: Event Player
-  es-MX: Jugador del evento
-  fr-FR: Joueur exécutant
-  ja-JP: イベント・プレイヤー
-  pt-BR: Jogador do Evento
-  zh-CN: 事件玩家
 eventWasCriticalHit:
   description: Whether the damage was a critical hit (such as a headshot) for the
     event currently being processed by this rule.
   args:
   return: bool
   en-US: Event Was Critical Hit
-  es-MX: El evento fue un golpe crítico
-  fr-FR: L’évènement était un coup critique
-  ja-JP: イベントがクリティカル・ヒットだった
-  pt-BR: Evento foi Golpe Crítico
-  zh-CN: 事件暴击
 eventWasHealthPack:
   description: Whether the healing was a health pack for the event currently being
     processed by this rule.
   args:
   return: bool
   en-US: Event Was Health Pack
-  es-MX: Evento fue suministro de salud
-  fr-FR: L’évènement était un kit de soins
-  ja-JP: ライフ・パックのイベントだった
-  pt-BR: Evento foi kit Médico
-  zh-CN: 事件为急救包
 _&getEyePosition:
   description: The position of a player's first person view (used for aiming)
   args:
@@ -957,11 +666,6 @@ _&getEyePosition:
     default: Event Player
   return: Position
   en-US: Eye Position
-  es-MX: Posición de la vista
-  fr-FR: Position des yeux
-  ja-JP: 目の位置
-  pt-BR: Posição do Olho
-  zh-CN: 眼睛位置
 _&getFacingDirection:
   description: The unit-length directional vector of a player's current facing relative
     to the world. This value includes both horizontal and vertical facing.
@@ -972,19 +676,11 @@ _&getFacingDirection:
     default: Event Player
   return: Direction
   en-US: Facing Direction Of
-  es-MX: Dirección de orientación de
-  fr-FR: Regard en direction de
-  ja-JP: 'プレイヤーが向いている方向: '
-  pt-BR: Direção Frontal de
-  zh-CN: 面朝方向
 'false':
   description: The boolean value of false.
   args:
   return: bool
   en-US: 'False'
-  es-MX: Falso
-  fr-FR: Faux
-  zh-CN: 假
 getFarthestPlayer:
   description: The player farthest from a position, optionally restricted by team.
   args:
@@ -998,11 +694,6 @@ getFarthestPlayer:
     default: Team
   return: Player
   en-US: Farthest Player From
-  es-MX: Jugador más lejos de
-  fr-FR: Joueur le plus éloigné de
-  ja-JP: '最も遠いプレイヤー。基準: '
-  pt-BR: Jogador Mais Distante de
-  zh-CN: 距离最远的玩家
 __filteredArray__:
   description: A copy of the specified array with any values that do not match the
     specified condition removed.
@@ -1019,11 +710,6 @@ __filteredArray__:
     default: Compare
   return: Array
   en-US: Filtered Array
-  es-MX: Matriz filtrada
-  fr-FR: Tableau filtré
-  ja-JP: フィルタリングされた配列
-  pt-BR: Matriz Filtrada
-  zh-CN: 已过滤的数组
 __firstOf__:
   description: The value at the start of the specified array. Results in 0 if the
     specified array is empty.
@@ -1036,11 +722,6 @@ __firstOf__:
   - Object
   - Array
   en-US: First Of
-  es-MX: Primero de
-  fr-FR: Premier de
-  ja-JP: 1番目の値
-  pt-BR: Primeiro de
-  zh-CN: 首个
 getFlagPosition:
   description: The position of a specific team's flag in capture the flag.
   args:
@@ -1050,11 +731,6 @@ getFlagPosition:
     default: Team
   return: Position
   en-US: Flag Position
-  es-MX: Posición de la bandera
-  fr-FR: Position du drapeau
-  ja-JP: フラッグの位置
-  pt-BR: Posição da Bandeira
-  zh-CN: 旗帜位置
 Vector.Forward:
   description: Shorthand for the directional vector(0, 0, 1), which points forward.
   args:
@@ -1064,19 +740,11 @@ Vector.Forward:
     - Integer
     - Integer
   en-US: Forward
-  es-MX: Adelante
-  fr-FR: Avant
-  ja-JP: 前方向
-  pt-BR: Para a Frente
-  zh-CN: 前
 __global__:
   return: GlobalVariable
   en-US: Global
   it-IT: Globale
-  ja-JP: グローバル
   pl-PL: Globalnie
-  ru-RU: Глобальные
-  zh-CN: 全局
   zh-TW: 全域
 __globalVar__:
   description: The current value of a global variable, which is a variable that belongs
@@ -1088,11 +756,6 @@ __globalVar__:
     default: A
   return: Value
   en-US: Global Variable
-  es-MX: Variable global
-  fr-FR: Variable globale
-  ja-JP: グローバル変数
-  pt-BR: Variável Global
-  zh-CN: 全局变量
 _&hasSpawned:
   description: Whether an entity has spawned in the world. Results in false for players
     who have not chosen a hero yet.
@@ -1104,11 +767,6 @@ _&hasSpawned:
     default: Event Player
   return: bool
   en-US: Has Spawned
-  es-MX: Ha aparecido
-  fr-FR: Apparition
-  ja-JP: スポーンした
-  pt-BR: Surgiu
-  zh-CN: 已重生
 _&hasStatusEffect:
   description: Whether the specified player has the specified status, either from
     the set status action or from a non-scripted game mechanic.
@@ -1123,33 +781,18 @@ _&hasStatusEffect:
     default: Hacked
   return: bool
   en-US: Has Status
-  es-MX: Tiene estado
-  fr-FR: Statut
-  ja-JP: ステータスがある
-  pt-BR: Tem Status
-  zh-CN: 具有状态
 healee:
   description: The player that received the healing for the event currently being
     processed by this rule. May be the same as the healer or the event player.
   args:
   return: Player
   en-US: Healee
-  es-MX: Sanado
-  fr-FR: Soigné
-  ja-JP: 回復対象
-  pt-BR: Curado
-  zh-CN: 受治疗者
 healer:
   description: The player that dealt the healing for the event currently being processed
     by this rule. May be the same as the healee or the event player.
   args:
   return: Player
   en-US: Healer
-  es-MX: Sanador
-  fr-FR: Soigneur
-  ja-JP: ヒーラー
-  pt-BR: Curandeiro
-  zh-CN: 治疗者
 _&getHealth:
   description: The current health of a player, including armor and shields.
   args:
@@ -1159,11 +802,6 @@ _&getHealth:
     default: Event Player
   return: Float
   en-US: Health
-  es-MX: Salud
-  fr-FR: Points de vie
-  ja-JP: ライフ
-  pt-BR: Vida
-  zh-CN: 生命值
 _&getNormalizedHealth:
   description: The current health of a player, including armor and shields, normalized
     between 0 and 1. (for example, 0 is no health, 0.5 is half health, 1 is full health,
@@ -1175,11 +813,6 @@ _&getNormalizedHealth:
     default: Event Player
   return: Float
   en-US: Normalized Health
-  es-MX: Salud normalizada
-  fr-FR: Points de vie normalisés
-  ja-JP: 正規化ライフ
-  pt-BR: Vida Normalizada
-  zh-CN: 标准化生命值
 __hero__:
   description: A hero constant.
   args:
@@ -1189,11 +822,6 @@ __hero__:
     default: ANA
   return: Hero
   en-US: Hero
-  es-MX: Héroe
-  fr-FR: Héros
-  ja-JP: ヒーロー
-  pt-BR: Herói
-  zh-CN: 英雄
 _&getHeroOfDuplication:
   description: The hero currently being duplicated by the specified player. If no
     hero is being duplicated, the resulting value is 0.
@@ -1204,11 +832,6 @@ _&getHeroOfDuplication:
     default: Event Player
   return: Hero
   en-US: Hero Being Duplicated
-  es-MX: Héroe que está siendo copiado
-  fr-FR: Héros dupliqué
-  ja-JP: コピーされているヒーロー
-  pt-BR: Herói Sendo Duplicado
-  zh-CN: 正在复制的英雄
 heroIcon:
   description: Converts a hero parameter into a string that shows up as an icon.
   args:
@@ -1218,11 +841,6 @@ heroIcon:
     default: Hero
   return: String
   en-US: Hero Icon String
-  es-MX: Cadena de ícono de héroe
-  fr-FR: Chaîne d’icône du héros
-  ja-JP: ヒーローアイコン文字列
-  pt-BR: String de Ícone de Herói
-  zh-CN: 英雄图标字符串
 _&getCurrentHero:
   description: The current hero of a player.
   args:
@@ -1232,11 +850,6 @@ _&getCurrentHero:
     default: Event Player
   return: Hero
   en-US: Hero Of
-  es-MX: Héroe de
-  fr-FR: Héros de
-  ja-JP: 'ヒーロー: '
-  pt-BR: Herói de
-  zh-CN: 所用英雄
 horizontalAngleFromDirection:
   description: The horizontal angle in degrees corresponding to the specified direction
     vector.
@@ -1248,11 +861,6 @@ horizontalAngleFromDirection:
     default: Vector
   return: float
   en-US: Horizontal Angle From Direction
-  es-MX: Ángulo horizontal desde la dirección
-  fr-FR: Angle horizontal depuis une direction
-  ja-JP: 方向からの水平角
-  pt-BR: Ângulo Horizontal a partir da Direção
-  zh-CN: 与此方向的水平角度
 horizontalAngleTowards:
   description: The horizontal angle in degrees from a player's current forward direction
     to the specified position. The result is positive if the position is on the player's
@@ -1268,11 +876,6 @@ horizontalAngleTowards:
     default: Vector
   return: float
   en-US: Horizontal Angle Towards
-  es-MX: Ángulo horizontal en dirección a
-  fr-FR: Angle horizontal vers
-  ja-JP: '水平角の方向: '
-  pt-BR: Ângulo Horizontal Rumo a
-  zh-CN: 水平方向夹角
 __gamemode__:
   description: A game mode constant.
   args:
@@ -1282,11 +885,6 @@ __gamemode__:
     default: ASSAULT
   return: Gamemode
   en-US: Game Mode
-  es-MX: Modo de juego
-  fr-FR: Mode de jeu
-  ja-JP: ゲーム・モード
-  pt-BR: Modo de jogo
-  zh-CN: 比赛模式
 _&getHorizontalFacingAngle:
   description: The horizontal angle in degrees of a player's current facing relative
     to the world. This value increases as the player rotates to the left (wrapping
@@ -1298,11 +896,6 @@ _&getHorizontalFacingAngle:
     default: Event Player
   return: float
   en-US: Horizontal Facing Angle Of
-  es-MX: Ángulo horizontal de orientación de
-  fr-FR: Angle horizontal du regard de
-  ja-JP: '対面水平角: '
-  pt-BR: Ângulo Horizontal Frontal de
-  zh-CN: 水平朝向角度
 _&getHorizontalSpeed:
   description: The current horizontal speed of a player in meters per second. This
     measurement excludes all vertical motion.
@@ -1313,22 +906,12 @@ _&getHorizontalSpeed:
     default: Event Player
   return: Float
   en-US: Horizontal Speed Of
-  es-MX: Velocidad horizontal de
-  fr-FR: Vitesse horizontale de
-  ja-JP: '水平速度: '
-  pt-BR: Velocidade Horizontal de
-  zh-CN: 水平速度
 hostPlayer:
   description: The player that is currently the host of the custom game. This value
     will change if the current host player leaves the match.
   args:
   return: Player
   en-US: Host Player
-  es-MX: Jugador anfitrión
-  fr-FR: Joueur hôte
-  ja-JP: ホスト・プレイヤー
-  pt-BR: Jogador Anfitrião
-  zh-CN: 主机玩家
 iconString:
   description: Allows you to use an icon inside of a string.
   args:
@@ -1338,11 +921,6 @@ iconString:
     default: 'Arrow: Down'
   return: String
   en-US: Icon String
-  es-MX: Cadena de ícono
-  fr-FR: Chaîne d’icône
-  ja-JP: アイコンストリング
-  pt-BR: String de Ícone
-  zh-CN: 图标字符串
 __ifThenElse__:
   description: Results in the Then value when the If condition is true; otherwise,
     results in the Else value.
@@ -1368,8 +946,6 @@ __ifThenElse__:
   - Object
   - Array
   en-US: If-Then-Else
-  fr-FR: Si-Alors-Sinon
-  ja-JP: If-Then-Else
 __indexOfArrayValue__:
   description: The index of a value within an array or -1 if no such value can be
     found.
@@ -1385,11 +961,6 @@ __indexOfArrayValue__:
     default: Number
   return: Integer
   en-US: Index Of Array Value
-  es-MX: Índice del valor de la matriz
-  fr-FR: Index de la valeur de tableau
-  ja-JP: 配列値のインデックス
-  pt-BR: Índice do Valor da Matriz
-  zh-CN: 数组值的索引
 _&isAlive:
   description: Whether a player is alive.
   args:
@@ -1399,31 +970,16 @@ _&isAlive:
     default: Event Player
   return: bool
   en-US: Is Alive
-  es-MX: Está vivo
-  fr-FR: En vie
-  ja-JP: 生存している
-  pt-BR: É Vivo
-  zh-CN: 存活
 isAssemblingHeroes:
   description: Whether the match is currently in its assemble heroes phase.
   args: []
   return: bool
   en-US: Is Assembling Heroes
-  es-MX: En Forma tu equipo
-  fr-FR: Phase de choix de héros
-  ja-JP: ヒーローを編成中
-  pt-BR: É Escolher Heróis
-  zh-CN: 正在集结英雄
 isMatchBetweenRounds:
   description: Whether the match is between rounds.
   args: []
   return: bool
   en-US: Is Between Rounds
-  es-MX: Entre rondas
-  fr-FR: Entre deux manches
-  ja-JP: ラウンドの間
-  pt-BR: É Entre Rodadas
-  zh-CN: 处于回合之间
 _&isHoldingButton:
   description: Whether a player is holding a specific button.
   args:
@@ -1437,11 +993,6 @@ _&isHoldingButton:
     default: Primary Fire
   return: bool
   en-US: Is Button Held
-  es-MX: Botón presionado
-  fr-FR: Bouton maintenu enfoncé
-  ja-JP: ボタンが長押しされている
-  pt-BR: É Botão Segurado
-  zh-CN: 按钮被按下
 _&isCommunicating:
   description: Whether a player is using a specific communication type (such as emoting,
     using a voice line, etc.).
@@ -1458,11 +1009,6 @@ _&isCommunicating:
     default: Voice Line Up
   return: bool
   en-US: Is Communicating
-  es-MX: Se está comunicando
-  fr-FR: Communication
-  ja-JP: コミュニケーションしている
-  pt-BR: É Comunicando
-  zh-CN: 正在交流
 _&isCommunicatingAnything:
   description: Whether a player is using any communication type (such as emoting,
     using a voice line, etc.).
@@ -1473,11 +1019,6 @@ _&isCommunicatingAnything:
     default: Event Player
   return: bool
   en-US: Is Communicating Any
-  es-MX: Comunica algo
-  fr-FR: N’importe quelle communication
-  ja-JP: 任意の方法でコミュニケーションしている
-  pt-BR: É Comunicando Qualquer
-  zh-CN: 正在与人交流
 _&isCommunicatingEmote:
   description: Whether a player is using an emote.
   args:
@@ -1487,11 +1028,6 @@ _&isCommunicatingEmote:
     default: Event Player
   return: bool
   en-US: Is Communicating Any Emote
-  es-MX: Comunica un gesto
-  fr-FR: Communication par emote
-  ja-JP: エモートでコミュニケーションしている
-  pt-BR: É Comunicando Qualquer Emote
-  zh-CN: 正在使用表情交流
 _&isCommunicatingVoiceline:
   description: Whether a player is using a voice line. (The duration of voice lines
     is assumed to be 4 seconds.)
@@ -1502,21 +1038,11 @@ _&isCommunicatingVoiceline:
     default: Event Player
   return: bool
   en-US: Is Communicating Any Voice line
-  es-MX: Comunica una línea de voz
-  fr-FR: Communication par réplique
-  ja-JP: ボイス・ラインでコミュニケーションしている
-  pt-BR: É Comunicando Qualquer Fala
-  zh-CN: 正在使用语音交流
 isControlPointLocked:
   description: Whether the point is locked in control mode.
   args: []
   return: bool
   en-US: Is Control Mode Point Locked
-  es-MX: Punto bloqueado en el modo Control
-  fr-FR: Point de contrôle verrouillé
-  ja-JP: コントロール・モードでポイントがロックされている
-  pt-BR: É Ponto Bloqueado do Modo de Controle
-  zh-CN: 占领要点模式占领点解锁
 _&isCrouching:
   description: Whether a player is crouching.
   args:
@@ -1526,11 +1052,6 @@ _&isCrouching:
     default: Event Player
   return: bool
   en-US: Is Crouching
-  es-MX: Agachado
-  fr-FR: Accroupi
-  ja-JP: しゃがんでいる
-  pt-BR: É Agachado
-  zh-CN: 正在蹲下
 _&isInAlternateForm:
   description: "Whether the specified player is currently in an alternate form:\n
     \       \n- Hammond's ball form\n- Baby Dva\n- Bastion's turret and tank forms\n-
@@ -1543,21 +1064,11 @@ _&isInAlternateForm:
     default: Event Player
   return: bool
   en-US: Is In Alternate Form
-  es-MX: Está en su forma alterna
-  fr-FR: Est dans une forme alternative
-  ja-JP: 異なる形態である
-  pt-BR: Está em uma Forma Alternativa
-  zh-CN: 处于非初始状态
 isInSuddenDeath:
   description: Whether the current game of capture the flag is in sudden death.
   args: []
   return: bool
   en-US: Is CTF Mode In Sudden Death
-  es-MX: Modo CLB en muerte súbita
-  fr-FR: Capture du drapeau en mort subite
-  ja-JP: キャプチャー・ザ・フラッグ・モードがサドンデス中
-  pt-BR: É Modo CaB em Morte Súbita
-  zh-CN: 在夺旗模式中开始绝杀局
 _&isDead:
   description: Whether a player is dead.
   args:
@@ -1567,11 +1078,6 @@ _&isDead:
     default: Event Player
   return: bool
   en-US: Is Dead
-  es-MX: Está muerto
-  fr-FR: Mort
-  ja-JP: 倒れている
-  pt-BR: É Morto
-  zh-CN: 死亡
 _&isDummy:
   description: Whether a player is a dummy bot.
   args:
@@ -1581,11 +1087,6 @@ _&isDummy:
     default: Event Player
   return: bool
   en-US: Is Dummy Bot
-  es-MX: Robot de entrenamiento
-  fr-FR: Est une I.A.
-  ja-JP: ダミーボットである
-  pt-BR: É Bot
-  zh-CN: 是否是机器人
 _&isDuplicatingAHero:
   description: Whether the specified player is duplicating another hero. To check
     which hero, use the Hero Being Duplicated value.
@@ -1596,11 +1097,6 @@ _&isDuplicatingAHero:
     default: Event Player
   return: bool
   en-US: Is Duplicating
-  es-MX: Está copiando
-  fr-FR: Effectue une duplication
-  ja-JP: コピー中
-  pt-BR: Está Duplicando
-  zh-CN: 正在人格复制
 _&isFiringPrimaryFire:
   description: Whether the specified player's primary weapon attack is being used.
   args:
@@ -1610,11 +1106,6 @@ _&isFiringPrimaryFire:
     default: Event Player
   return: bool
   en-US: Is Firing Primary
-  es-MX: Está usando el disparo principal
-  fr-FR: Tir principal
-  ja-JP: メイン攻撃を使用中
-  pt-BR: É Disparo Primário
-  zh-CN: 正在使用主要武器
 _&isFiringSecondaryFire:
   description: Whether the specified player's secondary weapon attack is being used.
   args:
@@ -1624,11 +1115,6 @@ _&isFiringSecondaryFire:
     default: Event Player
   return: bool
   en-US: Is Firing Secondary
-  es-MX: Está usando el disparo secundario
-  fr-FR: Tir secondaire
-  ja-JP: サブ攻撃を使用中
-  pt-BR: É Disparo Secundário
-  zh-CN: 正在使用辅助武器
 isFlagAtBase:
   description: Whether a specific team's flag is at its base in capture the flag.
   args:
@@ -1638,11 +1124,6 @@ isFlagAtBase:
     default: Team
   return: bool
   en-US: Is Flag At Base
-  es-MX: La bandera está en la base
-  fr-FR: Drapeau à la base
-  ja-JP: フラッグが陣地にある
-  pt-BR: É Bandeira na Base
-  zh-CN: 旗帜是否在基地中
 isFlagBeingCarried:
   description: Whether a specific team's flag is being carried by a member of the
     opposing team in capture the flag.
@@ -1653,22 +1134,12 @@ isFlagBeingCarried:
     default: Team
   return: bool
   en-US: Is Flag Being Carried
-  es-MX: La bandera está siendo transportada
-  fr-FR: Drapeau transporté
-  ja-JP: フラッグが運ばれている
-  pt-BR: É Bandeira Sendo Carregada
-  zh-CN: 是否有人携带旗帜
 isGameInProgress:
   description: Whether the main phase of the match is in progress (during which time
     combat and scoring are allowed).
   args: []
   return: bool
   en-US: Is Game In Progress
-  es-MX: Partida en curso
-  fr-FR: Partie en cours
-  ja-JP: 進行中のゲーム
-  pt-BR: É Jogo em Andamento
-  zh-CN: 游戏正在进行中
 teamHasHero:
   description: Whether a specific hero is being played (either on a team or in the
     match).
@@ -1683,11 +1154,6 @@ teamHasHero:
     default: Team
   return: bool
   en-US: Is Hero Being Played
-  es-MX: Jugando con el héroe
-  fr-FR: Héros joué
-  ja-JP: ヒーローがプレイされているか
-  pt-BR: É o Herói em Jogo
-  zh-CN: 正在使用英雄
 _&isInAir:
   description: Whether a player is airborne.
   args:
@@ -1697,11 +1163,6 @@ _&isInAir:
     default: Event Player
   return: bool
   en-US: Is In Air
-  es-MX: En el aire
-  fr-FR: Dans les airs
-  ja-JP: 空中にいる
-  pt-BR: É no Ar
-  zh-CN: 正在空中
 isInLoS:
   description: Whether two positions have line of sight with each other.
   args:
@@ -1727,21 +1188,11 @@ isInLoS:
     default: Barriers DO NOT BLOCK LOS
   return: bool
   en-US: Is In Line of Sight
-  es-MX: En la línea de visión
-  fr-FR: Dans la ligne de vue
-  ja-JP: 射線が通っている
-  pt-BR: É Na Linha de Visão
-  zh-CN: 在视线内
 isInSetup:
   description: Whether the match is currently in its setup phase.
   args: []
   return: bool
   en-US: Is In Setup
-  es-MX: En preparación
-  fr-FR: Dans les paramètres
-  ja-JP: セットアップ中
-  pt-BR: É em Organização
-  zh-CN: 正在设置
 _&isInSpawnRoom:
   description: Whether a specific player is in the spawn room (and is thus being healed
     and able to change heroes).
@@ -1752,11 +1203,6 @@ _&isInSpawnRoom:
     default: Event Player
   return: bool
   en-US: Is In Spawn Room
-  es-MX: En el cuarto de reaparición
-  fr-FR: Dans la salle d’apparition
-  ja-JP: リスポーンエリアにいる
-  pt-BR: É Na Sala de Ressurgimento
-  zh-CN: 在重生室中
 _&isInViewAngle:
   description: Whether a location is within view of a player.
   args:
@@ -1774,11 +1220,6 @@ _&isInViewAngle:
     default: Number
   return: bool
   en-US: Is In View Angle
-  es-MX: En el ángulo de vista
-  fr-FR: Dans le champ de vision
-  ja-JP: 視角範囲内
-  pt-BR: É No Ângulo de Visão
-  zh-CN: 在视野内
 _&isJumping:
   description: Whether the specified player is jumping.
   args:
@@ -1788,21 +1229,11 @@ _&isJumping:
     default: Event Player
   return: bool
   en-US: Is Jumping
-  es-MX: Está saltando
-  fr-FR: Utilise Saut
-  ja-JP: ジャンプ中
-  pt-BR: Está Pulando
-  zh-CN: 正在跳跃
 isMatchComplete:
   description: Whether the match has finished.
   args: []
   return: bool
   en-US: Is Match Complete
-  es-MX: Partida Completada
-  fr-FR: Partie terminée
-  ja-JP: マッチが完了している
-  pt-BR: É Partida Concluída
-  zh-CN: 比赛结束
 _&isMeleeing:
   description: Whether the specified player is meleeing.
   args:
@@ -1812,11 +1243,6 @@ _&isMeleeing:
     default: Event Player
   return: bool
   en-US: Is Meleeing
-  es-MX: Está usando un ataque melé
-  fr-FR: Utilise Mêlée
-  ja-JP: 近接攻撃中
-  pt-BR: Está Usando Corpo a Corpo
-  zh-CN: 正在近战攻击
 _&isMoving:
   description: Whether a player is moving (defined as having a nonzero current speed).
   args:
@@ -1826,11 +1252,6 @@ _&isMoving:
     default: Event Player
   return: bool
   en-US: Is Moving
-  es-MX: En movimiento
-  fr-FR: Se déplace
-  ja-JP: 移動している
-  pt-BR: É Movimentando-se
-  zh-CN: 正在移动
 isObjectiveComplete:
   description: Whether the specified objective has been completed. Results in false
     if the game mode is not assault, escort, or assault/escort.
@@ -1843,11 +1264,6 @@ isObjectiveComplete:
     default: Number
   return: bool
   en-US: Is Objective Complete
-  es-MX: Objetivo completado
-  fr-FR: Objectif accompli
-  ja-JP: 目標をクリアした
-  pt-BR: É Objetivo Concluído
-  zh-CN: 目标是否完成
 _&isOnGround:
   description: Whether a player is on the ground (or other walkable surface).
   args:
@@ -1857,11 +1273,6 @@ _&isOnGround:
     default: Event Player
   return: bool
   en-US: Is On Ground
-  es-MX: En el suelo
-  fr-FR: Au sol
-  ja-JP: 地上にいる
-  pt-BR: É No Chão
-  zh-CN: 在地面上
 _&isOnObjective:
   description: Whether a specific player is currently occupying a payload or capture
     point.
@@ -1872,11 +1283,6 @@ _&isOnObjective:
     default: Event Player
   return: bool
   en-US: Is On Objective
-  es-MX: En el objetivo
-  fr-FR: Sur l’objectif
-  ja-JP: 目標にいる
-  pt-BR: É No Objetivo
-  zh-CN: 在目标点上
 _&isOnWall:
   description: Whether a player is on a wall (climbing or riding).
   args:
@@ -1886,11 +1292,6 @@ _&isOnWall:
     default: Event Player
   return: bool
   en-US: Is On Wall
-  es-MX: En el muro
-  fr-FR: Sur le mur
-  ja-JP: 壁の上にいる
-  pt-BR: É Na Parede
-  zh-CN: 在墙上
 _&isOnFire:
   description: Whether a specific player's portrait is on fire.
   args:
@@ -1900,11 +1301,6 @@ _&isOnFire:
     default: Event Player
   return: bool
   en-US: Is Portrait On Fire
-  es-MX: Retrato en llamas
-  fr-FR: Portrait « en feu »
-  ja-JP: ポートレートに炎エフェクトがついている
-  pt-BR: É Retrato Em Chamas
-  zh-CN: 头像火力全开
 _&isStanding:
   description: Whether a player is standing (defined as both not moving and not in
     the air).
@@ -1915,11 +1311,6 @@ _&isStanding:
     default: Event Player
   return: bool
   en-US: Is Standing
-  es-MX: De pie
-  fr-FR: Debout
-  ja-JP: 立っている
-  pt-BR: É Parado
-  zh-CN: 正在站立
 isTeamOnDefense:
   description: Whether the specified team is currently on defense. Results in false
     if the game mode is not assault, escort, or assault/escort.
@@ -1930,11 +1321,6 @@ isTeamOnDefense:
     default: Team
   return: bool
   en-US: Is Team On Defense
-  es-MX: Equipo defensor
-  fr-FR: Équipe en défense
-  ja-JP: 防衛側のチーム
-  pt-BR: É Equipe na Defensa
-  zh-CN: 正在防守
 isTeamOnOffense:
   description: Whether the specified team is currently on offense. Results in false
     if the game mode is not assault, escort, or assault/escort.
@@ -1945,11 +1331,6 @@ isTeamOnOffense:
     default: Team
   return: bool
   en-US: Is Team On Offense
-  es-MX: Equipo atacante
-  fr-FR: Équipe en attaque
-  ja-JP: 攻撃側のチーム
-  pt-BR: É Equipe no Ataque
-  zh-CN: 作为进攻队伍
 __all__:
   description: Whether the specified condition evaluates to true for every value in
     the specified array.
@@ -1966,11 +1347,6 @@ __all__:
     default: Compare
   return: bool
   en-US: Is True For All
-  es-MX: Es verdadero para todos
-  fr-FR: Vrai pour tous
-  ja-JP: すべてに対して「True」
-  pt-BR: É Verdadeiro para Todos
-  zh-CN: 对全部为”真“
 __any__:
   description: Whether the specified condition evaluates to true for any value in
     the specified array.
@@ -1987,11 +1363,6 @@ __any__:
     default: Compare
   return: bool
   en-US: Is True For Any
-  es-MX: Es verdadero para cualquiera
-  fr-FR: Vrai pour n’importe qui
-  ja-JP: いずれに対しても「True」
-  pt-BR: É Verdadeiro para Qualquer
-  zh-CN: 对任意为”真“
 _&isUsingAbility1:
   description: Whether the specified player is using ability 1.
   args:
@@ -2001,11 +1372,6 @@ _&isUsingAbility1:
     default: Event Player
   return: bool
   en-US: Is Using Ability 1
-  es-MX: Está utilizando la habilidad 1
-  fr-FR: Capacité 1 utilisée
-  ja-JP: アビリティ1を使用
-  pt-BR: É Usando Habilidade 1
-  zh-CN: 正在使用技能 1
 _&isUsingAbility2:
   description: Whether the specified player is using ability 2.
   args:
@@ -2015,11 +1381,6 @@ _&isUsingAbility2:
     default: Event Player
   return: bool
   en-US: Is Using Ability 2
-  es-MX: Está utilizando la habilidad 2
-  fr-FR: Capacité 2 utilisée
-  ja-JP: アビリティ2を使用
-  pt-BR: É Usando Habilidade 2
-  zh-CN: 正在使用技能 2
 _&isUsingUltimate:
   description: Whether a player is using an ultimate ability.
   args:
@@ -2029,76 +1390,41 @@ _&isUsingUltimate:
     default: Event Player
   return: bool
   en-US: Is Using Ultimate
-  es-MX: Está usando la habilidad máxima
-  fr-FR: Capacité ultime utilisée
-  ja-JP: アルティメットを使用している
-  pt-BR: É Usando Suprema
-  zh-CN: 正在使用终极技能
 isWaitingForPlayers:
   description: Whether the match is waiting for players to join before starting.
   args: []
   return: bool
   en-US: Is Waiting For Players
-  es-MX: Esperando jugadores
-  fr-FR: En attente de joueurs
-  ja-JP: ほかのプレイヤーを待っている
-  pt-BR: É Aguardando Jogadores
-  zh-CN: 正在等待玩家
 getLastCreatedEntity:
   description: A reference to the last effect or icon entity created by the event
     player (or created at the global level).
   args: []
   return: EntityId
   en-US: Last Created Entity
-  es-MX: Última entidad creada
-  fr-FR: Dernière entité créée
-  ja-JP: 最新のエンティティ
-  pt-BR: Entidade Criada por Último
-  zh-CN: 最后创建的实体
 getLastDamageModification:
   description: An id representing the most recent start damage modification action
     that was executed by the event player (or executed at the global level).
   args: []
   return: DamageModificationId
   en-US: Last Damage Modification ID
-  es-MX: ID de modificación de daño anterior
-  fr-FR: Dernier identifiant de modification de dégâts
-  ja-JP: 最新のダメージ変更ID
-  pt-BR: ID de Modificação de Dano Mais Recente
-  zh-CN: 上一个伤害调整ID
 getLastDoT:
   description: An id representing the most recent damage over time action that was
     executed by the event player (or executed at the global level).
   args: []
   return: DotId
   en-US: Last Damage Over Time ID
-  es-MX: ID de daño con el tiempo anterior
-  fr-FR: Dernier identifiant de dégâts sur la durée
-  ja-JP: 最新の継続ダメージID
-  pt-BR: ID de Dano ao Longo do Tempo Mais Recente
-  zh-CN: 上一个持续伤害效果ID
 getLastHoT:
   description: An id representing the most recent heal over time action that was executed
     by the event player (or executed at the global level).
   args: []
   return: HotId
   en-US: Last Heal Over Time ID
-  es-MX: ID de sanación con el tiempo anterior
-  fr-FR: Dernier identifiant de soins sur la durée
-  ja-JP: 最新の継続回復ID
-  pt-BR: ID de Cura ao Longo do Tempo Mais Recente
-  zh-CN: 上一个持续治疗效果ID
 getLastHealingModification:
   description: An id representing the most recent start healing modification action
     that was executed by the event player (or executed at the global level).
   args: []
   return: HealingModificationId
   en-US: Last Healing Modification ID
-  es-MX: ID de modificación de sanación anterior
-  fr-FR: Dernier identifiant de modification de soins
-  ja-JP: 最新回復変更ID
-  pt-BR: ID da última modificação de cura
-  zh-CN: 上一个治疗调整ID
 __lastOf__:
   description: The value at the end of the specified array. Results in 0 if the specified
     array is empty.
@@ -2111,22 +1437,12 @@ __lastOf__:
   - Object
   - Array
   en-US: Last Of
-  es-MX: Último de
-  fr-FR: Dernier
-  ja-JP: 最後の値
-  pt-BR: Último de
-  zh-CN: 最后
 getLastCreatedText:
   description: A reference to the last piece of text created by the event player (or
     created at the global level) via the create hud text or create in-world text action.
   args: []
   return: TextId
   en-US: Last Text ID
-  es-MX: ID de texto anterior
-  fr-FR: Dernier identifiant de texte
-  ja-JP: 最新のテキストID
-  pt-BR: ID de Texto Mais Recente
-  zh-CN: 上一个文本ID
 Vector.Left:
   description: Shorthand for the directional vector(1, 0, 0), which points to the
     left.
@@ -2137,11 +1453,6 @@ Vector.Left:
     - Integer
     - Integer
   en-US: Left
-  es-MX: Izquierda
-  fr-FR: Gauche
-  ja-JP: 左
-  pt-BR: Esquerda
-  zh-CN: 左
 localVector:
   description: The vector in local coordinates corresponding to the provided vector
     in world coordinates.
@@ -2162,11 +1473,6 @@ localVector:
     default: ROTATION
   return: Vector
   en-US: Local Vector Of
-  es-MX: Vector local de
-  fr-FR: Vecteur local de
-  ja-JP: 'ローカルのベクトル: '
-  pt-BR: Vetor Local de
-  zh-CN: 本地矢量
 __map__:
   description: A map constant.
   args:
@@ -2177,35 +1483,19 @@ __map__:
   return: Map
   en-US: Map
   es-ES: Mapa
-  es-MX: Mapa
-  fr-FR: Carte
   it-IT: Mappa
-  ja-JP: マップ
   pl-PL: Mapa
-  pt-BR: Mapa
-  ru-RU: Поле боя
-  zh-CN: 地图
   zh-TW: 地圖
 getMatchRound:
   description: The current round of the match, counting up from 1.
   args: []
   return: Integer
   en-US: Match Round
-  es-MX: Ronda de la partida
-  fr-FR: Manche de la partie
-  ja-JP: マッチのラウンド
-  pt-BR: Rodada da Partida
-  zh-CN: 比赛回合
 getMatchTime:
   description: The amount of time in seconds remaining in the current game mode phase.
   args: []
   return: Float
   en-US: Match Time
-  es-MX: Tiempo de la partida
-  fr-FR: Temps de jeu
-  ja-JP: マッチ時間
-  pt-BR: Tempo da Partida
-  zh-CN: 比赛时间
 max:
   description: The greater of two numbers.
   args:
@@ -2219,11 +1509,6 @@ max:
     default: Number
   return: float
   en-US: Max
-  es-MX: Máximo
-  fr-FR: Maximum
-  ja-JP: 最大
-  pt-BR: Máx.
-  zh-CN: 较大
 _&getMaxHealth:
   description: The max health of a player, including armor and shields.
   args:
@@ -2233,11 +1518,6 @@ _&getMaxHealth:
     default: Event Player
   return: Float
   en-US: Max Health
-  es-MX: Salud máxima
-  fr-FR: Points de vie maximum
-  ja-JP: 最大ライフ
-  pt-BR: Vida Máxima
-  zh-CN: 最大生命值
 min:
   description: The lesser of two numbers.
   args:
@@ -2251,11 +1531,6 @@ min:
     default: Number
   return: float
   en-US: Min
-  es-MX: Mínimo
-  fr-FR: Minimum
-  ja-JP: 分
-  pt-BR: Mín.
-  zh-CN: 较小
 __modulo__:
   description: The remainder of the left-hand operand divided by the right-hand operand.
     Any number modulo zero results in zero.
@@ -2270,10 +1545,6 @@ __modulo__:
     default: Number
   return: float
   en-US: Modulo
-  es-MX: Módulo
-  ja-JP: 剰余
-  pt-BR: Modular
-  zh-CN: 余数
 __multiply__:
   description: The product of two numbers or vectors. A vector multiplied by a number
     will yield a scaled vector.
@@ -2297,11 +1568,6 @@ __multiply__:
   - float
   - Vector
   en-US: Multiply
-  es-MX: Multiplicar
-  fr-FR: Multiplication
-  ja-JP: 乗算
-  pt-BR: Multiplicar
-  zh-CN: 乘
 nearestWalkablePosition:
   description: The position closest to the specified position that can be stood on
     and is accessible from a spawn point.
@@ -2312,11 +1578,6 @@ nearestWalkablePosition:
     default: Vector
   return: Position
   en-US: Nearest Walkable Position
-  es-MX: Posición caminable más cercana
-  fr-FR: Position la plus proche en marchant
-  ja-JP: 最も近い歩行可能な位置
-  pt-BR: Posição Transitável Mais Próxima
-  zh-CN: 最近的可行走位置
 normalize:
   description: The unit-length normalization of a vector.
   args:
@@ -2326,11 +1587,6 @@ normalize:
     default: Vector
   return: Vector
   en-US: Normalize
-  es-MX: Normalizar
-  fr-FR: Normalisation
-  ja-JP: 正規化
-  pt-BR: Normalizar
-  zh-CN: 归一化
 __not__:
   description: Whether the input is false (or equivalent to false).
   args:
@@ -2341,22 +1597,12 @@ __not__:
     default: 'True'
   return: bool
   en-US: Not
-  es-MX: 'No'
-  fr-FR: Pas
-  ja-JP: NOT
-  pt-BR: Não
-  zh-CN: 非
 'null':
   description: The absence of a player. Used when no player is desired for a particular
     input. Equivalent to the real number 0 for the purposes of comparison and debugging.
   args:
   return: Player
   en-US: 'Null'
-  es-MX: Nulo
-  fr-FR: Non applicable
-  ja-JP: 'Null'
-  pt-BR: Nulo
-  zh-CN: 无
 getNumberOfDeadPlayers:
   description: The number of dead players on a team or in the match.
   args:
@@ -2366,11 +1612,6 @@ getNumberOfDeadPlayers:
     default: Team
   return: Integer
   en-US: Number of Dead Players
-  es-MX: Cantidad de jugadores muertos
-  fr-FR: Nombre de joueurs morts
-  ja-JP: 倒れたプレイヤーの数
-  pt-BR: Número de Jogadores Mortos
-  zh-CN: 死亡玩家数量
 _&getNumberOfDeaths:
   description: The number of deaths a specific player has earned. This value only
     accumulates while a game is in progress.
@@ -2381,11 +1622,6 @@ _&getNumberOfDeaths:
     default: Event Player
   return: Integer
   en-US: Number of Deaths
-  es-MX: Cantidad de muertes
-  fr-FR: Nombre de morts
-  ja-JP: デス数
-  pt-BR: Número de Mortes
-  zh-CN: 死亡数
 _&getNumberOfElims:
   description: The number of eliminations a specific player has earned. This value
     only accumulates while a game is in progress.
@@ -2396,11 +1632,6 @@ _&getNumberOfElims:
     default: Event Player
   return: Integer
   en-US: Number of Eliminations
-  es-MX: Cantidad de eliminaciones
-  fr-FR: Nombre d’éliminations
-  ja-JP: キル数
-  pt-BR: Número de Eliminações
-  zh-CN: 消灭数
 _&getNumberOfFinalBlows:
   description: The number of final blows a specific player has earned. This value
     only accumulates while a game is in progress.
@@ -2411,11 +1642,6 @@ _&getNumberOfFinalBlows:
     default: Event Player
   return: Integer
   en-US: Number of Final Blows
-  es-MX: Cantidad de golpes de gracia
-  fr-FR: Nombre de coups de grâce
-  ja-JP: ファイナル・ブロウ数
-  pt-BR: Número de Golpes Finais
-  zh-CN: 最后一击数
 getNumberOfHeroes:
   description: The number of players playing a specific hero on a team or in the match.
   args:
@@ -2429,11 +1655,6 @@ getNumberOfHeroes:
     default: Team
   return: Integer
   en-US: Number of Heroes
-  es-MX: Cantidad de héroes
-  fr-FR: Nombre de héros
-  ja-JP: ヒーローの数
-  pt-BR: Número de Heróis
-  zh-CN: 英雄数量
 getNumberOfLivingPlayers:
   description: The number of living players on a team or in the match.
   args:
@@ -2443,11 +1664,6 @@ getNumberOfLivingPlayers:
     default: Team
   return: Integer
   en-US: Number of Living Players
-  es-MX: Cantidad de jugadores vivos
-  fr-FR: Nombre de joueurs en vie
-  ja-JP: 生存プレイヤーの数
-  pt-BR: Número de Jogadores Vivos
-  zh-CN: 存活玩家数量
 getNumberOfPlayers:
   description: The number of players on a team or in the match.
   args:
@@ -2457,11 +1673,6 @@ getNumberOfPlayers:
     default: Team
   return: Integer
   en-US: Number of Players
-  es-MX: Cantidad de jugadores
-  fr-FR: Nombre de joueurs
-  ja-JP: プレイヤーの数
-  pt-BR: Número de Jogadores
-  zh-CN: 玩家数量
 getNumberOfPlayersOnObjective:
   description: The number of players occupying a payload or control point (either
     on a team or in the match).
@@ -2472,22 +1683,12 @@ getNumberOfPlayersOnObjective:
     default: Team
   return: Integer
   en-US: Number of Players On Objective
-  es-MX: Cantidad de jugadores en el objetivo
-  fr-FR: Nombre de joueurs sur l’objectif
-  ja-JP: 目標を確保中のプレイヤーの数
-  pt-BR: Número de Jogadores no Objetivo
-  zh-CN: 目标点上玩家数量
 getCurrentObjective:
   description: The control point, payload checkpoint, or payload destination currently
     active (either 0, 1, or 2). Valid in assault, assault/escort, escort, and control.
   args: []
   return: Integer
   en-US: Objective Index
-  es-MX: Índice de objetivo
-  fr-FR: Index de l’objectif
-  ja-JP: コントロール・モードのサブマップ番号
-  pt-BR: Índice do Objetivo
-  zh-CN: 对象索引
 getObjectivePosition:
   description: The position in the world of the specified objective (either a control
     point, a payload checkpoint, or a payload destination). Valid in assault, assault/escort,
@@ -2501,11 +1702,6 @@ getObjectivePosition:
     default: Number
   return: Integer
   en-US: Objective Position
-  es-MX: Posición del objetivo
-  fr-FR: Position de l’objectif
-  ja-JP: 目標の位置
-  pt-BR: Posição do Objetivo
-  zh-CN: 目标位置
 getOppositeTeam:
   description: The team opposite the specified team.
   args:
@@ -2515,11 +1711,6 @@ getOppositeTeam:
     default: Team
   return: Team
   en-US: Opposite Team Of
-  es-MX: Equipo contrario de
-  fr-FR: Équipe opposée à
-  ja-JP: '相手チーム: '
-  pt-BR: Equipe Adversária de
-  zh-CN: 对方队伍
 __or__:
   description: Whether either of the two inputs are true (or equivalent to true).
   args:
@@ -2535,32 +1726,17 @@ __or__:
     default: 'True'
   return: bool
   en-US: Or
-  es-MX: O
-  fr-FR: Ou
-  ja-JP: OR
-  pt-BR: Ou
-  zh-CN: 或
 getPayloadPosition:
   description: The position in the world of the active payload.
   args: []
   return: Position
   en-US: Payload Position
-  es-MX: Posición de la carga
-  fr-FR: Position du convoi
-  ja-JP: ペイロードの位置
-  pt-BR: Posição da Carga
-  zh-CN: 运载目标位置
 getPayloadProgressPercentage:
   description: The current progress towards the destination for the active payload
     (expressed as a percentage).
   args: []
   return: Float
   en-US: Payload Progress Percentage
-  es-MX: Porcentaje de progreso de la carga
-  fr-FR: Pourcentage de progression du convoi
-  ja-JP: ペイロード進行のパーセンテージ
-  pt-BR: Percentual de Progresso da Carga
-  zh-CN: 运载目标进度百分比
 getFlagCarrier:
   description: The player carrying a particular team's flag in capture the flag. Results
     in null if no player is carrying the flag.
@@ -2571,11 +1747,6 @@ getFlagCarrier:
     default: Team
   return: Player
   en-US: Player Carrying Flag
-  es-MX: Jugador que transporta la bandera
-  fr-FR: Joueur portant le drapeau
-  ja-JP: フラッグを運んでいる
-  pt-BR: Jogador Carregando a Bandeira
-  zh-CN: 携带旗帜的玩家
 _&getPlayerClosestToReticle:
   description: The player closest to the reticle of the specified player, optionally
     restricted by team.
@@ -2590,11 +1761,6 @@ _&getPlayerClosestToReticle:
     default: Team
   return: Player
   en-US: Player Closest To Reticle
-  es-MX: Jugador más cercano al retículo
-  fr-FR: Joueur le plus proche du réticule
-  ja-JP: 照準に最も近いプレイヤー
-  pt-BR: Jogador Mais Próximo da Mira
-  zh-CN: 距离准星最近的玩家
 __playerVar__:
   description: The current value of a player variable, which is a variable that belongs
     to a specific player.
@@ -2609,11 +1775,6 @@ __playerVar__:
     default: A
   return: Value
   en-US: Player Variable
-  es-MX: Variable de jugador
-  fr-FR: Variable de joueur
-  ja-JP: プレイヤー変数
-  pt-BR: Variável de Jogador
-  zh-CN: 玩家变量
 getPlayersInSlot:
   description: The player or array of players who occupy a specific slot in the game.
   args:
@@ -2631,11 +1792,6 @@ getPlayersInSlot:
   - Player
   - Array: Player
   en-US: Players In Slot
-  es-MX: Jugadores en la posición
-  fr-FR: Joueurs dans l’emplacement
-  ja-JP: スロットに入ったプレイヤー
-  pt-BR: Jogadores no Espaço
-  zh-CN: 此位置的玩家
 _&getPlayersInViewAngle:
   description: The players who are within a specific view angle of a specific player's
     reticle, optionally restricted by team.
@@ -2655,11 +1811,6 @@ _&getPlayersInViewAngle:
   return:
     Array: Player
   en-US: Players in View Angle
-  es-MX: Jugadores en el ángulo de vista
-  fr-FR: Joueurs dans le champ de vision
-  ja-JP: 視角範囲内のプレイヤー
-  pt-BR: Jogadores no Ângulo de Visão
-  zh-CN: 视角中的玩家
 getPlayersOnHero:
   description: The array of players playing a specific hero on a team or in the match.
   args:
@@ -2674,11 +1825,6 @@ getPlayersOnHero:
   return:
     Array: Player
   en-US: Players On Hero
-  es-MX: Jugadores con el héroe
-  fr-FR: Joueurs sur le héros
-  ja-JP: ヒーローを使用中のプレイヤー
-  pt-BR: Jogadores Usando o Herói
-  zh-CN: 选择英雄的玩家
 getPlayersInRadius:
   description: An array containing all players within a certain distance of a position,
     optionally restricted by team and line of sight.
@@ -2705,22 +1851,12 @@ getPlayersInRadius:
   return:
     Array: Player
   en-US: Players Within Radius
-  es-MX: Jugadores dentro del radio
-  fr-FR: Joueurs dans un rayon
-  ja-JP: 範囲内のプレイヤー
-  pt-BR: Jogadores no Raio
-  zh-CN: 范围内玩家
 getCapturePercentage:
   description: The current progress towards capture for the active control point (expressed
     as a percentage).
   args: []
   return: float
   en-US: Point Capture Percentage
-  es-MX: Porcentaje de captura de punto
-  fr-FR: Pourcentage de capture du point
-  ja-JP: ポイント・キャプチャーのパーセンテージ
-  pt-BR: Percentual de Captura do Ponto
-  zh-CN: 目标点占领百分比
 _&getPosition:
   description: The current position of a player as a vector.
   args:
@@ -2730,11 +1866,6 @@ _&getPosition:
     default: Event Player
   return: Position
   en-US: Position Of
-  es-MX: Posición de
-  fr-FR: Position de
-  ja-JP: '位置: '
-  pt-BR: Posição de
-  zh-CN: 所选位置
 __raiseToPower__:
   description: The left-hand operand raised to the power of the right-hand operand.
     If the left-hand operand is negative, the result is always zero.
@@ -2749,11 +1880,6 @@ __raiseToPower__:
     default: Number
   return: Float
   en-US: Raise To Power
-  es-MX: Elevar a la potencia
-  fr-FR: 'Élévation à une puissance '
-  ja-JP: 累乗
-  pt-BR: Elevar à Potência
-  zh-CN: 乘方
 random.randint:
   description: A random integer between the specified min and max, inclusive.
   args:
@@ -2769,11 +1895,6 @@ random.randint:
     default: Number
   return: Integer
   en-US: Random Integer
-  es-MX: Número entero aleatorio
-  fr-FR: Nombre entier aléatoire
-  ja-JP: ランダムな整数
-  pt-BR: Inteiro Aleatório
-  zh-CN: 随机整数
 random.uniform:
   description: A random real number between the specified min and max.
   args:
@@ -2787,11 +1908,6 @@ random.uniform:
     default: Number
   return: float
   en-US: Random Real
-  es-MX: Número real aleatorio
-  fr-FR: Nombre réel aléatoire
-  ja-JP: ランダムな実数
-  pt-BR: Real Aleatório
-  zh-CN: 随机实数
 random.choice:
   description: A random value from the specified array.
   args:
@@ -2804,11 +1920,6 @@ random.choice:
   - Object
   - Array
   en-US: Random Value In Array
-  es-MX: Valor aleatorio en matriz
-  fr-FR: Valeur aléatoire dans le tableau
-  ja-JP: 配列内のランダムな値
-  pt-BR: Valor Aleatório na Matriz
-  zh-CN: 数组随机取值
 random.shuffle:
   description: A copy of the specified array with the values in a random order.
   args:
@@ -2818,11 +1929,6 @@ random.shuffle:
     default: Global Variable
   return: Array
   en-US: Randomized Array
-  es-MX: Matriz aleatorizada
-  fr-FR: Tableau aléatoire
-  ja-JP: ランダム化された配列
-  pt-BR: Matriz Randomizada
-  zh-CN: 随机数组
 __raycastHitNormal__:
   description: The surface normal at the ray cast hit position (or from end pos to
     start pos if no hit occurs).
@@ -2855,11 +1961,6 @@ __raycastHitNormal__:
     default: 'True'
   return: Direction
   en-US: Ray Cast Hit Normal
-  es-MX: Estándar de impacto de lanzamiento de rayo
-  fr-FR: Surface intersectée par le rayon émis
-  ja-JP: レイ・キャストが当たった法線
-  pt-BR: Normal de Acerto do Lançamento de Raio
-  zh-CN: 射线命中法线
 __raycastHitPlayer__:
   description: The player hit by the ray cast (or null if no player is hit).
   args:
@@ -2891,11 +1992,6 @@ __raycastHitPlayer__:
     default: 'True'
   return: Player
   en-US: Ray Cast Hit Player
-  es-MX: Jugador de impacto de lanzamiento de rayo
-  fr-FR: Joueur intersecté par le rayon émis
-  ja-JP: レイ・キャストが当たったプレイヤー
-  pt-BR: Jogador Atingido pelo Lançamento de Raio
-  zh-CN: 射线命中玩家
 __raycastHitPosition__:
   description: The position where the ray cast hits a surface, object, or player (or
     the end pos if no hit occurs).
@@ -2928,11 +2024,6 @@ __raycastHitPosition__:
     default: 'True'
   return: Position
   en-US: Ray Cast Hit Position
-  es-MX: Posición de impacto de lanzamiento de rayo
-  fr-FR: Position d’impact du rayon émis
-  ja-JP: レイ・キャストのヒット位置
-  pt-BR: Posição de Acerto do Lançamento de Raio
-  zh-CN: 射线命中位置
 __removeFromArray__:
   description: A copy of an array with one or more values removed (if found).
   args_allow_null: true
@@ -2950,11 +2041,6 @@ __removeFromArray__:
     default: Number
   return: Array
   en-US: Remove From Array
-  es-MX: Eliminar de la matriz
-  fr-FR: Supprimer du tableau
-  ja-JP: 配列から削除
-  pt-BR: Remover da Matriz
-  zh-CN: 从数组中移除
 Vector.RIGHT:
   description: Shorthand for the directional vector(-1, 0, 0), which points to the
     right.
@@ -2965,11 +2051,6 @@ Vector.RIGHT:
     - Integer
     - Integer
   en-US: Right
-  es-MX: Derecha
-  fr-FR: Droite
-  ja-JP: 右
-  pt-BR: Direita
-  zh-CN: 右
 __round__:
   description: The integer to which the specified value rounds.
   args:
@@ -2983,11 +2064,6 @@ __round__:
     default: UP
   return: Integer
   en-US: Round To Integer
-  es-MX: Redondear a número entero
-  fr-FR: Arrondir à l’entier
-  ja-JP: 整数への四捨五入
-  pt-BR: Arredondar para Inteiro
-  zh-CN: 取整
 _&getScore:
   description: The current score of a player. Results in 0 if the game mode is not
     free-for-all.
@@ -2998,11 +2074,6 @@ _&getScore:
     default: Event Player
   return: Integer
   en-US: Score Of
-  es-MX: Puntuación de
-  fr-FR: Score de
-  ja-JP: 'スコア: '
-  pt-BR: Pontuação de
-  zh-CN: 分数
 getServerLoad:
   description: Provides a percentage representing the CPU load of the current game
     instance. As this number approaches or exceeds 100, it becomes increasingly likely
@@ -3010,11 +2081,6 @@ getServerLoad:
   args: []
   return: Float
   en-US: Server Load
-  es-MX: Uso del servidor
-  fr-FR: Charge du serveur
-  ja-JP: サーバー負荷
-  pt-BR: Uso do Servidor
-  zh-CN: 服务器负载
 getAverageServerLoad:
   description: Provides a percentage representing the average CPU load of the current
     game instance over the last two seconds. As this number approaches or exceeds
@@ -3023,11 +2089,6 @@ getAverageServerLoad:
   args: []
   return: Float
   en-US: Server Load Average
-  es-MX: Uso promedio del servidor
-  fr-FR: Charge moyenne du serveur
-  ja-JP: サーバー負荷平均
-  pt-BR: Média de Uso do Servidor
-  zh-CN: 服务器负载平均值
 getPeakServerLoad:
   description: Provides a percentage representing the highest CPU load of the current
     game instance over the last two seconds. As this number approaches or exceeds
@@ -3036,11 +2097,6 @@ getPeakServerLoad:
   args: []
   return: Float
   en-US: Server Load Peak
-  es-MX: Uso máximo del servidor
-  fr-FR: Pic de charge du serveur
-  ja-JP: サーバー負荷ピーク
-  pt-BR: Pico de Uso do Servidor
-  zh-CN: 服务器负载峰值
 sinDeg:
   description: Sine of the specified angle in degrees.
   args:
@@ -3050,11 +2106,6 @@ sinDeg:
     default: Number
   return: float
   en-US: Sine From Degrees
-  es-MX: Seno en grados
-  fr-FR: Sinus en degrés
-  ja-JP: 度のサイン
-  pt-BR: Seno de Graus
-  zh-CN: 角度的正弦值
 sin:
   description: Sine of the specified angle in radians.
   args:
@@ -3064,11 +2115,6 @@ sin:
     default: Number
   return: float
   en-US: Sine From Radians
-  es-MX: Seno en radianes
-  fr-FR: Sinus en radians
-  ja-JP: ラジアンのサイン
-  pt-BR: Seno de Radianos
-  zh-CN: 弧度的正弦值
 _&getSlot:
   description: The slot number of the specified player. In team games, each team has
     slots 0 through 5. In free-for-all games, slots are numbered 0 through 11.
@@ -3079,11 +2125,6 @@ _&getSlot:
     default: Event Player
   return: Integer
   en-US: Slot Of
-  es-MX: Posición de
-  fr-FR: Emplacement de
-  ja-JP: 'スロット: '
-  pt-BR: Espaço de
-  zh-CN: 位置
 __sortedArray__:
   description: A copy of the specified array with the values sorted according to the
     value rank that is evaluated for each element.
@@ -3102,11 +2143,6 @@ __sortedArray__:
   return:
     Array: Object
   en-US: Sorted Array
-  es-MX: Matriz ordenada
-  fr-FR: Tableau trié
-  ja-JP: ソートされた配列
-  pt-BR: Matriz Ordenada
-  zh-CN: 已排序的数组
 __mappedArray__:
   description: A copy of the specified array with the values mapped according to the Mapping Expression that is evaluated for each element.
   args:
@@ -3131,11 +2167,6 @@ _&getSpeed:
     default: Event Player
   return: Float
   en-US: Speed Of
-  es-MX: Velocidad de
-  fr-FR: Vitesse de
-  ja-JP: '速さ: '
-  pt-BR: Velocidade de
-  zh-CN: 速度
 _&getSpeedInDirection:
   description: The current speed of a player in a specific direction in meters per
     second.
@@ -3150,11 +2181,6 @@ _&getSpeedInDirection:
     default: Vector
   return: Float
   en-US: Speed Of In Direction
-  es-MX: Velocidad de/en dirección
-  fr-FR: Vitesse dans la direction donnée de
-  ja-JP: '速さと方向: '
-  pt-BR: Velocidade de na Direção
-  zh-CN: 指定方向速度
 sqrt:
   description: The square root of the specified value.
   args:
@@ -3165,11 +2191,6 @@ sqrt:
     default: Number
   return: Float
   en-US: Square Root
-  es-MX: Raíz cuadrada
-  fr-FR: Racine carrée
-  ja-JP: 平方根
-  pt-BR: Raiz Quadrada
-  zh-CN: 平方根
 __localizedString__:
   description: Text formed from a selection of strings and specified values.
   args:
@@ -3191,10 +2212,6 @@ __localizedString__:
     default: 'Null'
   return: String
   en-US: String
-  es-MX: Cadena
-  fr-FR: Chaîne de texte
-  ja-JP: 文字列
-  zh-CN: 字符串
 __subtract__:
   description: The difference between two numbers or vectors.
   args_allow_null: true
@@ -3217,11 +2234,6 @@ __subtract__:
   - float
   - Vector
   en-US: Subtract
-  es-MX: Restar
-  fr-FR: Soustraction
-  ja-JP: 減算
-  pt-BR: Subtrair
-  zh-CN: 减
 tanDeg:
   description: Tangent of the specified angle in degrees.
   args:
@@ -3231,11 +2243,6 @@ tanDeg:
     default: Number
   return: float
   en-US: Tangent From Degrees
-  es-MX: Tangente en grados
-  fr-FR: Tangente en degrés
-  ja-JP: 度のタンジェント
-  pt-BR: Tangente de Graus
-  zh-CN: 角度的正切值
 tan:
   description: Tangent of the specified angle in radians.
   args:
@@ -3245,11 +2252,6 @@ tan:
     default: Number
   return: float
   en-US: Tangent From Radians
-  es-MX: Tangente en radianes
-  fr-FR: Tangente en radians
-  ja-JP: ラジアンのタンジェント
-  pt-BR: Tangente de Radianos
-  zh-CN: 弧度的正切值
 _&getTeam:
   description: The team of a player. If the game mode is free-for-all, the team is
     considered to be all.
@@ -3260,11 +2262,6 @@ _&getTeam:
     default: Event Player
   return: Team
   en-US: Team Of
-  es-MX: Equipo de
-  fr-FR: Équipe de
-  ja-JP: 'チーム: '
-  pt-BR: Equipe de
-  zh-CN: 所在队伍
 teamScore:
   description: The current score for the specified team. Results in 0 in free-for-all
     game modes.
@@ -3275,11 +2272,6 @@ teamScore:
     default: Team
   return: Integer
   en-US: Team Score
-  es-MX: Puntuación del equipo
-  fr-FR: Score de l’équipe
-  ja-JP: チーム・スコア
-  pt-BR: Pontuação da Equipe
-  zh-CN: 团队得分
 _&getThrottle:
   description: The directional input of a player, represented by a vector with horizontal
     input on the x component (positive to the left) and vertical input on the z component
@@ -3291,30 +2283,17 @@ _&getThrottle:
     default: Event Player
   return: Direction
   en-US: Throttle Of
-  es-MX: Aceleración de
-  fr-FR: Accélération de
-  ja-JP: 'スロットル: '
-  pt-BR: Aceleração de
-  zh-CN: 阈值
 getTotalTimeElapsed:
   description: The total time in seconds that have elapsed since the game instance
     was created (including setup time and transitions).
   args: []
   return: Float
   en-US: Total Time Elapsed
-  es-MX: Tiempo total transcurrido
-  fr-FR: Temps total écoulé
-  ja-JP: 合計経過時間
-  pt-BR: Tempo Total Decorrido
-  zh-CN: 总计消耗时间
 'true':
   description: The boolean value of true.
   args:
   return: bool
   en-US: 'True'
-  es-MX: Verdadero
-  fr-FR: Vrai
-  zh-CN: 真
 _&getUltCharge:
   description: The current ultimate ability charge percentage of a player.
   args:
@@ -3324,11 +2303,6 @@ _&getUltCharge:
     default: Event Player
   return: Float
   en-US: Ultimate Charge Percent
-  es-MX: Porcentaje de carga de la habilidad máxima
-  fr-FR: Pourcentage de charge de la capacité ultime
-  ja-JP: アルティメット・チャージのパーセンテージ
-  pt-BR: Percentual de Carga da Suprema
-  zh-CN: 终极技能充能百分比
 Vector.UP:
   description: Shorthand for the directional vector(0, 1, 0), which points upward.
   args:
@@ -3338,11 +2312,6 @@ Vector.UP:
     - Integer
     - Integer
   en-US: Up
-  es-MX: Arriba
-  fr-FR: Haut
-  ja-JP: 上
-  pt-BR: Cima
-  zh-CN: 上
 __valueInArray__:
   description: The value found at a specific element of an array. Results in 0 if
     the element does not exist.
@@ -3359,11 +2328,6 @@ __valueInArray__:
   - Object
   - Array
   en-US: Value In Array
-  es-MX: Valor en la matriz
-  fr-FR: Valeur dans le tableau
-  ja-JP: 配列内の値
-  pt-BR: Valor na Matriz
-  zh-CN: 数组中的值
 vect:
   description: A vector composed of three real numbers (x, y, z) where x is left,
     y is up, and z is forward. Vectors are used for position, direction, and velocity.
@@ -3382,10 +2346,6 @@ vect:
     default: Number
   return: Vector
   en-US: Vector
-  fr-FR: Vecteur
-  ja-JP: ベクトル
-  pt-BR: Vetor
-  zh-CN: 矢量
 vectorTowards:
   description: The displacement vector from one position to another.
   args:
@@ -3399,11 +2359,6 @@ vectorTowards:
     default: Vector
   return: Direction
   en-US: Vector Towards
-  es-MX: Vector hacia
-  fr-FR: Vecteur vers
-  ja-JP: 'ベクトルの方向: '
-  pt-BR: Vetor Rumo a
-  zh-CN: 向量
 _&getVelocity:
   description: The current velocity of a player as a vector. If the player is on a
     surface, the y component of this velocity will be 0, even when traveling up or
@@ -3415,11 +2370,6 @@ _&getVelocity:
     default: Event Player
   return: Velocity
   en-US: Velocity Of
-  es-MX: Velocidad de
-  fr-FR: Vélocité de
-  ja-JP: '速度: '
-  pt-BR: Rapidez de
-  zh-CN: 速率
 verticalAngleOfDirection:
   description: The vertical angle in degrees corresponding to the specified direction
     vector.
@@ -3431,11 +2381,6 @@ verticalAngleOfDirection:
     default: Vector
   return: float
   en-US: Vertical Angle From Direction
-  es-MX: Ángulo vertical desde la dirección
-  fr-FR: Angle vertical depuis une direction
-  ja-JP: 方向からの頂角
-  pt-BR: Ângulo Vertical a partir da Direção
-  zh-CN: 与此方向的垂直角度
 verticalAngleTowards:
   description: The vertical angle in degrees from a player's current forward direction
     to the specified position. The result is positive if the position is below the
@@ -3451,11 +2396,6 @@ verticalAngleTowards:
     default: Vector
   return: float
   en-US: Vertical Angle Towards
-  es-MX: Ángulo vertical en dirección a
-  fr-FR: Angle vertical vers
-  ja-JP: '頂角の方向: '
-  pt-BR: Ângulo Vertical Rumo a
-  zh-CN: 垂直方向夹角
 _&getVerticalFacingAngle:
   description: The vertical angle in degrees of a player's current facing relative
     to the world. This value increases as the player looks down.
@@ -3466,11 +2406,6 @@ _&getVerticalFacingAngle:
     default: Event Player
   return: float
   en-US: Vertical Facing Angle Of
-  es-MX: Ángulo vertical de orientación de
-  fr-FR: Angle vertical du regard de
-  ja-JP: '対面頂角: '
-  pt-BR: Ângulo Vertical Frontal de
-  zh-CN: 垂直朝向角度
 _&getVerticalSpeed:
   description: The current vertical speed of a player in meters per second. This measurement
     excludes all horizontal motion, including motion while traveling up and down slopes.
@@ -3481,22 +2416,12 @@ _&getVerticalSpeed:
     default: Event Player
   return: Float
   en-US: Vertical Speed Of
-  es-MX: Velocidad vertical de
-  fr-FR: Vitesse verticale de
-  ja-JP: '垂直速度: '
-  pt-BR: Velocidade Vertical de
-  zh-CN: 垂直速度
 victim:
   description: The player that received the damage for the event currently being processed
     by this rule. May be the same as the attacker or the event player.
   args:
   return: Player
   en-US: Victim
-  es-MX: Víctima
-  fr-FR: Victime
-  ja-JP: 犠牲者
-  pt-BR: Vítima
-  zh-CN: 被攻击方
 worldVector:
   description: The vector in world coordinates corresponding to the provided vector
     in local coordinates.
@@ -3517,11 +2442,6 @@ worldVector:
     default: ROTATION
   return: Vector
   en-US: World Vector Of
-  es-MX: Vector global de
-  fr-FR: Vecteur mondial de
-  ja-JP: 'ワールド座標のベクトル: '
-  pt-BR: Vetor do Mundo de
-  zh-CN: 地图矢量
 __xComponentOf__:
   description: The x component of the specified vector, usually representing a leftward
     amount.
@@ -3532,11 +2452,6 @@ __xComponentOf__:
     default: Vector
   return: float
   en-US: X Component Of
-  es-MX: Componente X de
-  fr-FR: Composante X de
-  ja-JP: 'X成分: '
-  pt-BR: Componente X de
-  zh-CN: X方向分量
 __yComponentOf__:
   description: The y component of the specified vector, usually representing an upward
     amount.
@@ -3547,11 +2462,6 @@ __yComponentOf__:
     default: Vector
   return: float
   en-US: Y Component Of
-  es-MX: Componente Y de
-  fr-FR: Composante Y de
-  ja-JP: 'Y成分: '
-  pt-BR: Componente Y de
-  zh-CN: Y方向分量
 __zComponentOf__:
   description: The z component of the specified vector, usually representing a forward
     amount.
@@ -3562,11 +2472,6 @@ __zComponentOf__:
     default: Vector
   return: float
   en-US: Z Component Of
-  es-MX: Componente Z de
-  fr-FR: Composante Z de
-  ja-JP: 'Z成分: '
-  pt-BR: Componente Z de
-  zh-CN: Z方向分量
 _&getAbilityCharge:
   description: The ability charge count for a player associated by button.
   args:
@@ -3749,11 +2654,6 @@ workshopSettingReal:
   isConstant: true
   return: float
   en-US: Workshop Setting Real
-  es-MX: Configuración del Workshop real
-  fr-FR: Paramètre réel de la Forge
-  ja-JP: ワークショップの設定（実数）
-  pt-BR: Real de Configuração do Workshop
-  zh-CN: 地图工坊设置实数
 workshopSettingInteger:
   description: Provides the value of a new integer setting that will appear in the
     workshop settings card as a slider.
@@ -3785,11 +2685,6 @@ workshopSettingInteger:
   isConstant: true
   return: Integer
   en-US: Workshop Setting Integer
-  es-MX: Número entero de la configuración del Workshop
-  fr-FR: Paramètre entier de la Forge
-  ja-JP: ワークショップの設定（整数）
-  pt-BR: Inteiro de Configuração do Workshop
-  zh-CN: 地图工坊设置整数
 workshopSettingToggle:
   description: Provides the value (true or false) of a new toggle setting that will
     appear in the workshop settings card as a checkbox.
@@ -3812,11 +2707,6 @@ workshopSettingToggle:
     default: 0
   return: bool
   en-US: Workshop Setting Toggle
-  es-MX: Alternado de configuración del Workshop
-  fr-FR: Activerdésactiver le paramètre de la Forge
-  ja-JP: ワークショップの設定の切り替え
-  pt-BR: Alternar Configuração do Workshop
-  zh-CN: 地图工坊设置开关
 WorkshopSettingCombo:
   description: Provides the value (a choice of Custom Strings) of a new option setting that will appear in the Workshop Settings card as a combo box. This value returns the index of the selected choice.
   args:

--- a/config/arrays/wiki/values.yml
+++ b/config/arrays/wiki/values.yml
@@ -181,14 +181,14 @@ __and__:
   - name: Value
     description: One of the two inputs considered. If both are true (or equivalent
       to true), then the and value is true.
-    type: bool
+    type: Boolean
     default: 'True'
   - name: Value
     description: One of the two inputs considered. If both are true (or equivalent
       to true), then the and value is true.
-    type: bool
+    type: Boolean
     default: 'True'
-  return: bool
+  return: Boolean
   en-US: And
 angleBetweenVectors:
   description: The angle in degrees between two directional vectors (no normalization
@@ -328,7 +328,7 @@ __arrayContains__:
     description: The value for which to search.
     type: Object
     default: Number
-  return: bool
+  return: Boolean
   en-US: Array Contains
 __arraySlice__:
   description: A copy of the specified array containing only values from a specified
@@ -410,7 +410,7 @@ __compare__:
     - Object
     - Array
     default: Number
-  return: bool
+  return: Boolean
   en-US: Compare
 getControlScorePercentage:
   description: The score percentage for the specified team in control mode.
@@ -613,7 +613,7 @@ entityExists:
     - Player
     - EntityId
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Entity Exists
 eventAbility:
   description: The ability for the event currently being processed by this rule associated
@@ -649,13 +649,13 @@ eventWasCriticalHit:
   description: Whether the damage was a critical hit (such as a headshot) for the
     event currently being processed by this rule.
   args:
-  return: bool
+  return: Boolean
   en-US: Event Was Critical Hit
 eventWasHealthPack:
   description: Whether the healing was a health pack for the event currently being
     processed by this rule.
   args:
-  return: bool
+  return: Boolean
   en-US: Event Was Health Pack
 _&getEyePosition:
   description: The position of a player's first person view (used for aiming)
@@ -679,7 +679,7 @@ _&getFacingDirection:
 'false':
   description: The boolean value of false.
   args:
-  return: bool
+  return: Boolean
   en-US: 'False'
 getFarthestPlayer:
   description: The player farthest from a position, optionally restricted by team.
@@ -706,7 +706,7 @@ __filteredArray__:
     description: The condition that is evaluated for each element of the copied array.
       If the condition is true, the element is kept in the copied array. Use the current
       array element value to reference the element of the array currently being considered.
-    type: bool
+    type: Boolean
     default: Compare
   return: Array
   en-US: Filtered Array
@@ -765,7 +765,7 @@ _&hasSpawned:
       to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Has Spawned
 _&hasStatusEffect:
   description: Whether the specified player has the specified status, either from
@@ -779,7 +779,7 @@ _&hasStatusEffect:
     description: The status to check for.
     type: Status
     default: Hacked
-  return: bool
+  return: Boolean
   en-US: Has Status
 healee:
   description: The player that received the healing for the event currently being
@@ -928,7 +928,7 @@ __ifThenElse__:
   - name: If
     description: If this condition evaluates to true, the result of the value is then;
       otherwise, the result is else.
-    type: bool
+    type: Boolean
     default: 'True'
   - name: Then
     description: The result of the value when the if condition evaluates to true.
@@ -968,17 +968,17 @@ _&isAlive:
     description: The player whose life to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Alive
 isAssemblingHeroes:
   description: Whether the match is currently in its assemble heroes phase.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is Assembling Heroes
 isMatchBetweenRounds:
   description: Whether the match is between rounds.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is Between Rounds
 _&isHoldingButton:
   description: Whether a player is holding a specific button.
@@ -991,7 +991,7 @@ _&isHoldingButton:
     description: The button to check.
     type: ButtonLiteral
     default: Primary Fire
-  return: bool
+  return: Boolean
   en-US: Is Button Held
 _&isCommunicating:
   description: Whether a player is using a specific communication type (such as emoting,
@@ -1007,7 +1007,7 @@ _&isCommunicating:
       durations are assumed to be 2 seconds.
     type: Comms
     default: Voice Line Up
-  return: bool
+  return: Boolean
   en-US: Is Communicating
 _&isCommunicatingAnything:
   description: Whether a player is using any communication type (such as emoting,
@@ -1017,7 +1017,7 @@ _&isCommunicatingAnything:
     description: The player whose communication status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Communicating Any
 _&isCommunicatingEmote:
   description: Whether a player is using an emote.
@@ -1026,7 +1026,7 @@ _&isCommunicatingEmote:
     description: The player whose emoting status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Communicating Any Emote
 _&isCommunicatingVoiceline:
   description: Whether a player is using a voice line. (The duration of voice lines
@@ -1036,12 +1036,12 @@ _&isCommunicatingVoiceline:
     description: The player whose voice line status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Communicating Any Voice line
 isControlPointLocked:
   description: Whether the point is locked in control mode.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is Control Mode Point Locked
 _&isCrouching:
   description: Whether a player is crouching.
@@ -1050,7 +1050,7 @@ _&isCrouching:
     description: The player whose crouching status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Crouching
 _&isInAlternateForm:
   description: "Whether the specified player is currently in an alternate form:\n
@@ -1062,12 +1062,12 @@ _&isInAlternateForm:
     description: The player whose form to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is In Alternate Form
 isInSuddenDeath:
   description: Whether the current game of capture the flag is in sudden death.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is CTF Mode In Sudden Death
 _&isDead:
   description: Whether a player is dead.
@@ -1076,7 +1076,7 @@ _&isDead:
     description: The player whose death to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Dead
 _&isDummy:
   description: Whether a player is a dummy bot.
@@ -1085,7 +1085,7 @@ _&isDummy:
     description: Player to consider.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Dummy Bot
 _&isDuplicatingAHero:
   description: Whether the specified player is duplicating another hero. To check
@@ -1095,7 +1095,7 @@ _&isDuplicatingAHero:
     description: The player whose duplication status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Duplicating
 _&isFiringPrimaryFire:
   description: Whether the specified player's primary weapon attack is being used.
@@ -1104,7 +1104,7 @@ _&isFiringPrimaryFire:
     description: The player whose primary weapon attack usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Firing Primary
 _&isFiringSecondaryFire:
   description: Whether the specified player's secondary weapon attack is being used.
@@ -1113,7 +1113,7 @@ _&isFiringSecondaryFire:
     description: The player whose secondary weapon attack usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Firing Secondary
 isFlagAtBase:
   description: Whether a specific team's flag is at its base in capture the flag.
@@ -1122,7 +1122,7 @@ isFlagAtBase:
     description: The team whose flag to check.
     type: Team
     default: Team
-  return: bool
+  return: Boolean
   en-US: Is Flag At Base
 isFlagBeingCarried:
   description: Whether a specific team's flag is being carried by a member of the
@@ -1132,13 +1132,13 @@ isFlagBeingCarried:
     description: The team whose flag to check.
     type: Team
     default: Team
-  return: bool
+  return: Boolean
   en-US: Is Flag Being Carried
 isGameInProgress:
   description: Whether the main phase of the match is in progress (during which time
     combat and scoring are allowed).
   args: []
-  return: bool
+  return: Boolean
   en-US: Is Game In Progress
 teamHasHero:
   description: Whether a specific hero is being played (either on a team or in the
@@ -1152,7 +1152,7 @@ teamHasHero:
     description: The team or teams on which to check for the hero being played.
     type: Team
     default: Team
-  return: bool
+  return: Boolean
   en-US: Is Hero Being Played
 _&isInAir:
   description: Whether a player is airborne.
@@ -1161,7 +1161,7 @@ _&isInAir:
     description: The player whose airborne status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is In Air
 isInLoS:
   description: Whether two positions have line of sight with each other.
@@ -1186,12 +1186,12 @@ isInLoS:
       pos (if any) is used.
     type: BarrierLos
     default: Barriers DO NOT BLOCK LOS
-  return: bool
+  return: Boolean
   en-US: Is In Line of Sight
 isInSetup:
   description: Whether the match is currently in its setup phase.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is In Setup
 _&isInSpawnRoom:
   description: Whether a specific player is in the spawn room (and is thus being healed
@@ -1201,7 +1201,7 @@ _&isInSpawnRoom:
     description: The player whose spawn room status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is In Spawn Room
 _&isInViewAngle:
   description: Whether a location is within view of a player.
@@ -1218,7 +1218,7 @@ _&isInViewAngle:
     description: The view angle to compare against in degrees.
     type: float
     default: Number
-  return: bool
+  return: Boolean
   en-US: Is In View Angle
 _&isJumping:
   description: Whether the specified player is jumping.
@@ -1227,12 +1227,12 @@ _&isJumping:
     description: The player whose jump usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Jumping
 isMatchComplete:
   description: Whether the match has finished.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is Match Complete
 _&isMeleeing:
   description: Whether the specified player is meleeing.
@@ -1241,7 +1241,7 @@ _&isMeleeing:
     description: The player whose melee usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Meleeing
 _&isMoving:
   description: Whether a player is moving (defined as having a nonzero current speed).
@@ -1250,7 +1250,7 @@ _&isMoving:
     description: The player whose moving status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Moving
 isObjectiveComplete:
   description: Whether the specified objective has been completed. Results in false
@@ -1262,7 +1262,7 @@ isObjectiveComplete:
       own index.
     type: Integer
     default: Number
-  return: bool
+  return: Boolean
   en-US: Is Objective Complete
 _&isOnGround:
   description: Whether a player is on the ground (or other walkable surface).
@@ -1271,7 +1271,7 @@ _&isOnGround:
     description: The player whose ground status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is On Ground
 _&isOnObjective:
   description: Whether a specific player is currently occupying a payload or capture
@@ -1281,7 +1281,7 @@ _&isOnObjective:
     description: The player whose objective status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is On Objective
 _&isOnWall:
   description: Whether a player is on a wall (climbing or riding).
@@ -1290,7 +1290,7 @@ _&isOnWall:
     description: The player whose wall status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is On Wall
 _&isOnFire:
   description: Whether a specific player's portrait is on fire.
@@ -1299,7 +1299,7 @@ _&isOnFire:
     description: The player whose portrait to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Portrait On Fire
 _&isStanding:
   description: Whether a player is standing (defined as both not moving and not in
@@ -1309,7 +1309,7 @@ _&isStanding:
     description: The player whose standing status to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Standing
 isTeamOnDefense:
   description: Whether the specified team is currently on defense. Results in false
@@ -1319,7 +1319,7 @@ isTeamOnDefense:
     description: The team whose role to check.
     type: Team
     default: Team
-  return: bool
+  return: Boolean
   en-US: Is Team On Defense
 isTeamOnOffense:
   description: Whether the specified team is currently on offense. Results in false
@@ -1329,7 +1329,7 @@ isTeamOnOffense:
     description: The team whose role to check.
     type: Team
     default: Team
-  return: bool
+  return: Boolean
   en-US: Is Team On Offense
 __all__:
   description: Whether the specified condition evaluates to true for every value in
@@ -1343,9 +1343,9 @@ __all__:
     description: The condition that is evaluated for each element of the specified
       array. Use the current array element value to reference the element of the array
       currently being considered.
-    type: bool
+    type: Boolean
     default: Compare
-  return: bool
+  return: Boolean
   en-US: Is True For All
 __any__:
   description: Whether the specified condition evaluates to true for any value in
@@ -1359,9 +1359,9 @@ __any__:
     description: The condition that is evaluated for each element of the specified
       array. Use the current array element value to reference the element of the array
       currently being considered.
-    type: bool
+    type: Boolean
     default: Compare
-  return: bool
+  return: Boolean
   en-US: Is True For Any
 _&isUsingAbility1:
   description: Whether the specified player is using ability 1.
@@ -1370,7 +1370,7 @@ _&isUsingAbility1:
     description: The player whose ability 1 usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Using Ability 1
 _&isUsingAbility2:
   description: Whether the specified player is using ability 2.
@@ -1379,7 +1379,7 @@ _&isUsingAbility2:
     description: The player whose ability 2 usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Using Ability 2
 _&isUsingUltimate:
   description: Whether a player is using an ultimate ability.
@@ -1388,12 +1388,12 @@ _&isUsingUltimate:
     description: The player whose ultimate ability usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Using Ultimate
 isWaitingForPlayers:
   description: Whether the match is waiting for players to join before starting.
   args: []
-  return: bool
+  return: Boolean
   en-US: Is Waiting For Players
 getLastCreatedEntity:
   description: A reference to the last effect or icon entity created by the event
@@ -1593,9 +1593,9 @@ __not__:
   - name: Value
     description: When this input is false (or equivalent to false), then the not value
       is true. Otherwise, the not value is false.
-    type: bool
+    type: Boolean
     default: 'True'
-  return: bool
+  return: Boolean
   en-US: Not
 'null':
   description: The absence of a player. Used when no player is desired for a particular
@@ -1717,14 +1717,14 @@ __or__:
   - name: Value
     description: One of the two inputs considered. If either one is true (or equivalent
       to true), then the or value is true.
-    type: bool
+    type: Boolean
     default: 'True'
   - name: Value
     description: One of the two inputs considered. If either one is true (or equivalent
       to true), then the or value is true.
-    type: bool
+    type: Boolean
     default: 'True'
-  return: bool
+  return: Boolean
   en-US: Or
 getPayloadPosition:
   description: The position in the world of the active payload.
@@ -1957,7 +1957,7 @@ __raycastHitNormal__:
   - name: Include Player Owned Objects
     description: Whether player-owned objects (such as barriers or turrets) should
       be included in the ray cast.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Direction
   en-US: Ray Cast Hit Normal
@@ -1988,7 +1988,7 @@ __raycastHitPlayer__:
   - name: Include Player Owned Objects
     description: Whether player-owned objects (such as barriers or turrets) should
       be included in the ray cast.
-    type: bool
+    type: Boolean
     default: 'True'
   return: Player
   en-US: Ray Cast Hit Player
@@ -2292,7 +2292,7 @@ getTotalTimeElapsed:
 'true':
   description: The boolean value of true.
   args:
-  return: bool
+  return: Boolean
   en-US: 'True'
 _&getUltCharge:
   description: The current ultimate ability charge percentage of a player.
@@ -2515,7 +2515,7 @@ eventWasEnvironment:
   description: Whether the elimination was due to the environment for the event currently
     being processed by this rule.
   args:
-  return: bool
+  return: Boolean
   en-US: Event Was Environment
 _&getHealthOfType:
   description: The current health of the specified player, filtered by the given health
@@ -2548,7 +2548,7 @@ _&isReloading:
     description: The player whose reload usage to check.
     type: Player
     default: Event Player
-  return: bool
+  return: Boolean
   en-US: Is Reloading
 getLastCreatedHealthPool:
   description: An ID representing the most recent Add Health Pool action that was
@@ -2705,7 +2705,7 @@ workshopSettingToggle:
     description: The sort order of the setting relative to other settings in the same category. Settings with a higher sort order will come after settings with a lower sort order.
     type: IntLiteral
     default: 0
-  return: bool
+  return: Boolean
   en-US: Workshop Setting Toggle
 WorkshopSettingCombo:
   description: Provides the value (a choice of Custom Strings) of a new option setting that will appear in the Workshop Settings card as a combo box. This value returns the index of the selected choice.

--- a/lib/tasks/generate_wiki_articles.rake
+++ b/lib/tasks/generate_wiki_articles.rake
@@ -34,7 +34,7 @@ task :generate_wiki_articles => :environment do
       #{ content["description"] }
       #{ content_args if content_args }",
       category_id: @category.id,
-      tags: "#{ content["en-US"] }#{ ", " + content["es-MX"] if content["es-MX"] }#{ ", " + content["fr-FR"] if content["fr-FR"] }#{ ", " + content["ja-JP"] if content["ja-JP"] }#{ ", " + content["pt-BR"] if content["pt-BR"] }#{ ", " + content["zh-CN"] if content["zh-CN"] }"
+      tags: "#{ content["en-US"] }"
     )
 
     @edit = Wiki::Edit.create(
@@ -59,7 +59,7 @@ task :generate_wiki_articles => :environment do
       slug: CGI.escape(content["en-US"]).downcase,
       group_id: SecureRandom.urlsafe_base64,
       category_id: @category.id,
-      tags: "#{ content["en-US"] }#{ ", " + content["es-MX"] if content["es-MX"] }#{ ", " + content["fr-FR"] if content["fr-FR"] }#{ ", " + content["ja-JP"] if content["ja-JP"] }#{ ", " + content["pt-BR"] if content["pt-BR"] }#{ ", " + content["zh-CN"] if content["zh-CN"] }"
+      tags: "#{ content["en-US"] }"
     )
 
     @edit = Wiki::Edit.create(
@@ -103,7 +103,7 @@ task :generate_wiki_articles => :environment do
       #{ content_return if content_return }
       #{ content_args if content_args }",
       category_id: @category.id,
-      tags: "#{ content["en-US"] }#{ ", " + content["es-MX"] if content["es-MX"] }#{ ", " + content["fr-FR"] if content["fr-FR"] }#{ ", " + content["ja-JP"] if content["ja-JP"] }#{ ", " + content["pt-BR"] if content["pt-BR"] }#{ ", " + content["zh-CN"] if content["zh-CN"] }"
+      tags: "#{ content["en-US"] }"
     )
 
     @edit = Wiki::Edit.create(


### PR DESCRIPTION
This PR cleans up the actions/values/events/constants yaml files.

This includes:
- Replace all capital case with title case (eg. HEALTH -> Health)
- Replace all "(un)signed float/int(eger)" with "Float/Integer". Signed is not a thing in the workshop, and it makes no sense for us to list it. It also clears up incosistencies with some being called "int" and others "integer"
- Replace all "bool" with "Boolean"
- Remove all "guid" declarations, they are unused and will remain so
- Remove all languages other than en-US. We aren't maintaining these, so let's keep the data consistent.

This is all preparation for spicing up the arguments section of wiki articles.