### PR TITLE
feat(editor): Parameter Objects

### DIFF
--- a/app/assets/stylesheets/elements/_codemirror.scss
+++ b/app/assets/stylesheets/elements/_codemirror.scss
@@ -174,6 +174,11 @@
     background: transparent;
   }
 
+  .cm-lintRange-warning {
+    box-shadow: 0 3px 0 $orange;
+    background: transparent;
+  }
+
   .cm-lint-marker-error::before {
     content: "!";
     display: block;

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -78,10 +78,11 @@
 
       if (v.args?.length) {
         // Add detail arguments in autocomplete results
-        const detail = v.args.map(a => `${ toCapitalize(a.name) }`).join(", ")
+        const detail = v.args.map(a => `${ toCapitalize(a.name) }`)
+        const joinedDetail = detail.join(", ")
 
-        params.detail_full = detail
-        params.detail = `(${ detail.slice(0, 30) }${ detail.length > 30 ? "..." : "" })`
+        params.detail_full = joinedDetail
+        params.detail = `(${ joinedDetail.slice(0, 30) }${ joinedDetail.length > 30 ? "..." : "" })`
 
         // Add apply values when selecting autocomplete, filling in default args
         const lowercaseDefaults = Object.keys(defaults).map(k => k.toLowerCase())
@@ -93,6 +94,7 @@
           return toCapitalize(string)
         })
 
+        params.parameter_keys = detail
         params.parameter_defaults = apply
         params.apply = `${ v["en-US"] }(${ apply.join(", ") })`
 

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -174,7 +174,7 @@
   </div>
 
   {#if $recoveredProject}
-    <ProjectRecovery />y
+    <ProjectRecovery />
   {/if}
 </div>
 

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -93,7 +93,7 @@
           return toCapitalize(string)
         })
 
-        params.parameterDefaults = apply
+        params.parameter_defaults = apply
         params.apply = `${ v["en-US"] }(${ apply.join(", ") })`
 
         // Add arguments to info box
@@ -174,7 +174,7 @@
   </div>
 
   {#if $recoveredProject}
-    <ProjectRecovery />
+    <ProjectRecovery />y
   {/if}
 </div>
 

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -93,6 +93,7 @@
           return toCapitalize(string)
         })
 
+        params.parameterDefaults = apply
         params.apply = `${ v["en-US"] }(${ apply.join(", ") })`
 
         // Add arguments to info box

