### PR TITLE
evaluate parameter objects in getVariables and tests

### DIFF
--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -1,5 +1,5 @@
 import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "../parse"
-
+import { evaluateParameterObjects } from "./parameterObjects"
 // NOTE: The fact variable names can start with a decimal is intention.
 // We leave it to Overwatch to warn the user that this is not allowed.
 const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
@@ -138,6 +138,7 @@ function getLiteralPlayerVariables(source, stringRanges) {
 }
 
 export function getVariables(joinedItems) {
+  joinedItems = evaluateParameterObjects(joinedItems)
   const stringRanges = findRangesOfStrings(joinedItems)
 
   const playerVariablesFromActions = []

--- a/app/javascript/src/utils/compiler/variables.js
+++ b/app/javascript/src/utils/compiler/variables.js
@@ -1,6 +1,7 @@
 import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "../parse"
 import { evaluateParameterObjects } from "./parameterObjects"
-// NOTE: The fact variable names can start with a decimal is intention.
+
+// NOTE: The fact variable names can start with a decimal is intentional.
 // We leave it to Overwatch to warn the user that this is not allowed.
 const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
 
@@ -13,7 +14,6 @@ const globalVariablesRegex = /(?<=Global\.)[A-Za-z0-9_]+/g
  *   "Global.myGlobalVar.myPlayerVar.otherPlayerVar" => ".myPlayerVar", ".otherPlayerVar"
  *   "Global.Global.Global.myPlayerVar.otherPlayerVar" => "Global" (the second one), ".myPlayerVar", ".otherPlayerVar"
  *
- * NOTE: The fact variable names can start with a
  */
 const possiblePlayerVariablesRegex = /(?<![^\w.]Global)\.(?<variableName>[A-Za-z0-9_]+)/g
 


### PR DESCRIPTION
variables were not being added correctly when using parameter objects, sometimes causing errors when variables end up being added as undefined.

repro: autocomplete For Player Variable or Chase Player Variable At Rate as parameter objects, then try autocompleting anything.