### PR TITLE
Increase Discord icon visibility in nav bar

### DIFF
--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -18,8 +18,7 @@
 
 .navigation__item {
   --color: #{$text-color-lightest};
-  --discord-drop-shadow-color: #{rgba($text-color-lightest, 0.4)};
-
+  --discord-drop-shadow-color: var(--color);
   display: block;
   margin-bottom: $margin * 0.25;
   border-radius: $border-radius * 0.5;

--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -79,7 +79,12 @@
 
   &--discord {
     display: flex;
-    color: $discord;
+
+    @include media-min(mbl) {
+      :not(.wiki) & {
+        color: $discord;
+      }
+    }
 
     &:hover {
       color: $discord;

--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -18,6 +18,8 @@
 
 .navigation__item {
   --color: #{$text-color-lightest};
+  --discord-drop-shadow-color: #{rgba($text-color-lightest, 0.4)};
+
   display: block;
   margin-bottom: $margin * 0.25;
   border-radius: $border-radius * 0.5;
@@ -67,6 +69,7 @@
 
   .wiki & {
     --color: #{$white};
+    --discord-drop-shadow-color: transparent;
   }
 
   svg {
@@ -83,6 +86,7 @@
     @include media-min(mbl) {
       :not(.wiki) & {
         color: $discord;
+        filter: drop-shadow(0 0 4px var(--discord-drop-shadow-color));
       }
     }
 


### PR DESCRIPTION
- On the wiki and mobile nav menu, use a white color scheme
    | On the wiki | On the mobile nav menu |
    | --- | --- |
    | ![on the wiki](https://github.com/Mitcheljager/workshop.codes/assets/6181929/659ab732-5c2f-4fbb-b012-ea0e2df1789a) | ![on the mobile nav menu](https://github.com/Mitcheljager/workshop.codes/assets/6181929/a8220efb-4158-4630-bd93-0bae3efb0d81) |
- Outside of that, simply add a slight white glow that makes the icon pop
    ![switching glow on and off](https://github.com/Mitcheljager/workshop.codes/assets/6181929/c38ebf28-647d-44e9-946f-8a17aef05d9a)


