### PR TITLE
feat: Allow parameter objects to be used for in mixins

### DIFF
--- a/spec/javascript/utils/compiler/mixins.test.js
+++ b/spec/javascript/utils/compiler/mixins.test.js
@@ -215,6 +215,36 @@ describe("mixins.js", () => {
       expect(result.fullMixin).toEqual(joinedItems)
       expect(disregardWhitespace(result.replaceWith)).toEqual(disregardWhitespace("Global.slot = 1;"))
     })
+
+    it("Should replace Mixin variables with parameter objects if it's given as the only param", () => {
+      const input = `
+        @mixin testMixin(One = 1, Two = 2) {
+          Mixin.One;
+          Some Action(Mixin.Two);
+        }
+        @include testMixin({ Two: 3 });`
+
+      const expectedOutput = `
+        1;
+        Some Action(3);`
+
+      expect(disregardWhitespace(extractAndInsertMixins(input))).toBe(disregardWhitespace(expectedOutput))
+    })
+
+    it("Should replace Mixin variables with given parameter objects as parameters if more than one object is given", () => {
+      const input = `
+        @mixin testMixin(One, Two) {
+          Mixin.One;
+          Some Action(Mixin.Two);
+        }
+        @include testMixin({ One: 1 }, { someVar: someValue });`
+
+      const expectedOutput = `
+        { One: 1 };
+        Some Action({ someVar: someValue });`
+
+      expect(disregardWhitespace(extractAndInsertMixins(input))).toBe(disregardWhitespace(expectedOutput))
+    })
   })
 
   describe("getOpeningBracketAt", () => {


### PR DESCRIPTION
I had a mixin that looked like this:
```
@mixin projectileHeroSettings(hero, speed = 50, size = 0.1, radius = 0, timeBetweenShots = 0, maxRange = 0, delay = 0) {
```
The problem was that include result in a whole bunch of `50, 0.1, 0, 0, 0, 0.1` values because I only wanted to change the last value.

This PR changes that by allows parameter objects to be used in mixins, which lucky was a lot easier than expected, however it did present one issue; you might want to use parameter objects as values for your parameters, and how do we know if it's an object for the mixin or to be used literally? We don't. The solution I came up with is that if you provide only one parameters which is an object, we assume it's for the mixin. If you provide multiple we assume it's to be used literally.

That might be confusing to read so two examples:
```js
@mixin someMixin(one = 1, two = 2) {
  Some Action(Mixin.one);
  Some Action(Mixin.two);
}

@include someMixin({ one: 2, two: 3 })

// Results in
Some Action(2);
Some Action(3);
```

```js
@mixin someMixin(one = 1, two = 2) {
  Mixin.one;
  Mixin.two;
}

@include someMixin({ one: 2, two: 3 }, { one: 5, two: 6 })

// Results in
Some Action({ one: 2, two: 3 });
Some Action({ one: 5, two: 6 });
```

This has the downside that you can't have only one param that is an object, but this is easily remedied by including an empty param `@include someMixin({ one: 2 }, "");`. That's not great, but it's a way around an edge case.