### PR TITLE
feat(editor): Add intends to line wrapping

### DIFF
--- a/app/javascript/scss/editor/_codemirror-6.scss
+++ b/app/javascript/scss/editor/_codemirror-6.scss
@@ -269,4 +269,20 @@
     left: 0;
     opacity: 0;
   }
+
+}
+
+.indented-wrapped-line {
+  margin-left: calc(var(--indented));
+  text-indent: calc(-1 * var(--indented));
+
+  &.cm-activeLine {
+    box-shadow: calc((-1 * var(--indented)) + 4px) 0 0 rgba($white, 0.025)
+  }
+
+  &.cm-indent-markers {
+    &::before {
+      left: calc(var(--indented) * -1);
+    }
+  }
 }

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -89,8 +89,7 @@
           transformParameterObjectsIntoPositionalParameters
         ]),
         foldBrackets(),
-        ...($settings["word-wrap"] ? [EditorView.lineWrapping] : []),
-        indentedLineWrap
+        ...($settings["word-wrap"] ? [EditorView.lineWrapping, indentedLineWrap] : [])
       ]
     })
   }

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -20,6 +20,7 @@
   import { getPhraseFromPosition } from "@utils/parse"
   import { tabIndent, autoIndentOnEnter, indentMultilineInserts, pasteIndentAdjustments } from "@utils/codemirror/indent"
   import { get } from "svelte/store"
+  import { indentedLineWrap } from "@utils/codemirror/indentedLineWrap"
   import debounce from "@src/debounce"
 
   const dispatch = createEventDispatcher()
@@ -88,7 +89,8 @@
           transformParameterObjectsIntoPositionalParameters
         ]),
         foldBrackets(),
-        ...($settings["word-wrap"] ? [EditorView.lineWrapping] : [])
+        ...($settings["word-wrap"] ? [EditorView.lineWrapping] : []),
+        indentedLineWrap
       ]
     })
   }

--- a/app/javascript/src/utils/codemirror/indentedLineWrap.js
+++ b/app/javascript/src/utils/codemirror/indentedLineWrap.js
@@ -1,0 +1,46 @@
+// Adapted from https://github.com/fonsp/Pluto.jl/blob/eb85b0d34b05ee02e61c0316e6f2ea901afe9ab4/frontend/components/CellInput/awesome_line_wrapping.js
+
+import { EditorView, Decoration } from "@codemirror/view"
+import { StateField } from "@codemirror/state"
+
+export const getStartTabs = (line) => /^\t*/.exec(line)?.[0] ?? ""
+
+const getDecorations = (state) => {
+  const decorations = []
+
+  for (let i = 0; i < state.doc.lines; i ++) {
+    const line = state.doc.line(i + 1)
+    const numberOfTabs = getStartTabs(line.text).length
+    if (numberOfTabs === 0) continue
+
+    const offset = numberOfTabs * state.tabSize
+
+    const linerwapper = Decoration.line({
+      attributes: {
+        style: `--indented: ${offset}ch;`,
+        class: "indented-wrapped-line"
+      }
+    })
+
+    decorations.push(linerwapper.range(line.from, line.from))
+  }
+
+  return Decoration.set(decorations)
+}
+
+/**
+ * Plugin that makes line wrapping in the editor respect the identation of the line.
+ * It does this by adding a line decoration that adds margin-left (as much as there is indentation),
+ * and adds the same amount as negative "text-indent". The nice thing about text-indent is that it
+ * applies to the initial line of a wrapped line.
+ */
+export const indentedLineWrap = StateField.define({
+  create(state) {
+    return getDecorations(state)
+  },
+  update(deco, tr) {
+    if (!tr.docChanged) return deco
+    return getDecorations(tr.state)
+  },
+  provide: (f) => EditorView.decorations.from(f)
+})


### PR DESCRIPTION
Word wrapping did not respect indents, making it hard to use in some situations. This PR adds indents to word wrapping by using a modified version of https://github.com/fonsp/Pluto.jl/blob/eb85b0d34b05ee02e61c0316e6f2ea901afe9ab4/frontend/components/CellInput/awesome_line_wrapping.js. That file is meant for React and uses Lodash, which I've replaced.

This plugin also didn't account for the indent markers or for the highlighted line, which had to be indented negatively to make up for the indent of the entire line.

Perhaps there's a world where this could be an additional toggleable option, but I think for now this is what most people would want from word wrapping (it's what VSCode does by default).

Before | After
--- | ---
![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/49ce323a-da75-4902-b5b5-68bf13899c06) | ![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/068f4107-8504-4056-b931-9188a15b44f2)

