### PR TITLE
bugfix for indents after #410

### DIFF
--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -115,9 +115,9 @@ export function autoIndentOnEnter({ state, dispatch }) {
   const changes = state.changeByRange(range => {
     const { from, to } = range, line = state.doc.lineAt(from)
 
-    const cursorPos = from - line.from
-    let indent = getIndentForLine(state, from, cursorPos)
-    if (shouldNextLineBeIndent(line.text.slice(0, cursorPos))) indent++
+    const cursorPosition = from - line.from
+    let indent = getIndentForLine(state, from, cursorPosition)
+    if (shouldNextLineBeIndent(line.text.slice(0, cursorPosition))) indent++
 
     let insert = "\n"
     insert += "\t".repeat(indent)

--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -49,12 +49,14 @@ export function tabIndent({ state, dispatch }, event) {
       //'line.from' and 'from' are equal at start of line, dont reduce indents lower than 0.
       const fromModifier = line.from === from ? 0 : (insert.search(/\S/) - leadingWhitespaceLength - (from === to ? 1: 0))
       const toModifier = insert.length - originalLength
-      const selectionDirection = state.selection.main.head === to
-
+      const reverseSelection = state.selection.main.head === to
+      
+      let range = EditorSelection.range(to + toModifier, from + fromModifier)
+      if (reverseSelection) range = EditorSelection.range(from + fromModifier, to + toModifier)
+      
       return {
         changes: { from: line.from, to, insert },
-        range: selectionDirection ? EditorSelection.range(from + fromModifier, to + toModifier) :
-          EditorSelection.range(to + toModifier, from + fromModifier)
+        range
       }
     }
   })

--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -53,8 +53,8 @@ export function tabIndent({ state, dispatch }, event) {
 
       return {
         changes: { from: line.from, to, insert },
-        range: selectionDirection ? EditorSelection.range(from + fromModifier, to + toModifier) : 
-        EditorSelection.range(to + toModifier, from + fromModifier)
+        range: selectionDirection ? EditorSelection.range(from + fromModifier, to + toModifier) :
+          EditorSelection.range(to + toModifier, from + fromModifier)
       }
     }
   })

--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -49,10 +49,12 @@ export function tabIndent({ state, dispatch }, event) {
       //'line.from' and 'from' are equal at start of line, dont reduce indents lower than 0.
       const fromModifier = line.from === from ? 0 : (insert.search(/\S/) - leadingWhitespaceLength - (from === to ? 1: 0))
       const toModifier = insert.length - originalLength
+      const selectionDirection = state.selection.main.head === to
 
       return {
         changes: { from: line.from, to, insert },
-        range: EditorSelection.range(from + fromModifier, to + toModifier)
+        range: selectionDirection ? EditorSelection.range(from + fromModifier, to + toModifier) : 
+        EditorSelection.range(to + toModifier, from + fromModifier)
       }
     }
   })
@@ -113,8 +115,9 @@ export function autoIndentOnEnter({ state, dispatch }) {
   const changes = state.changeByRange(range => {
     const { from, to } = range, line = state.doc.lineAt(from)
 
-    let indent = getIndentForLine(state, from, from - line.from)
-    if (shouldNextLineBeIndent(line.text)) indent++
+    const cursorPos = from - line.from
+    let indent = getIndentForLine(state, from, cursorPos)
+    if (shouldNextLineBeIndent(line.text.slice(0, cursorPos))) indent++
 
     let insert = "\n"
     insert += "\t".repeat(indent)
@@ -151,7 +154,7 @@ export function indentMultilineInserts({ state, dispatch }, transaction) {
       }
 
       const currentLineIndentCount = getIndentCountForText(line)
-      const totalIndentCount = startIndentCount - firstIndentCount + currentLineIndentCount
+      const totalIndentCount = Math.max(startIndentCount - firstIndentCount + currentLineIndentCount)
       const tabs = "\t".repeat(totalIndentCount)
 
       return tabs + line.replace(/^\s+/, "")


### PR DESCRIPTION
Since #410 there is an error when copypasting code on a line that already has code: "Uncaught RangeError: Invalid count value: -2"
Adding Math.max() as a temporary solution, not sure what is causing it?

Adding back a bugfix (prevent auto-indents on enter from adding up infinitely when the cursor is outside of an open bracket) that disappeared with the change to some of the functions

added a selectionDirection constant to prevent the selection from flipping around when tabbing (cursor used to always jump to 'to' position, even when it started at 'from')