--- a/app/javascript/src/lib/OWLanguageLegacy.js
+++ b/app/javascript/src/lib/OWLanguageLegacy.js
@@ -33,7 +33,7 @@ const octal = /^\-?0o[0-7][0-7_]*/
 const hexadecimal = /^\-?0x[\dA-Fa-f][\dA-Fa-f_]*(?:(?:\.[\dA-Fa-f][\dA-Fa-f_]*)?[Pp]\-?\d[\d_]*)?/
 const decimal = /^\-?\d[\d_]*(?:\.\d[\d_]*)?(?:[Ee]\-?\d[\d_]*)?/
 const identifier = /^\$\d+|(`?)[_A-Za-z][_A-Za-z$0-9]*\1/
-const actionsValuesIdentifier = /^\s*(?=[A-Z])\b[A-Z][\w\s-]*/g
+const actionsValuesIdentifier = /^\s*(?=[A-Z])\b[A-Z][\w\s-]*(?!:)/g
 const phraseIdentifier = /^\s*(?=[A-Z]).+?(?= [+\-*%=|&<>~^?!]|[\(\)\{\}:;,./\n\[\]]|\s==)/
 const customKeywords = /(?<!\w)@(?:else if|\w+)/
 

--- a/app/javascript/src/utils/compiler/compile.js
+++ b/app/javascript/src/utils/compiler/compile.js
@@ -5,6 +5,7 @@ import { removeComments } from "./comments"
 import { evaluateConditionals } from "./conditionals"
 import { evaluateEachLoops } from "./each"
 import { evaluateForLoops } from "./for"
+import { evaluateParameterObjects } from "./parameterObjects"
 import { extractAndInsertMixins } from "./mixins"
 import { compileSubroutines } from "./subroutines"
 import { convertTranslations } from "./translations"
@@ -23,6 +24,7 @@ export function compile(overwriteContent = null) {
 
   joinedItems = joinedItems.replace(settings, "")
   joinedItems = extractAndInsertMixins(joinedItems)
+  joinedItems = evaluateParameterObjects(joinedItems)
   joinedItems = evaluateForLoops(joinedItems)
   joinedItems = evaluateEachLoops(joinedItems)
   joinedItems = evaluateConditionals(joinedItems)

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -53,7 +53,7 @@ export function getFirstParameterObject(content) {
 
   return {
     ...result,
-    phraseParameters: completion.detail_full.split(", "),
+    phraseParameters: completion.parameter_keys,
     phraseDefaults: completion.parameter_defaults
   }
 }

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -20,7 +20,7 @@ export function evaluateParameterObjects(joinedItems) {
 }
 
 export function getFirstParameterObject(content) {
-  const regex = /[a-z]\(\s*{/
+  const regex = /[a-z]\s*\(\s*{/
   const match = content.match(regex)
 
   if (!match) return null
@@ -52,7 +52,7 @@ export function getFirstParameterObject(content) {
   return {
     ...result,
     phraseParameters: completion.detail_full.split(", "),
-    phraseDefaults: completion.parameterDefaults
+    phraseDefaults: completion.parameter_defaults
   }
 }
 

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -5,12 +5,18 @@ import { get } from "svelte/store"
 export function evaluateParameterObjects(joinedItems) {
   let moreAvailableObjects = true
   let safety = 0
+  let startFromIndex = 0
 
   while (moreAvailableObjects) {
-    const parameterObject = getFirstParameterObject(joinedItems)
+    const parameterObject = getFirstParameterObject(joinedItems, startFromIndex)
 
-    if (!parameterObject || safety > 10_000) {
+    if (!parameterObject || safety > 1000) {
       moreAvailableObjects = false
+      continue
+    }
+
+    if (!parameterObject.phraseParameters.length) {
+      startFromIndex = parameterObject.start
       continue
     }
 
@@ -21,7 +27,9 @@ export function evaluateParameterObjects(joinedItems) {
   return joinedItems
 }
 
-export function getFirstParameterObject(content) {
+export function getFirstParameterObject(content, startFromIndex = 0) {
+  content = content.slice(startFromIndex)
+
   const regex = /[a-z]\s*\(\s*{/
   const match = content.match(regex)
 
@@ -42,7 +50,7 @@ export function getFirstParameterObject(content) {
     given[key.trim()] = (value || "").trim()
   })
 
-  const result = { start, end, given }
+  const result = { start: start + startFromIndex, end: end + startFromIndex, given }
 
   // Return a false object to replace contents of unfound phrase
   if (!completion) return {

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -27,6 +27,12 @@ export function evaluateParameterObjects(joinedItems) {
   return joinedItems
 }
 
+/**
+ * Find the first matching parameter object in a given string. Parameter objects are a special format that allow the user to give only specific sets of parameters rather than having to write them all out.
+ * @param {string} content Content to search for parameter objects in.
+ * @param {*} startFromIndex Skip over previous results. This is used when the regex format was found without matches phrases to skip over previous results.
+ * @returns {object|null} Object containing details about the parameter object and matching phrase.
+ */
 export function getFirstParameterObject(content, startFromIndex = 0) {
   content = content.slice(startFromIndex)
 
@@ -66,6 +72,12 @@ export function getFirstParameterObject(content, startFromIndex = 0) {
   }
 }
 
+/**
+ * Replaces and returns a parameter object in the given string.
+ * @param {string} content String the parameter object will be replaced in.
+ * @param {object} parameterObject Object containing all data needed to replace the expected string. This object contains a start index, end index, given parameters, parameter keys, and parameter defaults.
+ * @returns {string} String with parameter object replaced with Workshop code.
+ */
 export function replaceParameterObject(content, parameterObject) {
   const { start, end, given, phraseParameters, phraseDefaults } = parameterObject
 

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -27,8 +27,10 @@ export function getFirstParameterObject(content) {
 
   const phrase = getPhraseFromIndex(content, match.index)
   const completion = get(completionsMap).find(item => item.args_length && item.label === phrase)
+  let end = getClosingBracket(content, "{", "}", match.index)
 
-  const end = getClosingBracket(content, "{", "}", match.index)
+  if (end === -1) end = match.index + match.length
+
   const string = content.slice(match.index + match[0].length, end).trim()
   const splitParameters = splitArgumentsString(string)
   const given = {}

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -25,12 +25,12 @@ export function getFirstParameterObject(content) {
 
   if (!match) return null
 
-  const phrase = getPhraseFromIndex(content, match.index)
-  const completion = get(completionsMap).find(item => item.args_length && item.label === phrase)
   let end = getClosingBracket(content, "{", "}", match.index)
-
   if (end === -1) end = match.index + match.length
 
+  const start = match.index + match[0].indexOf("{")
+  const phrase = getPhraseFromIndex(content, match.index)
+  const completion = get(completionsMap).find(item => item.args_length && item.label === phrase)
   const string = content.slice(match.index + match[0].length, end).trim()
   const splitParameters = splitArgumentsString(string)
   const given = {}
@@ -40,11 +40,7 @@ export function getFirstParameterObject(content) {
     given[key.trim()] = (value || "").trim()
   })
 
-  const result = {
-    start: match.index + match[0].indexOf("{"),
-    end,
-    given
-  }
+  const result = { start, end, given }
 
   // Return a false object to replace contents of unfound phrase
   if (!completion) return {

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -1,0 +1,71 @@
+import { completionsMap } from "../../stores/editor"
+import { getClosingBracket, getPhraseFromIndex, splitArgumentsString } from "../parse"
+import { get } from "svelte/store"
+
+export function evaluateParameterObjects(joinedItems) {
+  let moreAvailableObjects = true
+
+  while (moreAvailableObjects) {
+    const parameterObject = getFirstParameterObject(joinedItems)
+
+    if (!parameterObject) {
+      moreAvailableObjects = false
+      continue
+    }
+
+    joinedItems = replaceParameterObject(joinedItems, parameterObject)
+  }
+
+  return joinedItems
+}
+
+export function getFirstParameterObject(content) {
+  const regex = /\(\s*{/
+  const match = content.match(regex)
+
+  if (!match) return null
+
+  const phrase = getPhraseFromIndex(content, match.index - 1)
+  const completion = get(completionsMap).find(item => item.args_length && item.label === phrase)
+
+  if (!completion) return null
+
+  const end = getClosingBracket(content, "{", "}", match.index)
+  const string = content.slice(match.index + match[0].length, end).trim()
+  const splitParameters = splitArgumentsString(string)
+  const given = {}
+
+  splitParameters.forEach(item => {
+    const [key, value] = item.split(/:(.+)/)
+    given[key.trim()] = value.trim()
+  })
+
+  return {
+    start: match.index + 1,
+    end,
+    given,
+    phraseParameters: completion.detail_full.split(", "),
+    phraseDefaults: completion.parameterDefaults
+  }
+}
+
+function replaceParameterObject(content, parameterObject) {
+  let offset = 0
+
+  const { start, end, given, phraseParameters, phraseDefaults } = parameterObject
+
+  const parameters = phraseDefaults.map((parameterDefault, i) => given[phraseParameters[i]] || parameterDefault)
+
+  const effectiveStart = start + offset
+  const effectiveEnd = end + offset
+
+  const prefix = content.slice(0, effectiveStart)
+  const suffix = content.slice(effectiveEnd + 1)
+
+  const string = parameters.join(", ")
+
+  content = prefix + string + suffix
+  offset += string.length - (effectiveEnd - effectiveStart + 1)
+
+  return content
+}

--- a/app/javascript/src/utils/parse.js
+++ b/app/javascript/src/utils/parse.js
@@ -84,6 +84,13 @@ export function getPhraseFromPosition(line, position) {
   }
 }
 
+export function getPhraseFromIndex(text, index) {
+  const start = getPhraseEnd(text, index, -1)
+  const end = getPhraseEnd(text, index, 1)
+
+  return text.slice(start, end + 1).trim()
+}
+
 export function removeSurroundingParenthesis(source) {
   const openMatch = /^[\s\n]*\(/.exec(source)
   const closeMatch = /\)[\s\n]*$/.exec(source)

--- a/spec/javascript/utils/compiler/parameterObjects.test.js
+++ b/spec/javascript/utils/compiler/parameterObjects.test.js
@@ -1,4 +1,4 @@
-import { getFirstParameterObject } from "../../../../app/javascript/src/utils/compiler/parameterObjects"
+import { getFirstParameterObject, replaceParameterObject, evaluateParameterObjects } from "../../../../app/javascript/src/utils/compiler/parameterObjects"
 import { completionsMap } from "../../../../app/javascript/src/stores/editor"
 import { disregardWhitespace } from "../../helpers/text"
 
@@ -8,11 +8,12 @@ describe("parameterObjects.js", () => {
       label: "Some Action",
       args_length: 3,
       detail_full: "One, Two, Three",
-      parameter_defaults: [
-        0,
-        0,
-        0
-      ]
+      parameter_defaults: [0, 0, 0]
+    }, {
+      label: "Some Second Action",
+      args_length: 4,
+      detail_full: "First, Second, Third, Fourth",
+      parameter_defaults: ["A", "B", "C", "D"]
     }])
   })
 
@@ -21,43 +22,129 @@ describe("parameterObjects.js", () => {
       const content = "Some Action(Some Value)"
       expect(getFirstParameterObject(content)).toBeNull()
     })
+
+    test("Should return correct parameter object with defaults for a valid content", () => {
+      const content = "Some Action({ One: 10, Three: 20 })"
+      const expected = {
+        start: 12,
+        end: 33,
+        given: { One: "10", Three: "20" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
+
+      expect(getFirstParameterObject(content)).toEqual(expected)
+    })
+
+    test("Should return empty values when phrase is not found", () => {
+      const content = "Some Other Action({ One: 10, Three: 20 })"
+      const expected = {
+        start: 18,
+        end: 39,
+        given: { One: "10", Three: "20" },
+        phraseParameters: [],
+        phraseDefaults: []
+      }
+
+      expect(getFirstParameterObject(content)).toEqual(expected)
+    })
+
+    test("Should handle white space as expected", () => {
+      const expected = {
+        given: { One: "10", Three: "20" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
+
+      expect(getFirstParameterObject("Some Action   ({ One: 10, Three: 20 })")).toEqual({ ...expected, start: 15, end: 36 })
+      expect(getFirstParameterObject("Some Action(   { One: 10, Three: 20 }   )")).toEqual({ ...expected, start: 15, end: 36 })
+      expect(getFirstParameterObject("Some Action({ One: 10,    Three: 20 })")).toEqual({ ...expected, start: 12, end: 36 })
+      expect(getFirstParameterObject(`Some Action(
+        {
+          One: 10, Three: 20
+        }
+      )`)).toEqual({ ...expected, start: 21, end: 60 })
+    })
   })
 
-  test("Should return correct parameter object with defaults for a valid content", () => {
-    const content = "Some Action({ One: 10, Three: 20 })"
-    const expected = {
-      start: 12,
-      end: 33,
-      given: { One: "10", Three: "20" },
-      phraseParameters: ["One", "Two", "Three"],
-      phraseDefaults: [0, 0, 0]
-    }
+  describe("replaceParameterObject", () => {
+    test("Should replace parameter object with given and default values", () => {
+      const content = "Some Action({ One: 10, Three: 20 })"
+      const parameterObject = {
+        start: 12,
+        end: 33,
+        given: { One: "10", Three: "20" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
 
-    expect(getFirstParameterObject(content)).toEqual(expected)
+      expect(replaceParameterObject(content, parameterObject)).toBe("Some Action(10, 0, 20)")
+    })
+
+    test("Should use phraseDefaults if given values are not found", () => {
+      const content = "Some Action({ Four: 10, Five: 20 })"
+      const parameterObject = {
+        start: 12,
+        end: 33,
+        given: { Four: "10", Five: "20" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
+
+      expect(replaceParameterObject(content, parameterObject)).toBe("Some Action(0, 0, 0)")
+    })
+
+    test("Should return input if end is larger than content length", () => {
+      const content = "Short"
+      const parameterObject = {
+        start: 1,
+        end: 50,
+        given: { One: "10", Three: "20" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
+
+      expect(replaceParameterObject(content, parameterObject)).toBe("Short")
+    })
   })
 
-  test("Should return empty values when phrase is not found", () => {
-    const content = "Some Other Action({ One: 10, Three: 20 })"
-    const expected = {
-      start: 18,
-      end: 39,
-      given: { One: "10", Three: "20" },
-      phraseParameters: [],
-      phraseDefaults: []
-    }
+  describe("evaluateParameterObjects", () => {
+    test("Should replace multiple parameter objects", () => {
+      const input = `
+        Some Action({ Two: 20 })
+        Some Second Action({ First: Some Value, Fourth: Some Other Value })
+        Some Other Action({ A: "1", B: "2", C: "3" })
+      `
+      const expected = `
+        Some Action(0, 20, 0)
+        Some Second Action(Some Value, B, C, Some Other Value)
+        Some Other Action()
+      `
 
-    expect(getFirstParameterObject(content)).toEqual(expected)
-  })
+      expect(evaluateParameterObjects(input)).toBe(expected)
+    })
 
-  test("Should handle white space as expected", () => {
-    const expected = {
-      given: { One: "10", Three: "20" },
-      phraseParameters: ["One", "Two", "Three"],
-      phraseDefaults: [0, 0, 0]
-    }
+    test("Should handle nested parameter objects", () => {
+      const input = "Some Action({ Two: Some Second Action({ First: Some Value, Fourth: Some Action({ One: 5 }) }) })"
+      const expected = "Some Action(0, Some Second Action(Some Value, B, C, Some Action(5, 0, 0)), 0)"
 
-    expect(getFirstParameterObject("Some Action   ({ One: 10, Three: 20 })")).toEqual({ ...expected, start: 15, end: 36 })
-    expect(getFirstParameterObject("Some Action(   { One: 10, Three: 20 }   )")).toEqual({ ...expected, start: 15, end: 36 })
-    expect(getFirstParameterObject("Some Action({ One: 10,    Three: 20 })")).toEqual({ ...expected, start: 12, end: 36 })
+      expect(evaluateParameterObjects(input)).toBe(expected)
+    })
+
+    test("Should handle nested parameter objects on multiple lines", () => {
+      const input = `
+        Some Action({
+          One: Some Second Action({ First: Some Value }),
+          Two: Some Second Action({
+            Second: Some Second Value
+          })
+        })
+      `
+      const expected = `
+        Some Action(Some Second Action(Some Value, B, C, D), Some Second Action(A, Some Second Value, C, D), 0)
+      `
+
+      expect(evaluateParameterObjects(input)).toBe(expected)
+    })
   })
 })

--- a/spec/javascript/utils/compiler/parameterObjects.test.js
+++ b/spec/javascript/utils/compiler/parameterObjects.test.js
@@ -1,0 +1,63 @@
+import { getFirstParameterObject } from "../../../../app/javascript/src/utils/compiler/parameterObjects"
+import { completionsMap } from "../../../../app/javascript/src/stores/editor"
+import { disregardWhitespace } from "../../helpers/text"
+
+describe("parameterObjects.js", () => {
+  beforeEach(() => {
+    completionsMap.set([{
+      label: "Some Action",
+      args_length: 3,
+      detail_full: "One, Two, Three",
+      parameter_defaults: [
+        0,
+        0,
+        0
+      ]
+    }])
+  })
+
+  describe("getFirstParameterObject", () => {
+    test("Should return null for content without a parameter object", () => {
+      const content = "Some Action(Some Value)"
+      expect(getFirstParameterObject(content)).toBeNull()
+    })
+  })
+
+  test("Should return correct parameter object with defaults for a valid content", () => {
+    const content = "Some Action({ One: 10, Three: 20 })"
+    const expected = {
+      start: 12,
+      end: 33,
+      given: { One: "10", Three: "20" },
+      phraseParameters: ["One", "Two", "Three"],
+      phraseDefaults: [0, 0, 0]
+    }
+
+    expect(getFirstParameterObject(content)).toEqual(expected)
+  })
+
+  test("Should return empty values when phrase is not found", () => {
+    const content = "Some Other Action({ One: 10, Three: 20 })"
+    const expected = {
+      start: 18,
+      end: 39,
+      given: { One: "10", Three: "20" },
+      phraseParameters: [],
+      phraseDefaults: []
+    }
+
+    expect(getFirstParameterObject(content)).toEqual(expected)
+  })
+
+  test("Should handle white space as expected", () => {
+    const expected = {
+      given: { One: "10", Three: "20" },
+      phraseParameters: ["One", "Two", "Three"],
+      phraseDefaults: [0, 0, 0]
+    }
+
+    expect(getFirstParameterObject("Some Action   ({ One: 10, Three: 20 })")).toEqual({ ...expected, start: 15, end: 36 })
+    expect(getFirstParameterObject("Some Action(   { One: 10, Three: 20 }   )")).toEqual({ ...expected, start: 15, end: 36 })
+    expect(getFirstParameterObject("Some Action({ One: 10,    Three: 20 })")).toEqual({ ...expected, start: 12, end: 36 })
+  })
+})

--- a/spec/javascript/utils/compiler/parameterObjects.test.js
+++ b/spec/javascript/utils/compiler/parameterObjects.test.js
@@ -66,6 +66,19 @@ describe("parameterObjects.js", () => {
         }
       )`)).toEqual({ ...expected, start: 21, end: 60 })
     })
