### PR TITLE
Only apply ordered list counter style tolist items immediately after an unordered list

### DIFF
--- a/app/assets/stylesheets/elements/_items.scss
+++ b/app/assets/stylesheets/elements/_items.scss
@@ -500,7 +500,7 @@
     list-style: none;
     padding-left: 2.5rem;
 
-    li {
+    > li {
       counter-increment: ordered-list;
       position: relative;
 


### PR DESCRIPTION
One-liner.

Given
```
1. ul li 1
  * ul li 1, ol li 1
  * ul li 2, ol li 2
2. ul li 2
3. ul li 3
  1. ul li 3, ul li 1
  2. ul li 3, ul li 2
4. ul li 4
  * ul li 4, ol li 1
```

Before
![unordered list items increasing the counter of the parent ordered list](https://github.com/Mitcheljager/workshop.codes/assets/6181929/0e189952-fb23-4fd2-bfdb-d2f48afeabd4)

After
![unordered list items not affecting the counter of the parent ordered list](https://github.com/Mitcheljager/workshop.codes/assets/6181929/0d9c2fc5-dae9-44c2-ba35-529f3e03fa79)
