### PR TITLE
feat: Autocomplete using parameter objects

### DIFF
--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -295,8 +295,7 @@
       const [range] = transaction.changedRanges
       const text = transaction.state.doc.toString().slice(range.fromB, range.toB)
       const indents = getIndentForLine(view.state, range.fromB)
-      let tabs = ""
-      for (let i = 0; i < indents; i++) { tabs += "\t" }
+      const tabs = "\t".repeat(indents)
 
       const changes = {
         from: range.fromB,

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -16,9 +16,19 @@
   import { currentItem, editorStates, editorScrollPositions, items, currentProjectUUID, completionsMap, variablesMap, subroutinesMap, mixinsMap, settings } from "../../stores/editor"
   import { translationsMap } from "../../stores/translationKeys"
   import { getPhraseFromPosition } from "../../utils/parse"
+  import { tabIndent, getIndentForLine, getIndentCountForText, shouldNextLineBeIndent, autoIndentOnEnter, indentMultilineInserts } from "../../utils/codemirror/indent"
   import debounce from "../../debounce"
 
   const dispatch = createEventDispatcher()
+  const updateItem = debounce(() => {
+    $currentItem = {
+      ...$currentItem,
+      content: view.state.doc.toString()
+    }
+
+    const index = $items.findIndex(i => i.id == $currentItem.id)
+    if (index !== -1) $items[index] = $currentItem
+  }, 250)
 
   let element
   let view
@@ -36,6 +46,44 @@
   })
 
   onDestroy(() => $editorStates = {})
+
+  function createEditorState(content) {
+    return EditorState.create({
+      doc: content,
+      extensions: [
+        syntaxHighlighting(highlightStyle),
+        StreamLanguage.define(OWLanguage),
+        autocompletion({
+          activateOnTyping: true,
+          override: [completions],
+          closeOnBlur: false,
+          hintOptions: /[()\[\]{};:>,+-=]/
+        }),
+        lintGutter(),
+        linter(OWLanguageLinter),
+        indentUnit.of("    "),
+        keymap.of([
+          { key: "Tab", run: tabIndent },
+          { key: "Shift-Tab", run: tabIndent },
+          { key: "Enter", run: autoIndentOnEnter },
+          { key: "Ctrl-Shift-z", run: redoAction }
+        ]),
+        EditorView.updateListener.of((transaction) => {
+          if (transaction.docChanged) {
+            indentMultilineInserts(view, transaction)
+            updateItem()
+          }
+          if (transaction.selectionSet) $editorStates[currentId].selection = view.state.selection
+        }),
+        basicSetup,
+        parameterTooltip(),
+        indentationMarkers(),
+        rememberScrollPosition(),
+        foldBrackets(),
+        ...($settings["word-wrap"] ? [EditorView.lineWrapping] : [])
+      ]
+    })
+  }
 
   function updateEditorState() {
     updatingState = true
@@ -69,46 +117,30 @@
 
     requestAnimationFrame(() => {
       updatingState = false
-      setScrollPosition()
+      setScrollPosition(view, currentId)
     })
   }
 
