### PR TITLE
Remove [linemarker]s from parameter object keys in the Editor compiler

### DIFF
--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -52,8 +52,11 @@ export function getFirstParameterObject(content, startFromIndex = 0) {
   const given = {}
 
   splitParameters.forEach(item => {
-    const [key, value] = item.split(/:(.*)/s)
-    given[key.trim()] = (value || "").trim()
+    let [key, value] = item.split(/:(.*)/s)
+    key = key.replace(/\[linemarker\].*?\[\/linemarker\]/, "").trim()
+    value = (value || "").trim()
+    if (!key) return
+    given[key] = value
   })
 
   const result = { start: start + startFromIndex, end: end + startFromIndex, given }

--- a/spec/javascript/utils/compiler/parameterObjects.test.js
+++ b/spec/javascript/utils/compiler/parameterObjects.test.js
@@ -79,6 +79,19 @@ describe("parameterObjects.js", () => {
 
       expect(getFirstParameterObject(content, 20)).toEqual(expected)
     })
+
+    test("Should ignore [linemarker]s", () => {
+      const content = "[linemarker]itemID|1[/linemarker]Some Action({\n[linemarker]itemID|2[/linemarker]\tOne: 10,\n[linemarker]itemID|3[/linemarker]\tThree: 20,\n[linemarker]itemID|4[/linemarker]})"
+      const expected = {
+        start: 45,
+        end: 168,
+        given: { One: "10", Three: "20" },
+        phraseParameters: ["One", "Two", "Three"],
+        phraseDefaults: [0, 0, 0]
+      }
+
+      expect(getFirstParameterObject(content)).toEqual(expected)
+    })
   })
 
   describe("replaceParameterObject", () => {


### PR DESCRIPTION
Fixes an issue where parameter keys would internally contain the [linemarker]s, meaning we wouldn't find the correct argument positions and just use default values instead.

Fixes #402 