### PR TITLE
Revamp VSCode launch tasks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	"recommendations": [
 		"svelte.svelte-vscode",
 		"dbaeumer.vscode-eslint",
-    "Orta.vscode-jest"
+    "Orta.vscode-jest",
+    "KoichiSasada.vscode-rdbg"
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,22 +5,41 @@
 	"version": "0.2.0",
 	"configurations": [
     {
-      // Required gems: ruby-debug-base and ruby-debug-ide
-      // Required extension: rebornix.ruby
-      "name": "Rails server",
-      "type": "Ruby",
+      // Required gems: debug
+      // Required extension: KoichiSasada.vscode-rdbg
+      "name": "Rails Server",
+      "type": "rdbg",
       "request": "launch",
-      "program": "${workspaceRoot}/bin/rails",
-      "args": [
-        "server"
-      ]
+      "command": "bundle exec",
+      "script": "rails s",
+      "useBundler": true,
+      "cwd": "${workspaceFolder}",
     },
     {
+      // Required gems: debug
+      // Required extension: KoichiSasada.vscode-rdbg
+      "name": "Webpack Dev Server",
+      "type": "rdbg",
+      "request": "launch",
+      "script": "./bin/webpack-dev-server",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+			"name": "Chrome against localhost:3000",
 			"type": "chrome",
 			"request": "launch",
-			"name": "Chrome against localhost:3000",
 			"url": "http://localhost:3000",
 			"webRoot": "${workspaceFolder}/app"
 		}
-	]
+	],
+  "compounds": [
+    {
+      "name": "All",
+      "configurations": [
+        "Rails Server",
+        "Webpack Dev Server",
+        "Chrome against localhost:3000"
+      ]
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,8 @@
 			"type": "chrome",
 			"request": "launch",
 			"url": "http://localhost:3000",
-			"webRoot": "${workspaceFolder}/app"
+			"webRoot": "${workspaceFolder}",
+      "sourceMaps": true
 		}
 	],
   "compounds": [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There's several Environment vars that are required for some parts of the website
 - `SENDGRID_USERNAME` - Your Sendgrid Username for sending emails
 - `SENDGRID_PASSWORD` - Your Sendgrid Password for sending emails
 - `LOCKBOX_MASTER_KEY` - Lockbox Master key to encrypt email addresses (Run `Lockbox.generate_key` to generate a key)
-- `BLIND_INDEX_MASTER_KEY` - Lockbox Blind index master key to search encrypted database fields (use `ffffffffffffffffffffffffffffffff` during testing)- 
+- `BLIND_INDEX_MASTER_KEY` - Lockbox Blind index master key to search encrypted database fields (use `ffffffffffffffffffffffffffffffff` during testing)-
 - `BNET_KEY` - Battle.net key for OAuth
 - `BNET_SECRET` - Battle.net secret for OAuth
 - `DIGITALOCEAN_SPACES_KEY` - DigitalOcean Spaces Key for image upload
@@ -44,3 +44,20 @@ There are several rake tasks you can use to make development a little closer to 
 - `rake hotness:set_hotness_for_posts` sets the `hotness` or "On Fire" score for posts. This is based on impressions, events and favorites. To get useful data out of this, use the website at random before running this task.
 - `rake generate_wiki_articles` to populate the Wiki with Workshop documentation\
 - `rake create_search_indexes` to create indexes for ElasticSearch
+
+## Debugging
+
+### VSCode
+
+There are 3 main launch tasks: Rails Server, Webpack Dev Server, and Chrome.
+You can run all of them via the compound task "All".
+
+- The Ruby tasks require the [`KoichiSasada.vscode-rdbg` extension](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg), which requires you to install the `debug` gem like so:
+
+  ```bash
+  gem install debug
+  ```
+
+  - If you only care about debugging client code, you can run the task commands on separate terminals instead.
+
+- The Chrome task is set up to work with Source Maps, so setting breakpoints through VSCode *should* work.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ There are several rake tasks you can use to make development a little closer to 
 There are 3 main launch tasks: Rails Server, Webpack Dev Server, and Chrome.
 You can run all of them via the compound task "All".
 
-- The Ruby tasks require the [`KoichiSasada.vscode-rdbg` extension](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg), which requires you to install the `debug` gem like so:
+- The Ruby tasks require the [VSCode rdbg Ruby Debugger extension](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg), which requires you to install the `debug` gem like so:
 
   ```bash
   gem install debug


### PR DESCRIPTION
- Make Rails Server task an "rdbg" task from [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg)
- Add Webpack Dev Server launch task to launch `./bin/webpack-dev-server`
- Fix Chrome launch task to link source maps correctly
- Add compound task to launch all tasks at once
- Document launch tasks in README

While it probably doesn't make sense to debug the Webpack Dev Server, it is convenient to have a single task to launch everything at the same time.

![](https://github.com/Mitcheljager/workshop.codes/assets/6181929/73689a8e-8583-4a72-94e1-459811a0e2ef)