-  function createEditorState(content) {
-    return EditorState.create({
-      doc: content,
-      extensions: [
-        syntaxHighlighting(highlightStyle),
-        StreamLanguage.define(OWLanguage),
-        autocompletion({
-          activateOnTyping: true,
-          override: [completions],
-          closeOnBlur: false,
-          hintOptions: /[()\[\]{};:>,+-=]/
-        }),
-        lintGutter(),
-        linter(OWLanguageLinter),
-        indentUnit.of("    "),
-        keymap.of([
-          { key: "Tab", run: tabIndent },
-          { key: "Shift-Tab", run: tabIndent },
-          { key: "Enter", run: autoIndentOnEnter },
-          { key: "Ctrl-Shift-z", run: redoAction }
-        ]),
-        EditorView.updateListener.of((transaction) => {
-          if (transaction.docChanged) {
-            indentMultilineInserts(transaction)
-            updateItem()
-          }
-          if (transaction.selectionSet) $editorStates[currentId].selection = view.state.selection
-        }),
-        basicSetup,
-        parameterTooltip(),
-        indentationMarkers(),
-        rememberScrollPosition(),
-        foldBrackets(),
-        ...($settings["word-wrap"] ? [EditorView.lineWrapping] : [])
-      ]
+  /**
+   * Returns a plugin that updates a store of scroll positions when the view is scrolled.
+   * The view is also scrolled when updating the view, but we don't want to store that position.
+   * For this we use the updatingState flag to determine if it was a user scroll or a update scroll.
+   */
+  function rememberScrollPosition() {
+    return EditorView.domEventHandlers({
+      scroll(_, view) {
+        if (updatingState) return
+
+        $editorScrollPositions = {
+          ...$editorScrollPositions,
+          [currentId]: view.scrollDOM.scrollTop
+        }
+      }
     })
+  }
+
+  function setScrollPosition(view, id) {
+    view.scrollDOM.scrollTo({ top: $editorScrollPositions[id] || 0 })
   }
 
   function completions(context) {
@@ -133,6 +165,13 @@
     }
   }
 
+  function click(event) {
+    if (!event.altKey) return
+
+    event.preventDefault()
+    searchWiki()
+  }
+
   function keydown(event) {
     if (event.ctrlKey && event.key === "2") {
       event.preventDefault()
@@ -144,118 +183,6 @@
     const { transaction } = redo(view)
     if (transaction) dispatch(transaction)
     return true
-  }
-
-  function autoIndentOnEnter({ state, dispatch }) {
-    const changes = state.changeByRange(range => {
-      const { from, to } = range, line = state.doc.lineAt(from)
-
-      const indent = getIndentForLine(state, from, from - line.from)
-      let insert = "\n"
-      for (let i = 0; i < indent; i++) { insert += "\t" }
-
-      if (shouldNextLineBeIndent(line.text)) insert += "\t"
-
-      return { changes: { from, to, insert }, range: EditorSelection.cursor(from + insert.length) }
-    })
-
-    dispatch(state.update(changes, { scrollIntoView: true, userEvent: "input" }))
-    return true
-  }
-
-  function tabIndent({ state, dispatch }, event) {
-    const { shiftKey } = event
-
-    if (element.querySelector(".cm-tooltip-autocomplete")) return true
-
-    const changes = state.changeByRange(range => {
-      const { from, to } = range, line = state.doc.lineAt(from)
-
-      let insert = ""
-
-      if (from == to && !shiftKey) {
-        const previousIndent = getIndentForLine(state, from - 1)
-        const currentIndent = getIndentForLine(state, from)
-
-        insert = "\t"
-        if (currentIndent < previousIndent) {
-          for (let i = 0; i < previousIndent - 1; i++) { insert += "\t" }
-        }
-
-        return {
-          changes: { from, to, insert },
-          range: EditorSelection.cursor(from + insert.length)
-        }
-      } else {
-        let insert = view.state.doc.toString().substring(line.from, to)
-
-        const originalLength = insert.length
-        const leadingWhitespaceLength = insert.search(/\S/)
-
-        if (shiftKey) {
-          if (!/^\s/.test(insert[0]) && !(insert.includes("\n ") || insert.includes("\n\t"))) return { range: EditorSelection.range(from, to) }
-
-          const firstChar = insert[0]
-          insert = insert.replaceAll(/\n[ \t]/g, "\n").substring(insert.search(/\S/) ? 1 : 0, insert.length)
-          insert = (/^\n/.test(firstChar) ? "\n" : "").concat(insert)
-        } else {
-          insert = "\t" + insert.replaceAll("\n", "\n\t")
-        }
-
-        //'line.from' and 'from' are equal at start of line, dont reduce indents lower than 0.
-        const fromModifier = line.from === from ? 0 : (insert.search(/\S/) - leadingWhitespaceLength - (from === to ? 1: 0))
-        const toModifier = insert.length - originalLength
-
-        return {
-          changes: { from: line.from, to, insert },
-          range: EditorSelection.range(from + fromModifier, to + toModifier)
-        }
-      }
-    })
-
-    dispatch(state.update(changes, { scrollIntoView: true, userEvent: "input" }))
-    dispatch({ selection: EditorSelection.create(changes.selection.ranges) })
-
-    return true
-  }
-
-  function getIndentForLine(state, line, charLimit) {
-    let lineText = state.doc.lineAt(Math.max(line, 0)).text
-    lineText = charLimit !== undefined ? lineText.slice(0, charLimit) : lineText
-
-    return getIndentCountForText(lineText)
-  }
-
-  function getIndentCountForText(text) {
-    const tabs = /^\t*/.exec(text)?.[0].length
-    const spaces = /^\s*/.exec(text)?.[0].length - tabs
-
-    return Math.floor(spaces / 4) + tabs
-  }
-
-  function shouldNextLineBeIndent(text) {
-    const isComment = text.includes("//")
-    const openBracket = !isComment && /[\{\(\[]/gm.exec(text)?.[0].length
-    const closeBracket = !isComment && /[\}\)\]]/gm.exec(text)?.[0].length
-
-    return !!(openBracket && !closeBracket)
-  }
-
-  const updateItem = debounce(() => {
-    $currentItem = {
-      ...$currentItem,
-      content: view.state.doc.toString()
-    }
-
-    const index = $items.findIndex(i => i.id == $currentItem.id)
-    if (index !== -1) $items[index] = $currentItem
-  }, 250)
-
-  function click(event) {
-    if (!event.altKey) return
-
-    event.preventDefault()
-    searchWiki()
   }
 
   function searchWiki() {
@@ -274,63 +201,6 @@
         EditorSelection.range(from, to)
       ])
     })
