### PR TITLE
Fixed several bugs with indentations

### DIFF
--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -195,7 +195,9 @@
         if (shiftKey) {
           if (!/^\s/.test(insert[0]) && !(insert.includes("\n ") || insert.includes("\n\t"))) return { range: EditorSelection.range(from, to) }
 
-          insert = (/^\n/.test(insert[0]) ? "\n" : "").concat(insert.replaceAll(/\n[ \t]/g, "\n").substring(insert.search(/\S/) ? 1 : 0, insert.length))
+          const firstChar = insert[0]
+          insert = insert.replaceAll(/\n[ \t]/g, "\n").substring(insert.search(/\S/) ? 1 : 0, insert.length)
+          insert = (/^\n/.test(firstChar) ? "\n" : "").concat(insert)
         } else {
           insert = "\t" + insert.replaceAll("\n", "\n\t")
         }

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -218,8 +218,8 @@
   }
 
   function getIndentForLine(state, line, charLimit) {
-    let lineText = state.doc.lineAt(Math.max(line, 0)).text;
-    lineText = charLimit !== undefined ? lineText.slice(0, charLimit) : lineText;
+    let lineText = state.doc.lineAt(Math.max(line, 0)).text
+    lineText = charLimit !== undefined ? lineText.slice(0, charLimit) : lineText
 
     const tabs = /^\t*/.exec(lineText)?.[0].length
     const spaces = /^\s*/.exec(lineText)?.[0].length - tabs


### PR DESCRIPTION
* Empty lines containing only a linebreak are no longer removed upon shift-tabbing with several lines of code selected.
* Shift-tabbing after selecting a chunk of code at the start of a line no longer causes the selection to jump to the line above.
* Shift-tabbing after selecting a chunk of code at the very start of a file no longer results in "Uncaught RangeError: Invalid position -1".
* Shift-tabbing with the cursor in front of other code no longer selects the first character following the cursor.

Auto indent on linebreak:
* Pressing Enter while the cursor is located somewhere in the middle of indentation will no longer build more and more indents for each new line.
* Pressing Enter on a line with a open bracket now only indent if the cursor is inside the bracket.