+
+    test("Should skip results when startFromIndex is given", () => {
+      const content = "Some Action({ One: 10, Three: 20 }); Some Action({ Two: 2 })"
+      const expected = {
+        start: 49,
+        end: 58,
+        given: { Two: "2" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
+
+      expect(getFirstParameterObject(content, 20)).toEqual(expected)
+    })
   })
 
   describe("replaceParameterObject", () => {
@@ -114,12 +127,12 @@ describe("parameterObjects.js", () => {
       const input = `
         Some Action({ Two: 20 })
         Some Second Action({ First: Some Value, Fourth: Some Other Value })
-        Some Other Action({ A: "1", B: "2", C: "3" })
+        Some Action({ Three: 20 })
       `
       const expected = `
         Some Action(0, 20, 0)
         Some Second Action(Some Value, B, C, Some Other Value)
-        Some Other Action()
+        Some Action(0, 0, 20)
       `
 
       expect(evaluateParameterObjects(input)).toBe(expected)
@@ -143,6 +156,21 @@ describe("parameterObjects.js", () => {
       `
       const expected = `
         Some Action(Some Second Action(Some Value, B, C, D), Some Second Action(A, Some Second Value, C, D), 0)
+      `
+
+      expect(evaluateParameterObjects(input)).toBe(expected)
+    })
+
+    test("Should leave non existing phrases intact", () => {
+      const input = `
+        Some Action({ One: ABC, Two: DEF })
+        Some False Action({ Test: Value })
+        Some Action({ One: 1, Two: 2 })
+      `
+      const expected = `
+        Some Action(ABC, DEF, 0)
+        Some False Action({ Test: Value })
+        Some Action(1, 2, 0)
       `
 
       expect(evaluateParameterObjects(input)).toBe(expected)

--- a/spec/javascript/utils/compiler/parameterObjects.test.js
+++ b/spec/javascript/utils/compiler/parameterObjects.test.js
@@ -7,12 +7,12 @@ describe("parameterObjects.js", () => {
     completionsMap.set([{
       label: "Some Action",
       args_length: 3,
-      detail_full: "One, Two, Three",
+      parameter_keys: ["One", "Two", "Three"],
       parameter_defaults: [0, 0, 0]
     }, {
       label: "Some Second Action",
       args_length: 4,
-      detail_full: "First, Second, Third, Fourth",
+      parameter_keys: ["First", "Second", "Third", "Fourth"],
       parameter_defaults: ["A", "B", "C", "D"]
     }])
   })
@@ -59,6 +59,7 @@ describe("parameterObjects.js", () => {
       expect(getFirstParameterObject("Some Action   ({ One: 10, Three: 20 })")).toEqual({ ...expected, start: 15, end: 36 })
       expect(getFirstParameterObject("Some Action(   { One: 10, Three: 20 }   )")).toEqual({ ...expected, start: 15, end: 36 })
       expect(getFirstParameterObject("Some Action({ One: 10,    Three: 20 })")).toEqual({ ...expected, start: 12, end: 36 })
+      expect(getFirstParameterObject("Some Action({ One    :10,    Three :     20 })")).toEqual({ ...expected, start: 12, end: 44 })
       expect(getFirstParameterObject(`Some Action(
         {
           One: 10, Three: 20


### PR DESCRIPTION
When working with actions or values with many parameters it can be quite a hassle. Either you only end up changing one or two of the values, or you end up with many values that make it difficult to see what is what. To address this this PR adds parameter objects. In terms of javascript you can look at it like a function `someFunction(someValue, someOtherValue)` vs `someFunction({ param1: someValue, param2: someOtherValue })`. The syntax I implemented here is very similar to that.

For example in this action all I'm doing is changing the position:
```js
Create In-World Text(All Players(All Teams), Custom String("Some string"), Vector(9, 9, 9), 1, Clip Against Surfaces, Visible To Position And String, Color(white), Default Visibility);
```
With parameter objects we can write it like this instead:
```js
Create In-World Text({ Position: Vector(9, 9, 9) });
```
And you could add more like so:
```js
Create In-World Text({ Position: Vector(9, 9, 9), text: Custom String("Some custom string") });
```
It can also help make your code much more readable, even when using all values:
```js
Create In-World Text({
  Players: All Players(All Teams),
  Text: Custom String("Some string"),
  Position: Vector(9, 9, 9),
  Scale: 1,
  Clipping: Clip Against Surfaces,
  Reevaluation: Visible To Position And String,
  Text Color: Color(white),
  Spectators: Default Visibility
});
```
Objects can be nested:
```js
Create In-World Text({ Position: Vector({ Y: 10 }) });
```

I've also added editor warnings, warning you about incorrectly used keys.

![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/9b566d45-24ab-41ed-aa4d-9f0eba18dcf8)

This is all optional of course. In the future I want to add a toggle to make it so autocomplete automatically inserts these objects rather than their default values, but let's see what the response and demand is first.