-  }
-
-  /**
-   * Returns a plguin that updates a store of scroll positions when the view is scrolled.
-   * The view is also scrolled when updating the view, but we don't want to store that position.
-   * For this we use the updatingState flag to determine if it was a user scroll or a update scroll.
-   */
-  function rememberScrollPosition(event) {
-    return EditorView.domEventHandlers({
-      scroll(event, view) {
-        if (updatingState) return
-
-        $editorScrollPositions = {
-          ...$editorScrollPositions,
-          [currentId]: view.scrollDOM.scrollTop
-        }
-      }
-    })
-  }
-
-  function setScrollPosition() {
-    view.scrollDOM.scrollTo({ top: $editorScrollPositions[currentId] || 0 })
-  }
-
-  function indentMultilineInserts(transaction) {
-    // Only perform this function if transaction is of an expected type performed by the user to prevent infinite loops on changes made by CodeMirror
-    if (transaction.transactions.every(tr => ["input.paste", "input.complete"].includes(tr.annotation(Transaction.userEvent)))) {
-      const [range] = transaction.changedRanges
-      const rangeLine = view.state.doc.lineAt(range.fromB)
-      const text = transaction.state.doc.toString().slice(range.fromB, range.toB)
-      const splitText = text.split("\n")
-
-      let startIndentCount = 0
-      let firstIndentCount = 0
-      const mappedText = splitText.map((line, i) => {
-        if (!i) {
-          firstIndentCount = getIndentCountForText(line)
-          startIndentCount = getIndentCountForText(rangeLine.text) - firstIndentCount
-
-          return line.replace(/^\s+/, "")
-        }
-
-        const currentLineIndentCount = getIndentCountForText(line)
-        const totalIndentCount = startIndentCount - firstIndentCount + currentLineIndentCount
-        const tabs = "\t".repeat(totalIndentCount)
-
-        return tabs + line.replace(/^\s+/, "")
-      })
-
-      const changes = {
-        from: range.fromB,
-        to: range.toB,
-        insert: mappedText.join("\n")
-      }
-
-      view.dispatch({ changes })
-    }
   }
 </script>
 

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -89,9 +89,11 @@
       // Add apply values when selecting autocomplete, filling in default args
       const lowercaseDefaults = Object.keys(defaults).map(k => k.toLowerCase())
       const useParameterObject = $settings["autocomplete-parameter-objects"] && params.args_length >= $settings["autocomplete-min-parameter-size"]
