### PR TITLE
refactor: Import metric graphics charts async

### DIFF
--- a/app/javascript/src/chart.js
+++ b/app/javascript/src/chart.js
@@ -1,6 +1,3 @@
-import { curveStep } from  "d3"
-import * as MG from "metrics-graphics"
-
 export function render() {
   const charts = document.querySelectorAll("[data-role='chart']")
 
@@ -9,7 +6,10 @@ export function render() {
   })
 }
 
-export default function createChart(element, data, dateformat = "%Y-%m-%d") {
+export default async function createChart(element, data, dateformat = "%Y-%m-%d") {
+  const { curveStep } = await import("d3")
+  const MG = await import("metrics-graphics")
+
   element.innerHTML = ""
 
   let processedMarkers = []


### PR DESCRIPTION
A large part of the logged in user specific JS is made up of these charts. Most users will not see this as it only shows when looking at analytics. So to reduce the file size of that entry this commit changes the imports to be fetched async when creating the charts.

This reduces logged-in-user.js from 826kb (270kb gzipped) to 369kb (123kb gzipped)