### PR TITLE
fix: Include special characters in syntax highlighting

### DIFF
--- a/app/javascript/src/lib/OWLanguageLegacy.js
+++ b/app/javascript/src/lib/OWLanguageLegacy.js
@@ -32,7 +32,7 @@ const punc = ":;,.(){}[]+-\\*"
 const octal = /^\-?0o[0-7][0-7_]*/
 const hexadecimal = /^\-?0x[\dA-Fa-f][\dA-Fa-f_]*(?:(?:\.[\dA-Fa-f][\dA-Fa-f_]*)?[Pp]\-?\d[\d_]*)?/
 const decimal = /^\-?\d[\d_]*(?:\.\d[\d_]*)?(?:[Ee]\-?\d[\d_]*)?/
-const identifier = /^\$\d+|(`?)[_A-Za-z][_A-Za-z$0-9]*\1/
+const identifier = /^\$\d+|(`?)[_A-Za-zÀ-ÖØ-öø-ÿ][_A-Za-zÀ-ÖØ-öø-ÿ$0-9]*\1/
 const actionsValuesIdentifier = /^\s*(?=[A-Z])\b[A-Z][\w\s-]*(?!:)/g
 const phraseIdentifier = /^\s*(?=[A-Z]).+?(?= [+\-*%=|&<>~^?!]|[\(\)\{\}:;,./\n\[\]]|\s==)/
 const customKeywords = /(?<!\w)@(?:else if|\w+)/

--- a/app/javascript/src/lib/OWLanguageLegacy.js
+++ b/app/javascript/src/lib/OWLanguageLegacy.js
@@ -32,7 +32,7 @@ const punc = ":;,.(){}[]+-\\*"
 const octal = /^\-?0o[0-7][0-7_]*/
 const hexadecimal = /^\-?0x[\dA-Fa-f][\dA-Fa-f_]*(?:(?:\.[\dA-Fa-f][\dA-Fa-f_]*)?[Pp]\-?\d[\d_]*)?/
 const decimal = /^\-?\d[\d_]*(?:\.\d[\d_]*)?(?:[Ee]\-?\d[\d_]*)?/
-const identifier = /^\$\d+|(`?)[_A-Za-zÀ-ÖØ-öø-ÿ][_A-Za-zÀ-ÖØ-öø-ÿ$0-9]*\1/
+const identifier = /^\$\d+|(`?)[\p{L}][_\p{L}$0-9]*\1/u
 const actionsValuesIdentifier = /^\s*(?=[A-Z])\b[A-Z][\w\s-]*(?!:)/g
 const phraseIdentifier = /^\s*(?=[A-Z]).+?(?= [+\-*%=|&<>~^?!]|[\(\)\{\}:;,./\n\[\]]|\s==)/
 const customKeywords = /(?<!\w)@(?:else if|\w+)/


### PR DESCRIPTION
Keywords with special accents were not being highlighted as expected. This PR fixes that by including these characters in the regex. It's a bit of a ChatGPT special, but it seems to work well.

Before | After
--- | ---
![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/d03605a1-bf1e-485f-8c3c-b90126d3bff6) | ![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/1b55527a-fefc-459b-bcdb-2ccfb074bb7b)