+      const useNewlines = params.args_length >= $settings["autocomplete-min-parameter-newlines"]
+
       const apply = v.args.map(a => {
         let string = a.default?.toString().toLowerCase().replaceAll(",", "")
-        if (useParameterObject) string = `\n\t${ a.name }: ${ string }`
+        if (useParameterObject) string = `${ useNewlines ? "\n\t" : "" }${ a.name }: ${ string }`
 
         if (lowercaseDefaults.includes(string)) return defaults[toCapitalize(string)]
 
@@ -102,7 +104,9 @@
       params.parameter_defaults = apply
 
       params.apply = useParameterObject ?
-        `${ v["en-US"] }({ ${ apply.join(", ") }\n})` :
+        useNewlines ?
+          `${ v["en-US"] }({ ${ apply.join(",") }\n})` :
+          `${ v["en-US"] }({ ${ apply.join(", ") } })` :
         `${ v["en-US"] }(${ apply.join(", ") })`
 
       // Add arguments to info box

--- a/app/javascript/src/components/editor/Settings.svelte
+++ b/app/javascript/src/components/editor/Settings.svelte
@@ -61,6 +61,54 @@
 
   {#if active}
     <div transition:fly={{ duration: 150, y: 20 }} use:escapeable on:escape={() => active = false} class="dropdown__content block p-1/4" style="width: 300px">
+      <h5 class="mt-0 mb-1/8">Settings</h5>
+
+      <div class="checkbox tooltip mt-1/8">
+        <input id="show-line-indent-markers" type="checkbox" bind:checked={$settings["show-indent-markers"]} />
+        <label for="show-line-indent-markers">Show line indent markers</label>
+
+        <div class="tooltip__content bg-darker">
+          Show line markers at the expected indents at 1 tab or 4 spaces.
+        </div>
+      </div>
+
+      <div class="checkbox tooltip mt-1/8">
+        <input id="word-wrap" type="checkbox" bind:checked={$settings["word-wrap"]} />
+        <label for="word-wrap">Word wrap</label>
+
+        <div class="tooltip__content bg-darker">
+          Wrap lines that no longer fit on screen.
+        </div>
+      </div>
+
+      <div class="checkbox tooltip mt-1/8">
+        <input id="autocomplete-parameter-objects" type="checkbox" bind:checked={$settings["autocomplete-parameter-objects"]} />
+        <label for="autocomplete-parameter-objects">
+          Autocomplete using parameter objects
+        </label>
+
+        <div class="tooltip__content bg-darker">
+          Parameter objects change the format of parameters in actions and values to be more readable and less cumbersome to write. You can exclude any parameters you don't change the default off.
+        </div>
+      </div>
+
+      {#if $settings["autocomplete-parameter-objects"]}
+        <div class="form-group mt-1/8 tooltip" transition:slide|local={{ duration: 100 }}>
+          <label for="" class="text-base nowrap">Minimum parameter length</label>
+
+          <div class="flex align-center">
+            <input type="range" min=1 max=20 step=1 class="range mr-1/8" bind:value={$settings["autocomplete-min-parameter-size"]} />
+            {$settings["autocomplete-min-parameter-size"]}
+          </div>
+
+          <div class="tooltip__content bg-darker">
+            Only autocomplete when an action or value has equal or more than this value in parameters.
+          </div>
+        </div>
+      {/if}
+
+      <hr />
+
       <h5 class="mt-0 mb-1/8">Font</h5>
 
       <div class="form-group-inline">
@@ -99,50 +147,6 @@
       {/each}
 
       <hr>
-
-      <div class="checkbox tooltip tooltip--top-left mt-1/8">
-        <input id="show-line-indent-markers" type="checkbox" bind:checked={$settings["show-indent-markers"]} />
-        <label for="show-line-indent-markers">Show line indent markers</label>
-
-        <div class="tooltip__content bg-darker">
-          Show line markers at the expected indents at 1 tab or 4 spaces.
-        </div>
-      </div>
-
-      <div class="checkbox tooltip tooltip--top-left mt-1/8">
-        <input id="word-wrap" type="checkbox" bind:checked={$settings["word-wrap"]} />
-        <label for="word-wrap">Word wrap</label>
-
-        <div class="tooltip__content bg-darker">
-          Wrap lines that no longer fit on screen.
-        </div>
-      </div>
-
-      <div class="checkbox tooltip tooltip--top-left mt-1/8">
-        <input id="autocomplete-parameter-objects" type="checkbox" bind:checked={$settings["autocomplete-parameter-objects"]} />
-        <label for="autocomplete-parameter-objects">
-          Autocomplete using parameter objects
-        </label>
-
-        <div class="tooltip__content bg-darker">
-          Parameter objects change the format of parameters in actions and values to be more readable and less cumbersome to write. You can exclude any parameters you don't change the default off.
-        </div>
-      </div>
-
-      {#if $settings["autocomplete-parameter-objects"]}
-        <div class="form-group mt-1/8 tooltip tooltip--top-left" transition:slide={{ duration: 100 }}>
-          <label for="" class="text-base nowrap">Minimum parameter length</label>
-
-          <div class="flex align-center">
-            <input type="range" min=1 max=20 step=1 class="range mr-1/8" bind:value={$settings["autocomplete-min-parameter-size"]} />
-            {$settings["autocomplete-min-parameter-size"]}
-          </div>
-
-          <div class="tooltip__content bg-darker">
-            Only autocomplete when an action or value has equal or more than this value in parameters.
-          </div>
-        </div>
-      {/if}
 
       <button class="button button--link button--small pb-0 mt-1/4" on:click={resetToDefault}>Reset all to default</button>
     </div>

--- a/app/javascript/src/components/editor/Settings.svelte
+++ b/app/javascript/src/components/editor/Settings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { fly } from "svelte/transition"
+  import { fly, slide } from "svelte/transition"
   import { onMount, tick } from "svelte"
   import { escapeable } from "../actions/escapeable"
   import { outsideClick } from "../actions/outsideClick"
@@ -100,17 +100,51 @@
 
       <hr>
 
-      <div class="checkbox mt-1/8">
+      <div class="checkbox tooltip tooltip--top-left mt-1/8">
         <input id="show-line-indent-markers" type="checkbox" bind:checked={$settings["show-indent-markers"]} />
         <label for="show-line-indent-markers">Show line indent markers</label>
+
+        <div class="tooltip__content bg-darker">
+          Show line markers at the expected indents at 1 tab or 4 spaces.
+        </div>
       </div>
 
-      <div class="checkbox mt-1/8 mb-1/4">
+      <div class="checkbox tooltip tooltip--top-left mt-1/8">
         <input id="word-wrap" type="checkbox" bind:checked={$settings["word-wrap"]} />
         <label for="word-wrap">Word wrap</label>
+
+        <div class="tooltip__content bg-darker">
+          Wrap lines that no longer fit on screen.
+        </div>
       </div>
 
-      <button class="button button--link button--small pb-0" on:click={resetToDefault}>Reset all to default</button>
+      <div class="checkbox tooltip tooltip--top-left mt-1/8">
+        <input id="autocomplete-parameter-objects" type="checkbox" bind:checked={$settings["autocomplete-parameter-objects"]} />
+        <label for="autocomplete-parameter-objects">
+          Autocomplete using parameter objects
+        </label>
+
+        <div class="tooltip__content bg-darker">
+          Parameter objects change the format of parameters in actions and values to be more readable and less cumbersome to write. You can exclude any parameters you don't change the default off.
+        </div>
+      </div>
+
+      {#if $settings["autocomplete-parameter-objects"]}
+        <div class="form-group mt-1/8 tooltip tooltip--top-left" transition:slide={{ duration: 100 }}>
+          <label for="" class="text-base nowrap">Minimum parameter length</label>
+
+          <div class="flex align-center">
+            <input type="range" min=1 max=20 step=1 class="range mr-1/8" bind:value={$settings["autocomplete-min-parameter-size"]} />
+            {$settings["autocomplete-min-parameter-size"]}
+          </div>
+
+          <div class="tooltip__content bg-darker">
+            Only autocomplete when an action or value has equal or more than this value in parameters.
+          </div>
+        </div>
+      {/if}
+
+      <button class="button button--link button--small pb-0 mt-1/4" on:click={resetToDefault}>Reset all to default</button>
     </div>
   {/if}
 </div>

--- a/app/javascript/src/components/editor/Settings.svelte
+++ b/app/javascript/src/components/editor/Settings.svelte
@@ -148,7 +148,7 @@
 
       <hr>
 
-      <button class="button button--link button--small pb-0 mt-1/4" on:click={resetToDefault}>Reset all to default</button>
+      <button class="button button--link button--small pb-0" on:click={resetToDefault}>Reset all to default</button>
     </div>
   {/if}
 </div>

--- a/app/javascript/src/components/editor/Settings.svelte
+++ b/app/javascript/src/components/editor/Settings.svelte
@@ -105,6 +105,19 @@
             Only autocomplete when an action or value has equal or more than this value in parameters.
           </div>
         </div>
+
+        <div class="form-group mt-1/8 tooltip" transition:slide|local={{ duration: 100 }}>
+          <label for="" class="text-base nowrap">Minimum newline length</label>
+
+          <div class="flex align-center">
+            <input type="range" min=1 max=20 step=1 class="range mr-1/8" bind:value={$settings["autocomplete-min-parameter-newlines"]} />
+            {$settings["autocomplete-min-parameter-newlines"]}
+          </div>
+
+          <div class="tooltip__content bg-darker">
+            Place each parameter on a new line when the action or value has equal or more than this value in parameters.
+          </div>
+        </div>
       {/if}
 
       <hr />

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -106,5 +106,6 @@ export const settings = writable({
   "show-indent-markers": true,
   "word-wrap": false,
   "autocomplete-parameter-objects": false,
-  "autocomplete-min-parameter-size": 2
+  "autocomplete-min-parameter-size": 2,
+  "autocomplete-min-parameter-newlines": 2
 })

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -104,5 +104,7 @@ export const settings = writable({
   "color-invalid": "#b33834",
   "color-custom-keyword": "#c678dd",
   "show-indent-markers": true,
-  "word-wrap": false
+  "word-wrap": false,
+  "autocomplete-parameter-objects": false,
+  "autocomplete-min-parameter-size": 2
 })

--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -1,0 +1,168 @@
+import { EditorSelection, Transaction } from "@codemirror/state"
+
+/**
+ * Indent on using tab with special conditions. Indent is reversed while holding shift
+ * @param {Object} view CodeMirror view
+ * @param {Object} event Event as fired from CodeMirror
+ * @returns {Boolean} Should return true on complete
+ */
+export function tabIndent({ state, dispatch }, event) {
+  const { shiftKey, target } = event
+
+  // Do not indent when autocomplete is open
+  if (target.closest(".cm-editor").querySelector(".cm-tooltip-autocomplete")) return true
+
+  // Insert tabs for each range, each range meaning a cursor position and/or selection
+  const changes = state.changeByRange(range => {
+    const { from, to } = range, line = state.doc.lineAt(from)
+
+    let insert = ""
+
+    // Using tab from a regular cursor without a selection
+    if (from == to && !shiftKey) {
+      const previousIndent = getIndentForLine(state, from - 1)
+      const currentIndent = getIndentForLine(state, from)
+
+      insert = "\t"
+      if (currentIndent < previousIndent) insert += "\t".repeat(previousIndent - 1)
+
+      return {
+        changes: { from, to, insert },
+        range: EditorSelection.cursor(from + insert.length)
+      }
+    } else {
+      let insert = state.doc.toString().substring(line.from, to)
+
+      const originalLength = insert.length
+      const leadingWhitespaceLength = insert.search(/\S/)
+
+      if (shiftKey) {
+        if (!/^\s/.test(insert[0]) && !(insert.includes("\n ") || insert.includes("\n\t"))) return { range: EditorSelection.range(from, to) }
+
+        const firstChar = insert[0]
+        insert = insert.replaceAll(/\n[ \t]/g, "\n").substring(insert.search(/\S/) ? 1 : 0, insert.length)
+        insert = (/^\n/.test(firstChar) ? "\n" : "").concat(insert)
+      } else {
+        insert = "\t" + insert.replaceAll("\n", "\n\t")
+      }
+
+      //'line.from' and 'from' are equal at start of line, dont reduce indents lower than 0.
+      const fromModifier = line.from === from ? 0 : (insert.search(/\S/) - leadingWhitespaceLength - (from === to ? 1: 0))
+      const toModifier = insert.length - originalLength
+
+      return {
+        changes: { from: line.from, to, insert },
+        range: EditorSelection.range(from + fromModifier, to + toModifier)
+      }
+    }
+  })
+
+  dispatch(state.update(changes, { scrollIntoView: true, userEvent: "input" }))
+  dispatch({ selection: EditorSelection.create(changes.selection.ranges) })
+
+  return true
+}
+
+/**
+ * Fine the number of indents of a given line number.
+ * @param {Object} state CodeMirror editor state
+ * @param {Number} line CodeMirror line number
+ * @param {Number} charLimit Max characters given in the text
+ * @returns {Number} Number of indents for the given line
+ */
+export function getIndentForLine(state, line, charLimit) {
+  let lineText = state.doc.lineAt(Math.max(line, 0)).text
+  lineText = charLimit !== undefined ? lineText.slice(0, charLimit) : lineText
+
+  return getIndentCountForText(lineText)
+}
+
+/**
+ * Get the number of indents for a given text. One tab means one indent, 4 spaces equal one tab.
+ * @param {String} text String to check for number of indents
+ * @returns {Number} Number of indents
+ */
+export function getIndentCountForText(text) {
+  const tabs = /^\t*/.exec(text)?.[0].length
+  const spaces = /^\s*/.exec(text)?.[0].length - tabs
+
+  return Math.floor(spaces / 4) + tabs
+}
+
+/**
+ * Returns whether or not the next given line should be indented. This is purely based on there
+ * being an opening character without a closing character on the previous line.
+ * @param {String} text String to check for expected indent level, should be a single line
+ * @returns {Boolean}
+ */
+export function shouldNextLineBeIndent(text) {
+  const isComment = text.includes("//")
+  const openBracket = !isComment && /[\{\(\[]/gm.exec(text)?.[0].length
+  const closeBracket = !isComment && /[\}\)\]]/gm.exec(text)?.[0].length
+
+  return !!(openBracket && !closeBracket)
+}
+
+/**
+ * Indent the next line when pressing enter. The number of indents is based on the indents on the
+ * previous line as well as there being an opening character on the previous line.
+ * @param {Object} view CodeMirror view
+ * @returns {Boolean} Should return true on complete
+ */
+export function autoIndentOnEnter({ state, dispatch }) {
+  const changes = state.changeByRange(range => {
+    const { from, to } = range, line = state.doc.lineAt(from)
+
+    let indent = getIndentForLine(state, from, from - line.from)
+    if (shouldNextLineBeIndent(line.text)) indent++
+
+    let insert = "\n"
+    insert += "\t".repeat(indent)
+
+    return { changes: { from, to, insert }, range: EditorSelection.cursor(from + insert.length) }
+  })
+
+  dispatch(state.update(changes, { scrollIntoView: true, userEvent: "input" }))
+  return true
+}
+
+/**
+ * Add indents to multiline inserts. This could be either when pasting multiple lines of code or
+ * on autocomplete with results that contain new lines.
+ * @param {Object} view CodeMirror view
+ * @param {Object} transaction CodeMirror transaction
+ */
+export function indentMultilineInserts({ state, dispatch }, transaction) {
+  // Only perform this function if transaction is of an expected type performed by the user to prevent infinite loops on changes made by CodeMirror
+  if (transaction.transactions.every(tr => ["input.paste", "input.complete"].includes(tr.annotation(Transaction.userEvent)))) {
+    const [range] = transaction.changedRanges
+    const rangeLine = state.doc.lineAt(range.fromB)
+    const text = transaction.state.doc.toString().slice(range.fromB, range.toB)
+    const splitText = text.split("\n")
+
+    let startIndentCount = 0
+    let firstIndentCount = 0
+    const mappedText = splitText.map((line, i) => {
+      if (!i) {
+        firstIndentCount = getIndentCountForText(line)
+        startIndentCount = getIndentCountForText(rangeLine.text) - firstIndentCount
+
+        return line.replace(/^\s+/, "")
+      }
+
+      const currentLineIndentCount = getIndentCountForText(line)
+      const totalIndentCount = startIndentCount - firstIndentCount + currentLineIndentCount
+      const tabs = "\t".repeat(totalIndentCount)
+
+      return tabs + line.replace(/^\s+/, "")
+    })
+
+    const changes = {
+      from: range.fromB,
+      to: range.toB,
+      insert: mappedText.join("\n")
+    }
+
+    dispatch({ changes })
+  }
+}


### PR DESCRIPTION
This PR adds an options to the settings dropdown to autocomplete using parameter objects. All autocompletes will use parameter objects instead of their regular format. When you change the settings the completions map is regenerated with the new corresponding format.
Along with that settings there's a setting to only do this if the completion has more than x arguments, defaulting to 2. If it has less than the given amount the regular format will be used. This is mostly to prevent silly parameter objects like `Button({ Button: Melee })`.
![param-objects-autocomplete](https://github.com/Mitcheljager/workshop.codes/assets/12848235/f485b656-2b62-4d28-899a-e635dee0d880)

Since the autocompletions can be multi line I added a function that transforms transactions in CodeMirror that contain new lines to use the expected amount of tabs. An added benefit of this is that this fixes a bug with pasting code that contains tabs that would only be indented correctly on the first line

Before | After
--- | ---
![paste-before](https://github.com/Mitcheljager/workshop.codes/assets/12848235/d39b043b-fe68-4371-84ed-1ad45847f901) | ![paste-after](https://github.com/Mitcheljager/workshop.codes/assets/12848235/4979af10-cf9b-4c83-9e2a-4935703bf691)
