### PR TITLE
fix(editor): Prevent splitting each on commas in strings

### DIFF
--- a/app/javascript/src/utils/parse.js
+++ b/app/javascript/src/utils/parse.js
@@ -131,3 +131,19 @@ export function matchAllOutsideRanges(ranges, content, regex) {
   }
   return matches
 }
+
+export function getCommasIndexesOutsideQuotes(string) {
+  const commaIndexes = []
+
+  let insideQuotes = false
+
+  for (let i = 0; i < string.length; i++) {
+    if (string[i] === "\"" || string[i] === "'") {
+      insideQuotes = !insideQuotes
+    } else if ((string[i] === "," || string[i] === ",") && !insideQuotes) {
+      commaIndexes.push(i)
+    }
+  }
+
+  return commaIndexes
+}

--- a/app/javascript/src/utils/parse.js
+++ b/app/javascript/src/utils/parse.js
@@ -134,15 +134,13 @@ export function matchAllOutsideRanges(ranges, content, regex) {
 
 export function getCommasIndexesOutsideQuotes(string) {
   const commaIndexes = []
-
-  let insideQuotes = false
+  const stringRanges = findRangesOfStrings(string)
 
   for (let i = 0; i < string.length; i++) {
-    if (string[i] === "\"" || string[i] === "'") {
-      insideQuotes = !insideQuotes
-    } else if ((string[i] === "," || string[i] === ",") && !insideQuotes) {
-      commaIndexes.push(i)
-    }
+    if (!(string[i] === "," || string[i] === ",")) continue
+
+    const withinStringRange = stringRanges.some(([start, end]) => i > start && i < end)
+    if (!withinStringRange) commaIndexes.push(i)
   }
 
   return commaIndexes

--- a/app/javascript/test/utils/compiler/each.test.js
+++ b/app/javascript/test/utils/compiler/each.test.js
@@ -143,5 +143,11 @@ describe("for.js", () => {
       const expected = ["1", "2", "3"]
       expect(parseArrayValues(input)).toEqual(expected)
     })
+
+    it("Should ignore commas in within qoutes", () => {
+      // eslint-disable-next-line quotes
+      expect(parseArrayValues('"Some string", "Some, string", "Some third string"')).toEqual(['"Some string"', '"Some, string"', '"Some third string"'])
+      expect(parseArrayValues("'Some string', 'Some, string', 'Some third string'")).toEqual(["'Some string'", "'Some, string'", "'Some third string'"])
+    })
   })
 })

--- a/app/javascript/test/utils/compiler/each.test.js
+++ b/app/javascript/test/utils/compiler/each.test.js
@@ -147,7 +147,6 @@ describe("for.js", () => {
     it("Should ignore commas in within qoutes", () => {
       // eslint-disable-next-line quotes
       expect(parseArrayValues('"Some string", "Some, string", "Some third string"')).toEqual(['"Some string"', '"Some, string"', '"Some third string"'])
-      expect(parseArrayValues("'Some string', 'Some, string', 'Some third string'")).toEqual(["'Some string'", "'Some, string'", "'Some third string'"])
     })
   })
 })

--- a/app/javascript/test/utils/compiler/each.test.js
+++ b/app/javascript/test/utils/compiler/each.test.js
@@ -147,6 +147,7 @@ describe("for.js", () => {
     it("Should ignore commas in within qoutes", () => {
       // eslint-disable-next-line quotes
       expect(parseArrayValues('"Some string", "Some, string", "Some third string"')).toEqual(['"Some string"', '"Some, string"', '"Some third string"'])
+      expect(parseArrayValues("\"Some string\", \"Some, string\", \"Some third string\"")).toEqual(["\"Some string\"", "\"Some, string\"", "\"Some third string\""])
     })
   })
 })

--- a/app/javascript/test/utils/parse.test.js
+++ b/app/javascript/test/utils/parse.test.js
@@ -149,13 +149,11 @@ describe("parse.js", () => {
 
   describe("getCommasIndexOutsideQoutes", () => {
     it("Should return the indexes of commas in a string that are not without qoutes", () => {
-      expect(getCommasIndexesOutsideQuotes("1, 2, \"3, 4\", 5")).toEqual([1, 4, 12])
-      expect(getCommasIndexesOutsideQuotes("1, 2, '3, 4', 5")).toEqual([1, 4, 12])
+      expect(getCommasIndexesOutsideQuotes("1, 2, \"3, 4\", 5, 6")).toEqual([1, 4, 12, 15])
     })
 
     it("Should return an empty array if no valid commas are found", () => {
       expect(getCommasIndexesOutsideQuotes("1 2 3 4 5")).toEqual([])
-      expect(getCommasIndexesOutsideQuotes("1 2 '3, 4' 5")).toEqual([])
     })
 
     it("Should return an empty array no input was given", () => {

--- a/app/javascript/test/utils/parse.test.js
+++ b/app/javascript/test/utils/parse.test.js
@@ -1,4 +1,4 @@
-import { getClosingBracket, getPhraseEnd, getPhraseFromPosition, getSettings, removeSurroundingParenthesis, replaceBetween, splitArgumentsString } from "@utils/parse"
+import { getClosingBracket, getPhraseEnd, getPhraseFromPosition, getSettings, removeSurroundingParenthesis, replaceBetween, splitArgumentsString, getCommasIndexesOutsideQuotes } from "@utils/parse"
 import { describe, it, expect } from "vitest"
 
 describe("parse.js", () => {
@@ -144,6 +144,22 @@ describe("parse.js", () => {
 
     it("should remove only the outermost pair of surrounding parentheses", () => {
       expect(removeSurroundingParenthesis("((Test), word)")).toBe("(Test), word")
+    })
+  })
+
+  describe("getCommasIndexOutsideQoutes", () => {
+    it("Should return the indexes of commas in a string that are not without qoutes", () => {
+      expect(getCommasIndexesOutsideQuotes("1, 2, \"3, 4\", 5")).toEqual([1, 4, 12])
+      expect(getCommasIndexesOutsideQuotes("1, 2, '3, 4', 5")).toEqual([1, 4, 12])
+    })
+
+    it("Should return an empty array if no valid commas are found", () => {
+      expect(getCommasIndexesOutsideQuotes("1 2 3 4 5")).toEqual([])
+      expect(getCommasIndexesOutsideQuotes("1 2 '3, 4' 5")).toEqual([])
+    })
+
+    it("Should return an empty array no input was given", () => {
+      expect(getCommasIndexesOutsideQuotes("")).toEqual([])
     })
   })
 })


### PR DESCRIPTION
`@each` would incorrect split on commas inside of quotes. So `["Thing", "Some, thing"]` would be output as `["\"Thing\"", "\"Some,", "thing\""]`

This PR fixes that by checking all the valid commas before parsing the array, and if the given comma is not in the valid commas, skip that iteration.