### PR TITLE
Mobile editor and DragHandle tweaks

### DIFF
--- a/app/assets/stylesheets/elements/_dropdown.scss
+++ b/app/assets/stylesheets/elements/_dropdown.scss
@@ -38,10 +38,6 @@
   overflow-y: auto;
   z-index: 100;
 
-  @media (max-width: 999px) {
-    right: -70px;
-  }
-
   @include styled-scrollbar();
 
   &--left {

--- a/app/assets/stylesheets/elements/_dropdown.scss
+++ b/app/assets/stylesheets/elements/_dropdown.scss
@@ -38,6 +38,10 @@
   overflow-y: auto;
   z-index: 100;
 
+  @media (max-width: 999px) {
+    right: -70px;
+  }
+
   @include styled-scrollbar();
 
   &--left {

--- a/app/javascript/src/components/editor/DragHandle.svelte
+++ b/app/javascript/src/components/editor/DragHandle.svelte
@@ -28,14 +28,19 @@
   function mouseMove(event) {
     if (!isDragging) return
 
-    const difference = (event[direction] || event.targetTouches[0]?.[direction]) - startPosition
-    currentSize = startSize + difference * (align == "right" ? 1 : -1)
+    requestAnimationFrame(() => {
+      const difference = (event[direction] || event.targetTouches[0]?.[direction]) - startPosition
+      currentSize = startSize + difference * (align == "right" ? 1 : -1)
 
-    setCssVariable(key, `${ currentSize }px`)
+      setCssVariable(key, `${ currentSize }px`)
 
-    currentSize = Math.min(Math.max(currentSize, (Math.max(window.innerWidth, window.innerHeight) / 10)), Math.max(window.innerWidth, window.innerHeight) / 2)
+      currentSize = Math.min(
+        Math.max(currentSize, Math.max(window.innerWidth, window.innerHeight) / 10),
+        Math.max(window.innerWidth, window.innerHeight) / 2
+      )
 
-    localStorage.setItem(key, currentSize)
+      localStorage.setItem(key, currentSize)
+    })
   }
 
   function mouseUp() {

--- a/app/javascript/src/components/editor/DragHandle.svelte
+++ b/app/javascript/src/components/editor/DragHandle.svelte
@@ -25,22 +25,21 @@
     startSize = parseInt(currentSize)
   }
 
-  function mouseMove(event) {
+  async function mouseMove(event) {
     if (!isDragging) return
 
-    requestAnimationFrame(() => {
-      const difference = (event[direction] || event.targetTouches[0]?.[direction]) - startPosition
-      currentSize = startSize + difference * (align == "right" ? 1 : -1)
+    await new Promise(res => requestAnimationFrame(res))
+    const difference = (event[direction] || event.targetTouches[0]?.[direction]) - startPosition
+    currentSize = startSize + difference * (align == "right" ? 1 : -1)
 
-      setCssVariable(key, `${ currentSize }px`)
+    setCssVariable(key, `${ currentSize }px`)
 
-      currentSize = Math.min(
-        Math.max(currentSize, Math.max(window.innerWidth, window.innerHeight) / 10),
-        Math.max(window.innerWidth, window.innerHeight) / 2
-      )
+    currentSize = Math.min(
+      Math.max(currentSize, Math.max(window.innerWidth, window.innerHeight) / 10),
+      Math.max(window.innerWidth, window.innerHeight) / 2
+    )
 
-      localStorage.setItem(key, currentSize)
-    })
+    localStorage.setItem(key, currentSize)
   }
 
   function mouseUp() {

--- a/app/javascript/src/components/editor/EditorList.svelte
+++ b/app/javascript/src/components/editor/EditorList.svelte
@@ -25,6 +25,9 @@
       swapTreshhold: 0.25,
       multiDrag: true,
       multiDragKey: "ctrl",
+      fallbackTolerance: 3,
+      delayOnTouchOnly: true,
+      delay: 100,
       onRemove: updateOrder,
       onUpdate: updateOrder,
       onSelect: event => {

--- a/app/javascript/src/components/editor/Settings.svelte
+++ b/app/javascript/src/components/editor/Settings.svelte
@@ -4,7 +4,7 @@
   import { escapeable } from "../actions/escapeable"
   import { outsideClick } from "../actions/outsideClick"
   import { setCssVariable } from "../../utils/setCssVariable"
-  import { settings } from "../../stores/editor"
+  import { settings, isMobile } from "../../stores/editor"
   import Cogs from "../icon/Cogs.svelte"
 
   let mounted = false
@@ -60,7 +60,12 @@
   </button>
 
   {#if active}
-    <div transition:fly={{ duration: 150, y: 20 }} use:escapeable on:escape={() => active = false} class="dropdown__content block p-1/4" style="width: 300px">
+    <div
+      transition:fly={{ duration: 150, y: 20 }}
+      use:escapeable on:escape={() => active = false}
+      class="dropdown__content block p-1/4"
+      style="width: 300px; right: { isMobile ? -70 : 0 }px">
+
       <h5 class="mt-0 mb-1/8">Settings</h5>
 
       <div class="checkbox tooltip mt-1/8">

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -10,7 +10,7 @@ import { debounced } from "../utils/debounceStore"
 const VARIABLE_EXTRACTION_DEBOUNCE_MS = 500
 
 export const screenWidth = writable(0)
-export const isMobile = derived(screenWidth, $screenWidth => $screenWidth && $screenWidth < 999)
+export const isMobile = derived(screenWidth, $screenWidth => $screenWidth && $screenWidth < 1100)
 
 export const modal = (() => {
   const { subscribe, set } = writable(null)

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -10,7 +10,7 @@ import { debounced } from "../utils/debounceStore"
 const VARIABLE_EXTRACTION_DEBOUNCE_MS = 500
 
 export const screenWidth = writable(0)
-export const isMobile = derived(screenWidth, $screenWidth => $screenWidth && $screenWidth < 1100)
+export const isMobile = derived(screenWidth, $screenWidth => $screenWidth && $screenWidth < 999)
 
 export const modal = (() => {
   const { subscribe, set } = writable(null)

--- a/app/javascript/src/stores/editor.js
+++ b/app/javascript/src/stores/editor.js
@@ -10,7 +10,7 @@ import { debounced } from "../utils/debounceStore"
 const VARIABLE_EXTRACTION_DEBOUNCE_MS = 500
 
 export const screenWidth = writable(0)
-export const isMobile = derived(screenWidth, $screenWidth => $screenWidth && $screenWidth < 1100)
+export const isMobile = derived(screenWidth, $screenWidth => $screenWidth && $screenWidth < 1000)
 
 export const modal = (() => {
   const { subscribe, set } = writable(null)


### PR DESCRIPTION
Added a short delay when touching the EditorList for mobile so that you can scroll and click them easier without accidentally moving the items. (fallbackTolerance should also help)

Moved the settings modal a bit to the right for small screens so that it doesnt get cutoff on the left side.

The requestAnimationFrame in DragHandle.svelte make moving the DragHandles less laggy, should work for both PC and mobile. 