### PR TITLE
Include subroutines used in actions in the compiled output of the Editor

### DIFF
--- a/app/javascript/src/utils/compiler/subroutines.js
+++ b/app/javascript/src/utils/compiler/subroutines.js
@@ -10,7 +10,9 @@ ${ subroutines.map((v, i) => `    ${ i }: ${ v }`).join("\n") }
 }
 
 export function getSubroutines(joinedItems) {
-  let subroutines = joinedItems.match(/Subroutine;[\r\n]+([^\r\n;]+)/g) || []
-  subroutines = subroutines.map(s => s.replace("Subroutine;\n", "").replace("Call Subroutine", "").replace(/[\())\s]/g, ""))
-  return [...new Set(subroutines)]
+  const declaredSubroutines = Array.from(joinedItems.matchAll(/Subroutine;[\r\n]+([^\r\n;]+)/g))
+    .map((match) => match[1].trim())
+  const usedSubroutines = Array.from(joinedItems.matchAll(/(?:Call Subroutine|Start Rule)\s*\(([^,\)]+)/g))
+    .map((match) => match[1].trim())
+  return [...new Set([...declaredSubroutines, ...usedSubroutines])]
 }

--- a/spec/javascript/utils/compiler/subroutines.test.js
+++ b/spec/javascript/utils/compiler/subroutines.test.js
@@ -3,13 +3,23 @@ import { disregardWhitespace } from "../../helpers/text"
 
 describe("subroutines.js", () => {
   describe("getSubroutines", () => {
-    test("Should extract subroutines", () => {
+    test("Should extract subroutines declared from rules", () => {
       const input = `
         Subroutine;
         someSubroutine1;
 
         Subroutine;
         someSubroutine2;
+      `
+      const expectedOutput = ["someSubroutine1", "someSubroutine2"]
+      expect(getSubroutines(input)).toEqual(expectedOutput)
+    })
+
+    test("Should extract subroutines used in actions", () => {
+      const input = `
+        Call Subroutine(someSubroutine1);
+
+        Start Rule(someSubroutine2, OtherParamIdk);
       `
       const expectedOutput = ["someSubroutine1", "someSubroutine2"]
       expect(getSubroutines(input)).toEqual(expectedOutput)
@@ -22,6 +32,10 @@ describe("subroutines.js", () => {
 
         Subroutine;
         someSubroutine;
+
+        Call Subroutine(someSubroutine);
+
+        Start Rule(someSubroutine, OtherParamIdk);
       `
       const expectedOutput = ["someSubroutine"]
       expect(getSubroutines(input)).toEqual(expectedOutput)
@@ -32,11 +46,14 @@ describe("subroutines.js", () => {
     test("Should compile subroutines", () => {
       const input = `
         Subroutine;
-        someSubroutine;
+        someSubroutine1;
+
+        Call Subroutine(someSubroutine2);
       `
       const expectedOutput = `
         subroutines {
-          0: someSubroutine
+          0: someSubroutine1
+          1: someSubroutine2
         }\n\n
       `
       expect(disregardWhitespace(compileSubroutines(input))).toBe(disregardWhitespace(expectedOutput))


### PR DESCRIPTION
While there is linter logic to catch these, it is sometimes hard to see the linter error in certain cases.

An argument can be made that, because the in-game editor allows for creating a subroutine but never defining a rule for it, we should also allow it as well.

In fact, this change fixes a case where importing a snippet that declares a subroutine but never define it, then compiling the project and trying to import that into the game would cause a workshop error because we stripped the subroutine from the subroutines list.

Also: refactor `getSubroutines` to use `String.matchAll()`, which is a bit better than `String.match()` and a ton of `String.replace()`s.