### PR TITLE
Increase Discord icon visibility in nav bar, part 2

### DIFF
--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -91,10 +91,6 @@
     &:hover {
       color: $discord;
     }
-
-    .wiki & {
-      color: $white;
-    }
   }
 }
 

--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -18,6 +18,8 @@
 
 .navigation__item {
   --color: #{$text-color-lightest};
+  --discord-color: #{$discord};
+  --discord-drop-shadow: drop-shadow(0 0 4px #{$white});
   display: block;
   margin-bottom: $margin * 0.25;
   border-radius: $border-radius * 0.5;
@@ -67,6 +69,8 @@
 
   .wiki & {
     --color: #{$white};
+    --discord-color: #{$white};
+    --discord-drop-shadow: none;
   }
 
   svg {
@@ -79,7 +83,8 @@
 
   &--discord {
     display: flex;
-    color: $discord;
+    color: var(--discord-color);
+    filter: var(--discord-drop-shadow);
 
     &:hover {
       color: $discord;

--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -87,10 +87,6 @@
     display: flex;
     color: var(--discord-color);
     filter: var(--discord-drop-shadow);
-
-    &:hover {
-      color: $discord;
-    }
   }
 }
 

--- a/app/javascript/scss/elements/_navigation.scss
+++ b/app/javascript/scss/elements/_navigation.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .navigation {
   display: flex;
   flex-direction: column;
@@ -19,7 +21,7 @@
 .navigation__item {
   --color: #{$text-color-lightest};
   --discord-color: #{$discord};
-  --discord-drop-shadow: drop-shadow(0 0 4px #{$white});
+  --discord-drop-shadow: drop-shadow(0 0 4px #{color.change($white, $alpha: 0.2)});
   display: block;
   margin-bottom: $margin * 0.25;
   border-radius: $border-radius * 0.5;


### PR DESCRIPTION
Follow-up to #459 which apparently was broken.

I simplified the stylesheet by using more CSS variables, removed the hover color overwrite in the Wiki, and reduced the drop shadow effect in non-Wiki pages.