### PR TITLE
Add Code Actions, "Transform parameter objects into positional parameters" and vice-versa code action, to the Editor

### DIFF
--- a/app/assets/stylesheets/elements/_codemirror.scss
+++ b/app/assets/stylesheets/elements/_codemirror.scss
@@ -303,4 +303,27 @@
       color: $text-color-light;
     }
   }
+
+  .cm-codeActionsLightbulb {
+    position: absolute;
+    aspect-ratio: 1;
+    line-height: 1;
+    font-size: 0.75rem;
+    background-color: $bg-darker;
+    padding: 0.25rem;
+    border-radius: 2px;
+    cursor: pointer;
+    transform: translate(-100%, -50%);
+    opacity: 0.5;
+    display: inline-block;
+  }
+
+  .cm-codeActionsLightbulb__dropdown {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+  }
 }

--- a/app/assets/stylesheets/elements/_codemirror.scss
+++ b/app/assets/stylesheets/elements/_codemirror.scss
@@ -304,7 +304,7 @@
     }
   }
 
-  .cm-codeActionsLightbulb {
+  .code-actions-lightbulb {
     position: absolute;
     aspect-ratio: 1;
     line-height: 1;
@@ -318,7 +318,7 @@
     display: inline-block;
   }
 
-  .cm-codeActionsLightbulb__dropdown {
+  .code-actions-lightbulb__dropdown {
     position: absolute;
     width: 100%;
     height: 100%;

--- a/app/assets/stylesheets/elements/_codemirror.scss
+++ b/app/assets/stylesheets/elements/_codemirror.scss
@@ -313,7 +313,7 @@
     padding: 0.25rem;
     border-radius: 2px;
     cursor: pointer;
-    transform: translate(-100%, -50%);
+    transform: translateX(-100%) translateY(-50%);
     opacity: 0.5;
     display: inline-block;
   }

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -13,6 +13,7 @@
   import { parameterTooltip } from "../../lib/parameterTooltip"
   import { extraCompletions } from "../../lib/extraCompletions"
   import { codeActions } from "../../lib/codeActions"
+  import { transformParameterObjectsIntoPositionalParameters } from "../../lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters"
   import { foldBrackets } from "../../lib/foldBrackets"
   import { currentItem, editorStates, editorScrollPositions, items, currentProjectUUID, completionsMap, variablesMap, subroutinesMap, mixinsMap, settings } from "../../stores/editor"
   import { translationsMap } from "../../stores/translationKeys"
@@ -83,21 +84,7 @@
         indentationMarkers(),
         rememberScrollPosition(),
         codeActions([
-          function(update) {
-            const from = update.state.selection.main.from
-            if (!update.state.doc.sliceString(from).startsWith("@codeActionTest"))
-              return
-
-            return [
-              {
-                label: "It works?",
-                position: from,
-                run() {
-                  alert("It works!")
-                }
-              }
-            ]
-          }
+          transformParameterObjectsIntoPositionalParameters
         ]),
         foldBrackets(),
         ...($settings["word-wrap"] ? [EditorView.lineWrapping] : [])

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { onDestroy, onMount, createEventDispatcher, tick } from "svelte"
+  import { onDestroy, onMount, createEventDispatcher } from "svelte"
   import { basicSetup } from "codemirror"
   import { EditorView, keymap } from "@codemirror/view"
   import { EditorState, EditorSelection, Transaction } from "@codemirror/state"
   import { indentUnit, StreamLanguage, syntaxHighlighting } from "@codemirror/language"
-  import { autocompletion, pickedCompletion } from "@codemirror/autocomplete"
+  import { autocompletion } from "@codemirror/autocomplete"
   import { redo } from "@codemirror/commands"
   import { linter, lintGutter } from "@codemirror/lint"
   import { indentationMarkers } from "@replit/codemirror-indentation-markers"
@@ -12,11 +12,12 @@
   import { OWLanguageLinter } from "../../lib/OWLanguageLinter"
   import { parameterTooltip } from "../../lib/parameterTooltip"
   import { extraCompletions } from "../../lib/extraCompletions"
+  import { codeActions } from "../../lib/codeActions"
   import { foldBrackets } from "../../lib/foldBrackets"
   import { currentItem, editorStates, editorScrollPositions, items, currentProjectUUID, completionsMap, variablesMap, subroutinesMap, mixinsMap, settings } from "../../stores/editor"
   import { translationsMap } from "../../stores/translationKeys"
   import { getPhraseFromPosition } from "../../utils/parse"
-  import { tabIndent, getIndentForLine, getIndentCountForText, shouldNextLineBeIndent, autoIndentOnEnter, indentMultilineInserts, pasteIndentAdjustments } from "../../utils/codemirror/indent"
+  import { tabIndent, autoIndentOnEnter, indentMultilineInserts, pasteIndentAdjustments } from "../../utils/codemirror/indent"
   import { get } from "svelte/store"
   import debounce from "../../debounce"
 
@@ -81,6 +82,23 @@
         parameterTooltip(),
         indentationMarkers(),
         rememberScrollPosition(),
+        codeActions([
+          function(update) {
+            const from = update.state.selection.main.from
+            if (!update.state.doc.sliceString(from).startsWith("@codeActionTest"))
+              return
+
+            return [
+              {
+                label: "It works?",
+                position: from,
+                run() {
+                  alert("It works!")
+                }
+              }
+            ]
+          }
+        ]),
         foldBrackets(),
         ...($settings["word-wrap"] ? [EditorView.lineWrapping] : [])
       ]
@@ -92,7 +110,7 @@
       // Only perform this function if transaction is of an expected type performed by the user
       // to prevent infinite loops on changes made by CodeMirror.
       const userEvents = transaction.transactions.map(tr => tr.annotation(Transaction.userEvent))
-      
+
       if (userEvents.every(eventType => eventType === "input.complete")) {
         autocompleteFormatting(view, transaction)
       } else if (userEvents.every(eventType => eventType === "input.paste")) {
@@ -161,7 +179,7 @@
 
   function searchScrollMargin(view, transaction) {
     if (transaction.transactions[0].annotations[0].value !== "select.search") return
-    
+
     view.dispatch ({
       effects: EditorView.scrollIntoView (
         view.state.selection.main.head,
@@ -206,7 +224,7 @@
 
     if (!validValue?.type) return
     const insertPosition = view.state.selection.ranges[0].from
-    
+
     view.dispatch({
       changes: { from: insertPosition, insert: ";" },
       selection: EditorSelection.create([

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
@@ -36,21 +36,21 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
   // empty positional parameters
   if (fileWideParenTo - fileWideParenFrom <= "()".length) return
 
-  const openParameterObjectBracketIndex = actionCallCont.slice(openParenIndex).match(/(?<=^\s*)\{/)?.index ?? -1
-  if (actionCallCont.slice(1).trimStart()[0] === "{") {
+  const openParameterObjectBracketIndex = actionCallCont.slice(openParenIndex + 1).match(/(?<=^\s*)\{/)?.index ?? -1
+  if (openParameterObjectBracketIndex >= 0) {
     // parameter object → positional parameters
 
     const closingParameterObjectBracketIndex = getClosingBracket(actionCallCont, "{", "}", 0)
     if (closingParameterObjectBracketIndex < 0) return
 
-    const fileWideParameterObjectFrom = fileWideParenFrom + openParameterObjectBracketIndex
-    const fileWideParameterObjectTo = fileWideParenFrom + closingParameterObjectBracketIndex
+    const fileWideParameterObjectFrom = (fileWideParenFrom + 1) + openParameterObjectBracketIndex
+    const fileWideParameterObjectTo = (fileWideParenFrom + 1) + closingParameterObjectBracketIndex
 
     actions.push({
       label: "Transform object into positional parameters",
       position: fileWideActionNameStart,
       run() {
-        const parameterObject = state.doc.sliceString(fileWideParameterObjectFrom, fileWideParameterObjectTo)
+        const parameterObject = state.doc.sliceString(fileWideParameterObjectFrom + 1, fileWideParameterObjectTo - 1)
         const parameters = parseParameterObjectContent(parameterObject, 0)
 
         const argumentList = completion.parameter_keys

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
@@ -47,7 +47,7 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
     const fileWideParameterObjectTo = (fileWideParenFrom + 1) + closingParameterObjectBracketIndex
 
     actions.push({
-      label: "Transform object into positional parameters",
+      label: "Transform parameter object into normal parameters",
       position: fileWideActionNameStart,
       run() {
         const parameterObject = state.doc.sliceString(fileWideParameterObjectFrom + 1, fileWideParameterObjectTo - 1)

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
@@ -46,6 +46,9 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
     const fileWideParameterObjectFrom = (fileWideParenFrom + 1) + openParameterObjectBracketIndex
     const fileWideParameterObjectTo = (fileWideParenFrom + 1) + closingParameterObjectBracketIndex
 
+    // there is other stuff after the parameter object (that is not white space)
+    if (!(/^\s*$/.test(state.doc.sliceString(fileWideParameterObjectTo, fileWideParenTo - 1)))) return
+
     actions.push({
       label: "Transform parameter object into normal parameters",
       position: fileWideActionNameStart,

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
@@ -81,10 +81,10 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
         const indent = "\t".repeat(getIndentForLine(state, cursorFrom, cursorFrom))
 
         let parameterObject = "{"
-        
+
         if (isMultiLine) parameterObject += "\n"
         else parameterObject += " "
-        
+
         parameterObject += args
           .map((value, index) => {
             const keyValue = `${ completion.parameter_keys[index] }: ${ value.trim() }`
@@ -94,8 +94,9 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
 
         if (isMultiLine) parameterObject += "\n" + indent
         else parameterObject += " "
-        
+
         parameterObject += "}"
+
 
         view.dispatch(
           view.state.update({

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
@@ -1,0 +1,99 @@
+import { completionsMap } from "../../stores/editor"
+import { getClosingBracket, getPhraseFromPosition, splitArgumentsString } from "../../utils/parse"
+import { get } from "svelte/store"
+import { parseParameterObjectContent } from "../../utils/compiler/parameterObjects"
+
+/**
+ * @type {import("../codeActions").CodeActionProvider}
+ */
+export function transformParameterObjectsIntoPositionalParameters({ view, state }) {
+  const actions = []
+
+  const { from: start, to: end } = state.selection.main
+  if (start !== end) return
+
+  const line = state.doc.lineAt(start)
+  if (!line.text) return null
+
+  const phrase = getPhraseFromPosition(line, start)
+  const completion = get(completionsMap).find(({ type, label }) => type === "function" && label === phrase.text)
+  if (!completion) return
+
+  const fileWideActionNameStart = line.from + phrase.start
+  const fileWideActionNameEnd = line.from + phrase.end + 1
+
+  const actionCallCont = state.doc.sliceString(fileWideActionNameEnd, fileWideActionNameEnd + 100)
+  const openParenIndex = actionCallCont.match(/(?<=^\s*)\(/)?.index ?? -1
+  if (openParenIndex < 0) return
+
+  const closingParenIndex = getClosingBracket(" " + actionCallCont, "(", ")", 0) // this function is cursed...
+  if (closingParenIndex < 0) return
+
+  const fileWideParenFrom = fileWideActionNameEnd + openParenIndex
+  const fileWideParenTo = fileWideActionNameEnd + closingParenIndex
+
+  // empty positional parameters
+  if (fileWideParenTo - fileWideParenFrom <= "()".length) return
+
+  const openParameterObjectBracketIndex = actionCallCont.slice(openParenIndex).match(/(?<=^\s*)\{/)?.index ?? -1
+  if (actionCallCont.slice(1).trimStart()[0] === "{") {
+    // parameter object → positional parameters
+
+    const closingParameterObjectBracketIndex = getClosingBracket(actionCallCont, "{", "}", 0)
+    if (closingParameterObjectBracketIndex < 0) return
+
+    const fileWideParameterObjectFrom = fileWideParenFrom + openParameterObjectBracketIndex
+    const fileWideParameterObjectTo = fileWideParenFrom + closingParameterObjectBracketIndex
+
+    actions.push({
+      label: "Transform object into positional parameters",
+      position: fileWideActionNameStart,
+      run() {
+        const parameterObject = state.doc.sliceString(fileWideParameterObjectFrom, fileWideParameterObjectTo)
+        const parameters = parseParameterObjectContent(parameterObject, 0)
+
+        const argumentList = completion.parameter_keys
+          .map((key, index) => parameters[key] ?? completion.parameter_defaults[index])
+          .join(", ")
+
+        view.dispatch(
+          view.state.update({
+            changes: {
+              from: fileWideParenFrom,
+              to: fileWideParenTo,
+              insert: `(${ argumentList })`
+            }
+          })
+        )
+      }
+    })
+  } else {
+    // positional parameters → parameter object
+
+    actions.push({
+      label: "Transform parameters into a parameter object",
+      position: fileWideActionNameStart,
+      run() {
+        const args = splitArgumentsString(state.doc.sliceString(fileWideParenFrom + 1, fileWideParenTo - 1))
+
+        // TODO(netux): indent according to "Autocomplete parameter objects → Minimum newline length"
+
+        const parameterObject = `{ ${ args
+          .map((value, index) => `${ completion.parameter_keys[index] }: ${ value.trim() }`)
+          .join(", ") } }`
+
+        view.dispatch(
+          view.state.update({
+            changes: {
+              from: fileWideParenFrom,
+              to: fileWideParenTo,
+              insert: `(${ parameterObject })`
+            }
+          })
+        )
+      }
+    })
+  }
+
+  return actions
+}

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.js
@@ -81,16 +81,20 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
         const indent = "\t".repeat(getIndentForLine(state, cursorFrom, cursorFrom))
 
         let parameterObject = "{"
+        
         if (isMultiLine) parameterObject += "\n"
         else parameterObject += " "
+        
         parameterObject += args
           .map((value, index) => {
             const keyValue = `${ completion.parameter_keys[index] }: ${ value.trim() }`
             return (isMultiLine ? (indent + "\t") : "") + keyValue
           })
           .join(",\n")
+
         if (isMultiLine) parameterObject += "\n" + indent
         else parameterObject += " "
+        
         parameterObject += "}"
 
         view.dispatch(

--- a/app/javascript/src/lib/codeActions.js
+++ b/app/javascript/src/lib/codeActions.js
@@ -1,0 +1,96 @@
+import { Decoration, ViewPlugin, ViewUpdate, WidgetType } from "@codemirror/view"
+
+/**
+ * @typedef CodeAction
+ * @property {number} position
+ * @property {string} label
+ * @property {Function} run
+ */
+
+/**
+ * @typedef {(update: ViewUpdate) => CodeAction[]} CodeActionProvider
+ */
+
+class CodeActionLightBulbWidget extends WidgetType {
+  constructor(actions) {
+    super()
+
+    this.actions = actions
+  }
+
+  toDOM() {
+    const container = document.createElement("span")
+    container.className = "button cm-codeActionsLightbulb"
+    container.textContent = "💡"
+
+    const dropdown = document.createElement("select")
+    dropdown.className = "cm-codeActionsLightbulb__dropdown"
+    container.appendChild(dropdown)
+
+    const blankOption = document.createElement("option")
+    blankOption.style.display = "none"
+    dropdown.appendChild(blankOption)
+
+    for (let actionIndex = 0; actionIndex < this.actions.length; actionIndex++) {
+      const action = this.actions[actionIndex]
+
+      const option = document.createElement("option")
+      option.value = actionIndex.toString()
+      option.text = action.label
+      dropdown.appendChild(option)
+    }
+
+    container.addEventListener("click", () => dropdown.click())
+    dropdown.addEventListener("change", (event) => {
+      const actionIndex = parseInt(event.target.value, 10)
+      const action = this.actions[actionIndex]
+
+      action.run()
+    })
+
+    return container
+  }
+}
+
+function createLightBulbDecoration(position, actions) {
+  return Decoration.widget({
+    widget: new CodeActionLightBulbWidget(actions),
+    side: -1, // -1 for left, 1 for right
+    block: false
+  }).range(position)
+}
+
+/**
+ * @param {CodeActionProvider[]} providers
+ */
+export function codeActions(providers) {
+  return ViewPlugin.fromClass(class {
+    constructor(_view) {
+      this.decorations = Decoration.none
+    }
+
+    /**
+     * @param {ViewUpdate} update
+     */
+    update(update) {
+      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+        this.decorations = Decoration.none
+
+        const actions = providers
+          .map((provider) => provider(update) ?? [])
+          .flat()
+
+        if (actions.length > 0) {
+          const { from } = update.state.selection.main
+          const decorationPosition = actions.reduce((position, action) => Math.min(action.position ?? Infinity, position), from)
+
+          this.decorations = Decoration.set([
+            createLightBulbDecoration(decorationPosition, actions)
+          ])
+        }
+      }
+    }
+  }, {
+    decorations: (extension) => extension.decorations
+  })
+}

--- a/app/javascript/src/lib/codeActions.js
+++ b/app/javascript/src/lib/codeActions.js
@@ -20,11 +20,11 @@ class CodeActionLightBulbWidget extends WidgetType {
 
   toDOM() {
     const container = document.createElement("span")
-    container.className = "button cm-codeActionsLightbulb"
+    container.className = "button code-actions-lightbulb"
     container.textContent = "💡"
 
     const dropdown = document.createElement("select")
-    dropdown.className = "cm-codeActionsLightbulb__dropdown"
+    dropdown.className = "code-actions-lightbulb__dropdown"
     container.appendChild(dropdown)
 
     const blankOption = document.createElement("option")

--- a/app/javascript/src/lib/codeActions.js
+++ b/app/javascript/src/lib/codeActions.js
@@ -73,22 +73,22 @@ export function codeActions(providers) {
      * @param {ViewUpdate} update
      */
     update(update) {
-      if (update.docChanged || update.selectionSet || update.viewportChanged) {
-        this.decorations = Decoration.none
+      if (!(update.docChanged || update.selectionSet || update.viewportChanged))
+      
+      this.decorations = Decoration.none
 
-        const actions = providers
-          .map((provider) => provider(update) ?? [])
-          .flat()
+      const actions = providers
+        .map((provider) => provider(update) ?? [])
+        .flat()
 
-        if (actions.length > 0) {
-          const { from } = update.state.selection.main
-          const decorationPosition = actions.reduce((position, action) => Math.min(action.position ?? Infinity, position), from)
+      if (!actions.length) return
+      
+      const { from } = update.state.selection.main
+      const decorationPosition = actions.reduce((position, action) => Math.min(action.position ?? Infinity, position), from)
 
-          this.decorations = Decoration.set([
-            createLightBulbDecoration(decorationPosition, actions)
-          ])
-        }
-      }
+      this.decorations = Decoration.set([
+        createLightBulbDecoration(decorationPosition, actions)
+      ])
     }
   }, {
     decorations: (extension) => extension.decorations

--- a/app/javascript/src/lib/codeActions.js
+++ b/app/javascript/src/lib/codeActions.js
@@ -73,8 +73,8 @@ export function codeActions(providers) {
      * @param {ViewUpdate} update
      */
     update(update) {
-      if (!(update.docChanged || update.selectionSet || update.viewportChanged))
-      
+      if (!(update.docChanged || update.selectionSet || update.viewportChanged)) return
+
       this.decorations = Decoration.none
 
       const actions = providers
@@ -82,7 +82,7 @@ export function codeActions(providers) {
         .flat()
 
       if (!actions.length) return
-      
+
       const { from } = update.state.selection.main
       const decorationPosition = actions.reduce((position, action) => Math.min(action.position ?? Infinity, position), from)
 

--- a/app/javascript/src/utils/codemirror/indent.js
+++ b/app/javascript/src/utils/codemirror/indent.js
@@ -1,4 +1,4 @@
-import { EditorSelection, Transaction } from "@codemirror/state"
+import { EditorSelection } from "@codemirror/state"
 
 /**
  * Indent on using tab with special conditions. Indent is reversed while holding shift
@@ -50,10 +50,10 @@ export function tabIndent({ state, dispatch }, event) {
       const fromModifier = line.from === from ? 0 : (insert.search(/\S/) - leadingWhitespaceLength - (from === to ? 1: 0))
       const toModifier = insert.length - originalLength
       const reverseSelection = state.selection.main.head === to
-      
+
       let range = EditorSelection.range(to + toModifier, from + fromModifier)
       if (reverseSelection) range = EditorSelection.range(from + fromModifier, to + toModifier)
-      
+
       return {
         changes: { from: line.from, to, insert },
         range
@@ -68,7 +68,7 @@ export function tabIndent({ state, dispatch }, event) {
 }
 
 /**
- * Fine the number of indents of a given line number.
+ * Find the number of indents of a given line number.
  * @param {Object} state CodeMirror editor state
  * @param {Number} line CodeMirror line number
  * @param {Number} charLimit Max characters given in the text

--- a/app/javascript/src/utils/compiler/parameterObjects.js
+++ b/app/javascript/src/utils/compiler/parameterObjects.js
@@ -28,6 +28,27 @@ export function evaluateParameterObjects(joinedItems) {
 }
 
 /**
+ * Obtain a JavaScript Object out of the string contents of a parameter object
+ *
+ * @param {string} innerContent Content inside the parameter object's curly braces
+ * @returns {Object}
+ */
+export function parseParameterObjectContent(innerContent) {
+  const splitParameters = splitArgumentsString(innerContent)
+  const result = {}
+
+  splitParameters.forEach(item => {
+    let [key, value] = item.split(/:(.*)/s)
+    key = key.replace(/\[linemarker\].*?\[\/linemarker\]/, "").trim()
+    value = (value || "").trim()
+    if (!key) return
+    result[key] = value
+  })
+
+  return result
+}
+
+/**
  * Find the first matching parameter object in a given string. Parameter objects are a special format that allow the user to give only specific sets of parameters rather than having to write them all out.
  * @param {string} content Content to search for parameter objects in.
  * @param {*} startFromIndex Skip over previous results. This is used when the regex format was found without matches phrases to skip over previous results.
@@ -47,17 +68,8 @@ export function getFirstParameterObject(content, startFromIndex = 0) {
   const start = match.index + match[0].indexOf("{")
   const phrase = getPhraseFromIndex(content, match.index)
   const completion = get(completionsMap).find(item => item.args_length && item.label.replace(" ", "") === phrase.replace(" ", ""))
-  const string = content.slice(match.index + match[0].length, end).trim()
-  const splitParameters = splitArgumentsString(string)
-  const given = {}
-
-  splitParameters.forEach(item => {
-    let [key, value] = item.split(/:(.*)/s)
-    key = key.replace(/\[linemarker\].*?\[\/linemarker\]/, "").trim()
-    value = (value || "").trim()
-    if (!key) return
-    given[key] = value
-  })
+  const innerContent = content.slice(match.index + match[0].length, end).trim()
+  const given = parseParameterObjectContent(innerContent)
 
   const result = { start: start + startFromIndex, end: end + startFromIndex, given }
 

--- a/spec/javascript/utils/compiler/parameterObjects.test.js
+++ b/spec/javascript/utils/compiler/parameterObjects.test.js
@@ -1,4 +1,4 @@
-import { getFirstParameterObject, replaceParameterObject, evaluateParameterObjects } from "../../../../app/javascript/src/utils/compiler/parameterObjects"
+import { getFirstParameterObject, replaceParameterObject, evaluateParameterObjects, parseParameterObjectContent } from "../../../../app/javascript/src/utils/compiler/parameterObjects"
 import { completionsMap } from "../../../../app/javascript/src/stores/editor"
 import { disregardWhitespace } from "../../helpers/text"
 
@@ -91,6 +91,28 @@ describe("parameterObjects.js", () => {
       }
 
       expect(getFirstParameterObject(content)).toEqual(expected)
+    })
+  })
+
+  describe("parseParameterObjectContent", () => {
+    test("Should convert the string contents of a parameter object into a JS object", () => {
+      const content = "One:    10,\n\tThree: 20    ,\n"
+      const expected = {
+        One: "10",
+        Three: "20"
+      }
+
+      expect(parseParameterObjectContent(content)).toEqual(expected)
+    })
+
+    test("Should ignore [linemarker]s", () => {
+      const content = "[linemarker]itemID|1[/linemarker]\tOne: 10,\n[linemarker]itemID|2[/linemarker]\tThree: 20,\n[linemarker]itemID|3[/linemarker]"
+      const expected = {
+        One: "10",
+        Three: "20"
+      }
+
+      expect(parseParameterObjectContent(content)).toEqual(expected)
     })
   })
 


### PR DESCRIPTION
## Code Actions

Similar to VSCode's code actions, add a lighbulb icon near the user's cursor that can be clicked to select refactor actions[1] in the code

![Lightbulb](https://github.com/Mitcheljager/workshop.codes/assets/6181929/30df88ca-0f3f-47c5-b5ed-b882f2148939)
![Lightbulb dropdown open](https://github.com/Mitcheljager/workshop.codes/assets/6181929/db848a2a-5627-44b7-8ab8-02cc81640d7d)

[1]: In reality, these are not limited to code refactors, but are meant for it anyway

## Transform parameter objects into positional parameters (and vice-versa) code action provider

As the name implies, they convert action arguments to be in one form or the other. E.g. `{ Param 1: value1, Param 2: value2 }` → `(value1, value2)`.

Takes into consideration parameter order and "autocomplete-min-parameter-newlines" for multi-line parameter objects


https://github.com/Mitcheljager/workshop.codes/assets/6181929/932eb9ce-b257-4087-8474-66a30eeb4263


Fixes #437 