### PR TITLE
Indent on paste and search adjustments

### DIFF
--- a/app/assets/stylesheets/editor/_editor-item.scss
+++ b/app/assets/stylesheets/editor/_editor-item.scss
@@ -23,7 +23,7 @@
     top: 0.25rem;
     left: 0.45rem;
     height: 1.5rem;
-    width: 1.5rem;
+    width: 1.05rem;
     color: darken($gray, 30%);
   }
 
@@ -82,7 +82,8 @@
   right: 0;
   top: 0.25rem;
   background: darken($bg-dark, 7.5%);
-
+  z-index: 1;
+  
   .editor-item:hover > & {
     display: flex;
   }

--- a/app/assets/stylesheets/editor/_editor.scss
+++ b/app/assets/stylesheets/editor/_editor.scss
@@ -125,7 +125,7 @@ $top-height: 4rem;
 
 .drag-handle {
   position: absolute;
-  height: 0.5rem;
+  height: 0.75rem;
   width: 100%;
   padding: 0;
   bottom: 0;
@@ -136,7 +136,7 @@ $top-height: 4rem;
   @include media-min(mbl) {
     cursor: ew-resize;
     height: 100%;
-    width: 0.5rem;
+    width: 0.25rem;
   }
 
   &--left {

--- a/app/assets/stylesheets/editor/_matches.scss
+++ b/app/assets/stylesheets/editor/_matches.scss
@@ -30,3 +30,8 @@
     color: $white;
   }
 }
+
+.matches__hidden {
+  opacity: 0.5;
+  text-decoration: line-through;
+}

--- a/app/assets/stylesheets/elements/_codemirror.scss
+++ b/app/assets/stylesheets/elements/_codemirror.scss
@@ -115,6 +115,10 @@
     box-shadow: 0 0 0 1px $primary;
   }
 
+  .cm-searchMatch-selected {
+    background: darken($bg-dark, 10%);
+  }
+
   .cm-matchingBracket {
     background: lighten($bg-dark, 20%) !important;
   }

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -52,6 +52,7 @@
       }
 
       return {
+        hidden: i.hidden,
         id: i.id,
         name: i.name,
         parent: i.parent,
@@ -184,7 +185,7 @@
 
       {#each (itemMatches || []) as item, i}
         <button class="matches__item" class:matches__item--active={selected == i} on:click={() => selectItem(item.id)}>
-          {item.name}
+          <div class="{item.hidden ? "matches__hidden" : ""}">{item.name}</div>
 
           {#if item.parent}
             <div class="text-small text-dark">{getParentsString(item.parent)}</div>

--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -167,3 +167,27 @@ export function indentMultilineInserts({ state, dispatch }, transaction) {
 
   dispatch({ changes })
 }
+
+/**
+ * Adjust multiline-indents so that the indent on first line matches the rest.
+ * @param {Object} view CodeMirror view
+ * @param {Object} transaction CodeMirror transaction
+ */
+export function pasteIndentAdjustments({ dispatch }, transaction){
+  const [range] = transaction.changedRanges
+  const paste = transaction.state.doc.toString().slice(range.fromB, range.toB)
+  const line = transaction.state.doc.lineAt(range.fromB)
+  const lineText = line.text.slice(0, range.fromB - line.from)
+
+  let indentCount = 0
+  if (paste.includes("\n")) {
+    while ((lineText[indentCount] == "\t" || lineText[indentCount] == " ") &&
+    (paste[indentCount] == "\t" || paste[indentCount] == " ")) {
+      indentCount++
+    }
+  }
+
+  dispatch({
+    changes: { from: range.fromB, to: range.fromB + indentCount, insert: "" }
+  })
+}

--- a/config/arrays/wiki/actions.yml
+++ b/config/arrays/wiki/actions.yml
@@ -209,7 +209,7 @@ __chasePlayerVariableOverTime__:
   - name: Variable
     description: Specifies which of the player's variables to modify gradually.
     type: PlayerVariable
-    default: Variable
+    default: A
   - name: Destination
     description: The value that the player variable will eventually reach. The type of this value may be either a number or a vector, though the variable's existing value must be of the same type before the chase begins.
     type:
@@ -306,7 +306,7 @@ createDummy:
   - name: Slot
     description: The player slot which will receive the bot (-1 for first available slot). Up to 6 bots may be added to each team, or 12 bots to the free-for-all team, regardless of lobby settings.
     type: Integer
-    default: Number
+    default: -1
   - name: Position
     description: The initial position where the bot will appear.
     type: Position

--- a/config/arrays/wiki/constants.yml
+++ b/config/arrays/wiki/constants.yml
@@ -305,6 +305,11 @@ Impulse:
     description: If the target is moving against the direction of the impulse, this
       relative velocity is negated before the impulse is applied.
     en-US: Cancel Contrary Motion
+  CANCEL_CONTRARY_MOTION_XYZ:
+    description: If the target is moving against the direction of the impulse, this
+      relative velocity is negated before the impulse is applied. Horizontal and
+      vertical velocity (XYZ) are processed together.
+    en-US: Cancel Contrary Motion XYZ
   INCORPORATE_CONTRARY_MOTION:
     description: The impulse is added directly to the velocity of the target, so if
       the target is moving against the direction of the impulse, it might seem like


### PR DESCRIPTION
**pasteIndentAdjustments** Should be pretty friendly. only changes actual tabs and spaces so specialcharacters are not removed, and only adjusts the first line since codemirror does a decent job with the rest. (The previous indent changes were not applied to paste since the code was changed to adjust indents for autocomplete separately).

**searchScrollMargin**
Makes sure the searched results are not hidden behind the search window.

**_matches.scss** and **FindReplaceAll.svelte**:
Make the items that are excluded from compiler show with line-through text in the search.

**_codemirror.scss**:
Show which of the search results are actually selected.

**_editor.scss**:
Make the scrollbar easier to click.

**_editor-item.scss**:
Make it easier to click the beginning of the item name, and prevent icon tooltips from going underneath the selected item.

Feel free to criticize if something is not readable enough or if something needs adjustments (especially in Codemirror.svelte) 😬