### PR TITLE
fix(editor): increase text-indent multiplier for word-wrapping indent in Chromium browsers

### DIFF
--- a/app/javascript/scss/editor/_codemirror-6.scss
+++ b/app/javascript/scss/editor/_codemirror-6.scss
@@ -273,8 +273,14 @@
 }
 
 .indented-wrapped-line {
+  --text-indent-multiplier: -1.5;
+
+  .is-firefox & {
+    --text-indent-multiplier: -1;
+  }
+
   margin-left: calc(var(--indented));
-  text-indent: calc(-1 * var(--indented));
+  text-indent: calc(var(--text-indent-multiplier) * var(--indented));
 
   &.cm-activeLine {
     box-shadow: calc((-1 * var(--indented)) + 4px) 0 0 rgba($white, 0.025)

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -40,6 +40,8 @@
   // Updates the tab title
   $: document.title = $currentProject?.title !== undefined ? `${$currentProject.title} | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
 
+  $: document.body.classList.toggle("is-firefox", navigator.userAgent.includes("Firefox"))
+
   onMount(async() => {
     loading = true
 


### PR DESCRIPTION
Turns out Chrome and Firefox handle negative indents differently. This fixes the duplicate indents in Chrome, while keeping the indents normal for Firefox.

~~This code assumes there are only two browser engines. Sorry Ladybird :(~~