### PR TITLE
Fix default for parameter objects & semicolon after autocomplete

### DIFF
--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -17,6 +17,7 @@
   import { translationsMap } from "../../stores/translationKeys"
   import { getPhraseFromPosition } from "../../utils/parse"
   import { tabIndent, getIndentForLine, getIndentCountForText, shouldNextLineBeIndent, autoIndentOnEnter, indentMultilineInserts } from "../../utils/codemirror/indent"
+  import { get } from "svelte/store"
   import debounce from "../../debounce"
 
   const dispatch = createEventDispatcher()
@@ -70,7 +71,7 @@
         ]),
         EditorView.updateListener.of((transaction) => {
           if (transaction.docChanged) {
-            indentMultilineInserts(view, transaction)
+            autocompleteFormatting(view, transaction)
             updateItem()
           }
           if (transaction.selectionSet) $editorStates[currentId].selection = view.state.selection
@@ -162,6 +163,34 @@
       to: word.to,
       options: specialOverwrite || [...$completionsMap, ...$variablesMap, ...$subroutinesMap, ...extraCompletions],
       validFor: /^(?:[a-zA-Z0-9]+)$/i
+    }
+  }
+
+  function autocompleteFormatting(view, transaction) {
+    if (transaction.transactions.every(tr => ["input.complete"].includes(tr.annotation(Transaction.userEvent)))) {
+      indentMultilineInserts(view, transaction)
+      insertSemicolon(view, transaction)
+    }
+  }
+
+  function insertSemicolon(view, transaction) {
+    const line = view.state.doc.lineAt(transaction.changedRanges[0].fromB)
+    const phrase = getPhraseFromPosition(line, transaction.changedRanges[0].fromB)
+
+    const possibleValues = get(completionsMap).filter(v => v.args_length)
+    const validValue = possibleValues.find(v => v.label == phrase.text)
+
+    if (validValue?.type) {
+      const insertPosition = view.state.selection.ranges[0].from
+      
+      if(validValue.type === "function") {
+        view.dispatch({
+          changes: { from: insertPosition, insert: `;` },
+          selection: EditorSelection.create([
+            EditorSelection.range(insertPosition + 1, insertPosition + 1)
+          ])
+        })
+      }
     }
   }
 

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -174,17 +174,17 @@
   }
 
   function insertSemicolon(view, transaction) {
+    if (!$settings["autocomplete-semicolon"]) return
+
     const line = view.state.doc.lineAt(transaction.changedRanges[0].fromB)
     const phrase = getPhraseFromPosition(line, transaction.changedRanges[0].fromB)
-
     const possibleValues = get(completionsMap).filter(v => v.args_length)
     const validValue = possibleValues.find(v => v.label == phrase.text)
 
     if (!validValue?.type) return
+    if(validValue.type !== "function") return
 
     const insertPosition = view.state.selection.ranges[0].from
-      
-    if(validValue.type !== "function") return
     
     view.dispatch({
       changes: { from: insertPosition, insert: ";" },

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -167,15 +167,15 @@
   }
 
   function autocompleteFormatting(view, transaction) {
+    // Only perform this function if transaction is of an expected type performed by the user to prevent infinite loops on changes made by CodeMirror
     if (transaction.transactions.every(tr => ["input.complete"].includes(tr.annotation(Transaction.userEvent)))) {
       indentMultilineInserts(view, transaction)
-      insertSemicolon(view, transaction)
+      if ($settings["autocomplete-semicolon"])
+        insertSemicolon(view, transaction)
     }
   }
 
   function insertSemicolon(view, transaction) {
-    if (!$settings["autocomplete-semicolon"]) return
-
     const line = view.state.doc.lineAt(transaction.changedRanges[0].fromB)
     const phrase = getPhraseFromPosition(line, transaction.changedRanges[0].fromB)
     const possibleValues = get(completionsMap).filter(v => v.args_length)

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -180,18 +180,18 @@
     const possibleValues = get(completionsMap).filter(v => v.args_length)
     const validValue = possibleValues.find(v => v.label == phrase.text)
 
-    if (validValue?.type) {
-      const insertPosition = view.state.selection.ranges[0].from
+    if (!validValue?.type) return
+
+    const insertPosition = view.state.selection.ranges[0].from
       
-      if(validValue.type === "function") {
-        view.dispatch({
-          changes: { from: insertPosition, insert: ";" },
-          selection: EditorSelection.create([
-            EditorSelection.range(insertPosition + 1, insertPosition + 1)
-          ])
-        })
-      }
-    }
+    if(validValue.type !== "function") return
+    
+    view.dispatch({
+      changes: { from: insertPosition, insert: ";" },
+      selection: EditorSelection.create([
+        EditorSelection.range(insertPosition + 1, insertPosition + 1)
+      ])
+    })
   }
 
   function click(event) {

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -185,7 +185,7 @@
       
       if(validValue.type === "function") {
         view.dispatch({
-          changes: { from: insertPosition, insert: `;` },
+          changes: { from: insertPosition, insert: ";" },
           selection: EditorSelection.create([
             EditorSelection.range(insertPosition + 1, insertPosition + 1)
           ])

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -95,10 +95,12 @@
         const name = toCapitalize(a.name?.toString().toLowerCase())
         let defaultValue = a.default?.toString().toLowerCase().replaceAll(",", "")
         
-        if (lowercaseDefaults.includes(defaultValue.toLowerCase()) defaultValue = defaults[toCapitalize(defaultValue)]
+        if (lowercaseDefaults.includes(defaultValue.toLowerCase())) defaultValue = defaults[toCapitalize(defaultValue)]
         else defaultValue =toCapitalize(defaultValue)
 
-        return useParameterObject ? `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }` : defaultValue
+        if (useParameterObject) return `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }`
+        
+        return defaultValue
       })
 
       params.parameter_keys = detail

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -94,9 +94,9 @@
       const apply = v.args.map(a => {
         const name = toCapitalize(a.name?.toString().toLowerCase())
         let defaultValue = a.default?.toString().toLowerCase().replaceAll(",", "")
-        defaultValue = lowercaseDefaults.includes(defaultValue.toLowerCase()) ?
-          defaults[toCapitalize(defaultValue)] :
-          toCapitalize(defaultValue)
+        
+        if (lowercaseDefaults.includes(defaultValue.toLowerCase()) defaultValue = defaults[toCapitalize(defaultValue)]
+        else defaultValue =toCapitalize(defaultValue)
 
         return useParameterObject ? `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }` : defaultValue
       })

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -96,7 +96,7 @@
         let defaultValue = a.default?.toString().toLowerCase().replaceAll(",", "")
         
         if (lowercaseDefaults.includes(defaultValue.toLowerCase())) defaultValue = defaults[toCapitalize(defaultValue)]
-        else defaultValue =toCapitalize(defaultValue)
+        else defaultValue = toCapitalize(defaultValue)
 
         if (useParameterObject) return `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }`
         

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -98,7 +98,7 @@
           defaults[toCapitalize(defaultValue)] :
           toCapitalize(defaultValue)
 
-        return useParameterObject ? `${useNewlines ? "\n\t" : ""}${name}: ${defaultValue}` : defaultValue
+        return useParameterObject ? `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }` : defaultValue
       })
 
       params.parameter_keys = detail

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -92,12 +92,13 @@
       const useNewlines = params.args_length >= $settings["autocomplete-min-parameter-newlines"]
 
       const apply = v.args.map(a => {
-        let string = a.default?.toString().toLowerCase().replaceAll(",", "")
-        if (useParameterObject) string = `${ useNewlines ? "\n\t" : "" }${ a.name }: ${ string }`
+        const name = toCapitalize(a.name?.toString().toLowerCase())
+        let defaultValue = a.default?.toString().toLowerCase().replaceAll(",", "")
+        defaultValue = lowercaseDefaults.includes(defaultValue.toLowerCase()) ?
+          defaults[toCapitalize(defaultValue)] :
+          toCapitalize(defaultValue)
 
-        if (lowercaseDefaults.includes(string)) return defaults[toCapitalize(string)]
-
-        return toCapitalize(string)
+        return useParameterObject ? `${useNewlines ? "\n\t" : ""}${name}: ${defaultValue}` : defaultValue
       })
 
       params.parameter_keys = detail

--- a/app/javascript/src/components/editor/Settings.svelte
+++ b/app/javascript/src/components/editor/Settings.svelte
@@ -82,6 +82,15 @@
       </div>
 
       <div class="checkbox tooltip mt-1/8">
+        <input id="autocomplete-semicolon" type="checkbox" bind:checked={$settings["autocomplete-semicolon"]} />
+        <label for="autocomplete-semicolon">Insert semicolon on autocomplete</label>
+
+        <div class="tooltip__content bg-darker">
+          Insert a semicolon at the end of the line when autocompleting actions.
+        </div>
+      </div>
+      
+      <div class="checkbox tooltip mt-1/8">
         <input id="autocomplete-parameter-objects" type="checkbox" bind:checked={$settings["autocomplete-parameter-objects"]} />
         <label for="autocomplete-parameter-objects">
           Autocomplete using parameter objects

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -105,6 +105,7 @@ export const settings = writable({
   "color-custom-keyword": "#c678dd",
   "show-indent-markers": true,
   "word-wrap": false,
+  "autocomplete-semicolon": true,
   "autocomplete-parameter-objects": false,
   "autocomplete-min-parameter-size": 2,
   "autocomplete-min-parameter-newlines": 2


### PR DESCRIPTION
The default values inserted when using autocomplete and parameter objects were not correct. for example, when you expect to get the number 0 you would instead get the string "Number". i changed the code to handle the name and default separately before adding the newlines which did the trick.

Also added semicolons to autocomplete according to issue [#246](https://github.com/Mitcheljager/workshop.codes/issues/246).
The semicolons are inserted only when autocompleting actions. having it insert a semicolon for other type of values could probably get annoying