### PR TITLE
 Add lint rule to the Editor that warns about usage of triple equals

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -633,7 +633,7 @@ function findTripleEquals(content) {
       from,
       to: from + match[0].length,
       severity: "error",
-      message: "This isn't JavaScript! Use single equals for assignments, or double equals to comparisons."
+      message: "Use single equals for assignments, or double equals to comparisons. Triple equals doesn't exist here (this isn't JavaScript!)."
     })
   }
 }

--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -625,7 +625,7 @@ function findUndefinedSubroutines(content) {
 }
 
 function findTripleEquals(content) {
-  const stringRanges = findRangesOfStrings(content);
+  const stringRanges = findRangesOfStrings(content)
 
   for (const match of matchAllOutsideRanges(stringRanges, content, /===/g)) {
     const from = match.index

--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -632,7 +632,7 @@ function findTripleEquals(content) {
     diagnostics.push({
       from,
       to: from + match[0].length,
-      severity: "warning",
+      severity: "error",
       message: "This isn't JavaScript! Use single equals for assignments, or double equals to comparisons."
     })
   }

--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -627,7 +627,7 @@ function findUndefinedSubroutines(content) {
 function findTripleEquals(content) {
   const stringRanges = findRangesOfStrings(content);
 
-  for (const match of matchAllOutsideRanges(stringRanges, content, /={3}/g)) {
+  for (const match of matchAllOutsideRanges(stringRanges, content, /===/g)) {
     const from = match.index
     diagnostics.push({
       from,


### PR DESCRIPTION
Makes sure to only detect them outside of strings.