### PR TITLE
Small improvements to the posts snippet viewer ("ide")

### DIFF
--- a/app/assets/stylesheets/elements/_ide.scss
+++ b/app/assets/stylesheets/elements/_ide.scss
@@ -34,6 +34,7 @@
 
   .ide--fullscreen & {
     max-height: 100%;
+    border-radius: 0;
   }
 }
 

--- a/app/assets/stylesheets/elements/_ide.scss
+++ b/app/assets/stylesheets/elements/_ide.scss
@@ -9,7 +9,7 @@
     height: 100%;
     width: 100%;
     margin-top: 0;
-    z-index: 10;
+    z-index: 100;
   }
 }
 

--- a/app/assets/stylesheets/elements/_ide.scss
+++ b/app/assets/stylesheets/elements/_ide.scss
@@ -75,14 +75,14 @@
   line-height: 1.5em;
 }
 
-.ide__tray {
+.ide__actions {
   display: flex;
   position: absolute;
-  bottom: 1.5rem;
+  top: 1.5rem;
   right: 1.5rem;
 }
 
-.ide__tray-item {
+.ide__actions-item {
   appearance: none;
   position: relative;
   padding: .5em;

--- a/app/views/posts/_snippet.html.erb
+++ b/app/views/posts/_snippet.html.erb
@@ -7,9 +7,9 @@
   <pre class="ide__content"><div class="ide__code-wrapper"><div class="ide__line-counter"></div>
     <div class="hidden" data-copy="snippet"></div>
     <code class="ide__code microlight" data-role="ide-content">Loading...</code>
-    <div class="ide__tray">
-      <button class="ide__tray-item" data-action="toggle-ide-fullscreen">Fullscreen</button>
-      <button class="ide__tray-item" data-action="copy-to-clipboard" data-target="snippet">Copy to clipboard</button>
+    <div class="ide__actions">
+      <button class="ide__actions-item" data-action="toggle-ide-fullscreen">Fullscreen</button>
+      <button class="ide__actions-item" data-action="copy-to-clipboard" data-target="snippet">Copy to clipboard</button>
     </div>
   </div></pre>
 </div>


### PR DESCRIPTION
- Move action buttons to the top right, so users don't have to scroll all the way down to toggle fullscreen or copy the snippet to clipboard
- Increase z-index the search bar's filter actions toggle button doesn't render on top of the fullscreen ide view
  ![](https://github.com/Mitcheljager/workshop.codes/assets/6181929/2eb480c2-b8cd-4d39-9906-5db1a151acbd)
- Remove rounded corners