### PR TITLE
Prevent looping when no closing parenthesis is found

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -122,7 +122,7 @@ function findIncorrectArgsLength(content) {
         let argumentMatch
         while ((argumentMatch = /\(/g.exec(argumentsString)) != null && safeIndex < 100) {
           const argumentClosing = getClosingBracket(argumentsString, "(", ")", argumentMatch.index - 1)
-          if (argumentClosing === -1) { break }
+          if (argumentClosing === -1) break
           argumentsString = argumentsString.substring(0, argumentMatch.index) + argumentsString.substring(argumentClosing + 1)
 
           safeIndex++

--- a/app/javascript/src/lib/OWLanguageLinter.js
+++ b/app/javascript/src/lib/OWLanguageLinter.js
@@ -122,6 +122,7 @@ function findIncorrectArgsLength(content) {
         let argumentMatch
         while ((argumentMatch = /\(/g.exec(argumentsString)) != null && safeIndex < 100) {
           const argumentClosing = getClosingBracket(argumentsString, "(", ")", argumentMatch.index - 1)
+          if (argumentClosing === -1) { break }
           argumentsString = argumentsString.substring(0, argumentMatch.index) + argumentsString.substring(argumentClosing + 1)
 
           safeIndex++


### PR DESCRIPTION
![linterOops](https://github.com/Mitcheljager/workshop.codes/assets/85789932/72de2911-e8c6-4f63-9368-ec2fa74b0ef2)
The argumentsString variable builds up to extreme lengths when argumentClosing is -1 (no closing parenthesis).

Reproduce with code:

```hs
rule("Each Player Rule")
{
    event
    {
        Ongoing - Each Player;
        All;
        All;
    }

    conditions
    {

    }

    actions
    {
	    Apply Impulse(Event Player, Dot Product(Velocity Of(
	    Event Player), Normalize(X Component Of(Throttle))

        
    }
}
```