### PR TITLE
fix(editor): Fix incorrect compiled values when using Autocomplete using Parameter Objects

### DIFF
--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -93,7 +93,7 @@
       const useNewlines = params.args_length >= $settings["autocomplete-min-parameter-newlines"]
 
       // Generate Apply map to be used for autocomplete and other bits
-      let apply = v.args.map(a => {
+      const apply = v.args.map(a => {
         const name = toCapitalize(a.name?.toString().toLowerCase())
         let defaultValue = a.default?.toString().toLowerCase().replaceAll(",", "")
 
@@ -107,12 +107,13 @@
       params.parameter_keys = detail
       params.parameter_defaults = apply.map(([_, defaultValue]) => defaultValue)
 
-      // If useParameterObject is enabled transform the apply to include the parameter name.
-      // It's important this happens after setting the parameter_defaults param, as that uses
-      // a different format and we don't want it to use the parameter object format.
-      if (useParameterObject) apply = apply.map(([name, defaultValue]) => ([name, `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }`]))
-
-      const applyValues = apply.map(([_, defaultValue]) => defaultValue)
+      const applyValues = apply.map(([name, defaultValue]) => {
+        // If useParameterObject is enabled add the parameter name to the apply.
+        // It's important this happens after setting the parameter_defaults param, as that uses
+        // a different format and we don't want it to use the parameter object format.
+        if (useParameterObject) return `${ useNewlines ? "\n\t" : "" } ${ name }: ${ defaultValue }`
+        return defaultValue
+      })
 
       // params.apply is used by CodeMirror for autocompete values.
       // The value we set is dependent on useParameterObjects and useNewlines.

--- a/app/javascript/src/utils/text.js
+++ b/app/javascript/src/utils/text.js
@@ -1,0 +1,3 @@
+export function toCapitalize(string) {
+  return string.toLowerCase().replace(/(^\w{1})|(\s+\w{1})/g, letter => letter.toUpperCase())
+}


### PR DESCRIPTION
When Autocomplete using Parameter Objects was enabled the compiler would include the parameter names in the compiled result, resulting in something like:
```
Create HUD Text(
	 Visible To: All Players(All Teams), Custom String("Test"), 
	 Subheader: Null, 
	 Text: Null, 
	 Location: Left, 
	 Sort Order: 0, 
	 Header Color: Color(white), 
	 Subheader Color: Color(white), 
	 Text Color: Color(white), 
	 Reevaluation: Visible To And String, 
	 Spectators: Default Visibility);
```
This happened because the value set in the completions map for `parameter_default` was set to the same value as `apply`, which is used for autocompletions. As a result it would insert the value as if it was the autocomplete value, including all the keys for the parameter object.

I fixed this by setting the param `parameter_default` _before_ transforming the `apply` value for Parameter Objects.

The code was a bit hard to read before, and this didn't really fix it, but I included some comments and moved a function to hopefully help in the future.