### PR TITLE
refactor: Fetch editor data via json rather than passing it via the controller

### DIFF
--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -1,13 +1,29 @@
 class EditorController < ApplicationController
-  def index
-    current_user_projects(:workshop_codes)
+  def index; end
 
-    @project = Project.select(:uuid, :title).find_by_uuid(params[:uuid]) if params[:uuid].present?
-    @events = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "events.yml")))
-    @actions = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "actions.yml")))
-    @values = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "values.yml")))
-    @defaults = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "defaults.yml")))
-    @constants = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "constants.yml")))
+  def data
+    respond_to do |format|
+      format.json {
+        current_user_projects(:workshop_codes)
+
+        events = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "events.yml")))
+        actions = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "actions.yml")))
+        values = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "values.yml")))
+        defaults = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "defaults.yml")))
+        constants = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "constants.yml")))
+
+        render json: {
+          current_user_projects: @projects,
+          events: events,
+          actions: actions,
+          values: values,
+          defaults: defaults,
+          constants: constants,
+          maps: maps,
+          heroes: heroes,
+        }, layout: false
+      }
+    end
   end
 
   def zez_ui

--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -4,24 +4,28 @@ class EditorController < ApplicationController
   def data
     respond_to do |format|
       format.json {
+        response = Rails.cache.fetch("editor_data", expires_in: 1.day) do
+          events = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "events.yml")))
+          actions = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "actions.yml")))
+          values = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "values.yml")))
+          defaults = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "defaults.yml")))
+          constants = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "constants.yml")))
+
+          response = {
+            events: events,
+            actions: actions,
+            values: values,
+            defaults: defaults,
+            constants: constants,
+            maps: maps,
+            heroes: heroes,
+          }
+        end
+
         current_user_projects(:workshop_codes)
+        response["current_user_projects"] = @projects
 
-        events = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "events.yml")))
-        actions = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "actions.yml")))
-        values = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "values.yml")))
-        defaults = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "defaults.yml")))
-        constants = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "constants.yml")))
-
-        render json: {
-          current_user_projects: @projects,
-          events: events,
-          actions: actions,
-          values: values,
-          defaults: defaults,
-          constants: constants,
-          maps: maps,
-          heroes: heroes,
-        }, layout: false
+        render json: response, layout: false
       }
     end
   end

--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -4,6 +4,8 @@ class EditorController < ApplicationController
   def data
     respond_to do |format|
       format.json {
+        expires_in 4.hours, public: true
+
         response = Rails.cache.fetch("editor_data", expires_in: 1.day) do
           events = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "events.yml")))
           actions = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "actions.yml")))
@@ -22,10 +24,17 @@ class EditorController < ApplicationController
           }
         end
 
-        current_user_projects(:workshop_codes)
-        response["current_user_projects"] = @projects
-
         render json: response, layout: false
+      }
+    end
+  end
+
+  def user_projects
+    respond_to do |format|
+      format.json {
+        current_user_projects(:workshop_codes)
+
+        render json: @projects, layout: false
       }
     end
   end

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -32,6 +32,9 @@
 
   $: if (data) $completionsMap = parseKeywords($settings)
 
+  // Updates the tab title
+  $: document.title = $currentProject?.title !== undefined ? `${ $currentProject.title } | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
+
   onMount(async() => {
     loading = true
 
@@ -150,9 +153,6 @@
         alert(`Something went wrong while loading, please try again. ${ error }`)
       })
   }
-
-  // Updates the tab title
-  $: document.title = $currentProject?.title !== undefined ? `Editor | ${ $currentProject.title } | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
 </script>
 
 <svelte:window bind:innerWidth={$screenWidth} />

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -42,10 +42,7 @@
     $isSignedIn = _isSignedIn
 
     ;[data, userProjects] = (
-      await Promise.allSettled([
-        fetchData().then(r => r || {}),
-        fetchProjects().then(r => r || [])
-      ])
+      await Promise.allSettled([fetchData(), fetchProjects()])
     ).map(promise => promise.value)
 
     if (!data) return

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Editor | #{(@project.title + " | ") if @project.present?} Workshop.codes Script Editor" %>
+<% content_for :page_title, "Editor | Workshop.codes Script Editor" %>
 <% content_for :og_description, "The Workshop.codes Overwatch Workshop Script Editor enables editing your Workshop Script right from your browser using an intuitive and easy to use text based editor. Useful for new and experienced programmers!" %>
 <% content_for :og_summary_small, "true" %>
 
@@ -10,15 +10,7 @@
 
 <div class="wiki">
   <%= svelte_component "Editor", {
-    events: @events,
-    values: @values,
-    actions: @actions,
-    constants: @constants,
-    defaults: @defaults,
-    heroes: heroes,
-    maps: maps,
     bugsnagApiKey: ENV["BUGSNAG_API_KEY"],
-    _projects: @projects,
     _isSignedIn: current_user.present?
   } %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "explanation", to: "pages#explanation"
 
   get "editor", to: "editor#index", as: "editor"
+  get "editor/data", "editor#data"
   get "workshop-ui", to: "editor#zez_ui", as: "zez_ui"
 
   get "active_storage_blob_variant_url/:key", to: "application#active_storage_blob_variant_url"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   get "editor", to: "editor#index", as: "editor"
   get "editor/data", "editor#data"
+  get "editor/user_projects", "editor#user_projects"
   get "workshop-ui", to: "editor#zez_ui", as: "zez_ui"
 
   get "active_storage_blob_variant_url/:key", to: "application#active_storage_blob_variant_url"


### PR DESCRIPTION
The data for the editor was passed directly from the controller. This was convenient, but it is also hard to cache, and has the potential to slow down the initial response by quite a bit.

This PR refactors the data by moving it to json endpoints, allowing the editor to fetch them after the page has loaded. There's 2 endpoints; One for the general editor data (values, actions, etc), and one for the users projects. They are separate so that the browser can cache the data endpoint without having to invalidate it somehow if the user logs into a different account. The projects endpoint is not cached.

This should alleviate some stress from the server and lower the initial response time. In return the user will see the initial loading spinner for a little longer.