### PR TITLE
feat(editor): Live inspector logs

### DIFF
--- a/app/javascript/scss/editor/_logs.scss
+++ b/app/javascript/scss/editor/_logs.scss
@@ -1,0 +1,45 @@
+.logs {
+  background: lighten($bg-darker, 5%);
+  height: calc(100% - var(--offset) - 4.5rem);
+  margin-top: $margin * 0.25;
+  border-radius: $border-radius;
+  overflow: auto;
+
+  @include styled-scrollbar();
+}
+
+.logs__scroller {
+  display: flex;
+  flex-direction: column;
+  gap: $margin * 0.125;
+  overflow-anchor: none;
+  min-height: 100.001%;
+  padding: $margin * 0.25;
+}
+
+.logs__anchor {
+  height: 1px;
+  overflow-anchor: auto;
+}
+
+.log {
+  flex: 0 0 auto;
+  background: $bg-darker;
+  border-radius: $border-radius;
+  padding: $margin * 0.125;
+  word-break: break-all;
+  overflow-anchor: none;
+
+  &:first-child {
+    margin-top: auto;
+  }
+}
+
+.log__timestamp {
+  font-size: $font-size-small;
+  color: $text-color-dark;
+}
+
+.log__content {
+  color: $text-color-light;
+}

--- a/app/javascript/scss/elements/_tabs.scss
+++ b/app/javascript/scss/elements/_tabs.scss
@@ -76,7 +76,7 @@
     color: $text-color-lightest;
 
     &::after {
-      background: $primary;
+      background: var(--primary, #{$primary});
       width: 100%;
       transition: width 50ms, background-color 50ms;
     }

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from "svelte"
+  import { onMount, tick } from "svelte"
   import { fly } from "svelte/transition"
   import { currentItem, currentProject, currentProjectUUID, recoveredProject, items, sortedItems, projects, isSignedIn, completionsMap, workshopConstants, isMobile, screenWidth, settings } from "@stores/editor"
   import { toCapitalize } from "@utils/text"
@@ -19,6 +19,7 @@
   import Logo from "@components/icon/Logo.svelte"
   import Bugsnag from "@components/Bugsnag.svelte"
   import EyeIcon from "@components/icon/Eye.svelte"
+  import Logs from "@components/Editor/Logs.svelte"
 
   export let bugsnagApiKey = ""
   export let _isSignedIn = false
@@ -28,6 +29,7 @@
   let userProjects = null
   let defaults = {}
   let loading = true
+  let currentSidebarTab = "wiki"
 
   $: if ($currentProject && $sortedItems?.length && $currentItem && !Object.keys($currentItem).length)
     $currentItem = $sortedItems.filter(i => i.type == "item")?.[0] || {}
@@ -235,7 +237,11 @@
         There could be more elegant solutions that use the CodeMirror API to update extensions,
         but this is the far more simple and readable solution. -->
         {#key $settings["word-wrap"]}
-          <CodeMirror on:search={({ detail }) => fetchArticle(`wiki/search/${detail}`, true)} />
+          <CodeMirror on:search={async({ detail }) => {
+            currentSidebarTab = "wiki"
+            await tick()
+            fetchArticle(`wiki/search/${detail}`, true)
+          }} />
         {/key}
 
         {#if isCurrentItemInherentlyHidden}
@@ -278,7 +284,16 @@
 
   {#if !$settings["hide-wiki-sidebar"]}
     <div class="editor__popout editor__scrollable" in:fly={$isMobile ? { y: 10, duration: 200 } : { x: 10, duration: 200 }}>
-      <EditorWiki bind:fetchArticle />
+      <div class="tabs bg-transparent p-0 mb-1/4">
+        <button class="tabs__item pt-1/8 pb-1/8 m-0 mr-1/4" class:tabs__item--active={currentSidebarTab === "wiki"} on:click={() => currentSidebarTab = "wiki"}>Wiki</button>
+        <button class="tabs__item pt-1/8 pb-1/8 m-0" class:tabs__item--active={currentSidebarTab === "logs"} on:click={() => currentSidebarTab = "logs"}>Live inspector logs</button>
+      </div>
+
+      {#if currentSidebarTab === "wiki"}
+        <EditorWiki bind:fetchArticle />
+      {:else}
+        <Logs />
+      {/if}
 
       <DragHandle key="popout-width" currentSize=300 align="left" />
     </div>

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -19,7 +19,7 @@
   import Logo from "@components/icon/Logo.svelte"
   import Bugsnag from "@components/Bugsnag.svelte"
   import EyeIcon from "@components/icon/Eye.svelte"
-  import Logs from "@components/Editor/Logs.svelte"
+  import Logs from "@components/editor/Logs.svelte"
 
   export let bugsnagApiKey = ""
   export let _isSignedIn = false

--- a/app/javascript/src/components/editor/Logs.svelte
+++ b/app/javascript/src/components/editor/Logs.svelte
@@ -76,13 +76,13 @@
 </script>
 
 <div bind:clientHeight={infoHeight}>
-  {#if supported}
-    {#if !directoryHandle}
-      <p>View inspector logs right from your browser, allowing you to more easily copy over values from the Workshop.</p>
-      <p>Use "Log To Inspector" to have the log appear here.</p>
-      <p>Make sure you have enabled "Enable Workshop Inspector Log File" in your Overwatch settings under "Settings &gt; Gameplay &gt; General &gt; Custom Games - Workshop".</p>
-    {/if}
+  {#if !directoryHandle}
+    <p>View inspector logs right from your browser, allowing you to more easily copy over values from the Workshop.</p>
+    <p>Use "Log To Inspector" to have the log appear here.</p>
+    <p>Make sure you have enabled "Enable Workshop Inspector Log File" in your Overwatch settings under "Settings &gt; Gameplay &gt; General &gt; Custom Games - Workshop".</p>
+  {/if}
 
+  {#if supported}
     <button class="button button--square w-100" class:button--dark={directoryHandle} on:click={openLogFile}>
       {directoryHandle ? "Change Workshop Log Directory" : "Select Workshop Log Directory"}
     </button>

--- a/app/javascript/src/components/editor/Logs.svelte
+++ b/app/javascript/src/components/editor/Logs.svelte
@@ -32,18 +32,17 @@
 
       if (!mostRecentFile) return
 
-      // If file is larger than 1MB it likely is not an inspector log, and processing it might prove fatal.
-      if (mostRecentFile.size > 1_000_000) {
-        entries = []
-        currentFileName = mostRecentFile.name
-        fileTooLarge = true
-        return
-      }
-
       // The most recent file has changed, mostly likely because a new lobby was opened. In this case we reset the logs.
       if (mostRecentFile.name !== currentFileName) {
         entries = []
         currentFileName = mostRecentFile.name
+        fileTooLarge = false
+      }
+
+      // If file is larger than 1MB it likely is not an inspector log, and processing it might prove fatal.
+      if (mostRecentFile.size > 1_000_000) {
+        fileTooLarge = true
+        return
       }
 
       if (new Date(fileLastModified).getTime() === new Date(mostRecentFile.lastModifiedDate).getTime()) return

--- a/app/javascript/src/components/editor/Logs.svelte
+++ b/app/javascript/src/components/editor/Logs.svelte
@@ -2,7 +2,7 @@
   import { onDestroy, onMount } from "svelte"
   import { getMostRecentFileFromDirectory } from "@utils/files"
 
-  const supported = "showOpenFilePicker" in self
+  const supported = "showDirectoryPicker" in self
 
   let interval
   let entries = []
@@ -86,6 +86,10 @@
     <button class="button button--square w-100" class:button--dark={directoryHandle} on:click={openLogFile}>
       {directoryHandle ? "Change Workshop Log Directory" : "Select Workshop Log Directory"}
     </button>
+
+    {#if !directoryHandle}
+      <p class="text-small"><em>By default the Workshop directory is found in "C:\Users\[username]\Documents\Overwatch\Workshop"</em></p>
+    {/if}
   {:else}
     <div class="warning br-1 mt-0">Your browser does not support this feature. Sorry :&#40;</div>
   {/if}

--- a/app/javascript/src/components/editor/Logs.svelte
+++ b/app/javascript/src/components/editor/Logs.svelte
@@ -1,0 +1,111 @@
+<script>
+  import { onDestroy, onMount } from "svelte"
+  import { getMostRecentFileFromDirectory } from "@utils/files"
+
+  const supported = "showOpenFilePicker" in self
+
+  let interval
+  let entries = []
+  let fileLastModified = null
+  let directoryHandle = null
+  let currentFileName = ""
+  let fileTooLarge = false
+  let infoHeight = 0
+  let element
+
+  onMount(() => {
+    element.scroll(0, 10000)
+  })
+
+  onDestroy(() => {
+    if (interval) clearInterval(interval)
+  })
+
+  async function openLogFile() {
+    directoryHandle = await window.showDirectoryPicker()
+
+    if (interval) clearInterval(interval)
+
+    interval = setInterval(async() => {
+      const mostRecentFile = await getMostRecentFileFromDirectory(directoryHandle)
+
+      if (!mostRecentFile) return
+
+      if (mostRecentFile.size > 1_000_000) {
+        entries = []
+        currentFileName = mostRecentFile.name
+        fileTooLarge = true
+        return
+      }
+
+      if (mostRecentFile.name !== currentFileName) {
+        entries = []
+        currentFileName = mostRecentFile.name
+      }
+
+      const text = await mostRecentFile.text()
+
+      if (new Date(fileLastModified).getTime() === new Date(mostRecentFile.lastModifiedDate).getTime()) return
+
+      fileLastModified = mostRecentFile.lastModifiedDate
+
+      const lines = text.split(/\n/).filter(Boolean)
+      entries = parseEntries(lines.slice(Math.max(lines.length - 100, 0))) // Last 100 entries
+    }, 1000)
+  }
+
+  function parseEntries(entries) {
+    const parsedEntries = []
+
+    entries.forEach(entry => {
+      const match = entry.match(/^\[(\d{2}:\d{2}:\d{2})\] (.*)$/)
+      if (!match) return
+
+      const [_, timestamp, content] = match
+      parsedEntries.push({ timestamp, content })
+    })
+
+    return parsedEntries
+  }
+</script>
+
+<div bind:clientHeight={infoHeight}>
+  {#if supported}
+    {#if !directoryHandle}
+      <p>View inspector logs right from your browser, allowing you to more easily copy over values from the Workshop.</p>
+      <p>Use "Log To Inspector" to have the log appear here.</p>
+      <p>Make sure you have enabled "Enable Workshop Inspector Log File" in your Overwatch settings under "Settings &gt; Gameplay &gt; General &gt; Custom Games - Workshop".</p>
+    {/if}
+
+    <button class="button button--square w-100" class:button--dark={directoryHandle} on:click={openLogFile}>
+      {directoryHandle ? "Change Workshop Log Directory" : "Select Workshop Log Directory"}
+    </button>
+  {:else}
+    <div class="warning br-1 mt-0">Your browser does not support this feature. Sorry :&#40;</div>
+  {/if}
+
+  {#if directoryHandle}
+    {#if currentFileName}
+      <p><em>Watching for logs in file "{directoryHandle.name}/{currentFileName}"</em></p>
+
+      {#if fileTooLarge}
+        <div class="warning br-1 mt-0">The log file is too large. Are you sure you selected the correct directory?</div>
+      {/if}
+    {:else}
+      <p><em>Watching for files in "{directoryHandle.name}"</em></p>
+    {/if}
+  {/if}
+</div>
+
+<div class="logs" style:--offset="{infoHeight}px" bind:this={element}>
+  <div class="logs__scroller">
+    {#each entries as { timestamp, content }}
+      <div class="log">
+        <div class="log__timestamp">{timestamp}</div>
+        <div class="log__content">{content}</div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="logs__anchor" />
+</div>

--- a/app/javascript/src/utils/files.js
+++ b/app/javascript/src/utils/files.js
@@ -1,0 +1,18 @@
+export async function getMostRecentFileFromDirectory(directoryHandle) {
+  let mostRecentFile = null
+  let mostRecentDate = new Date(0)
+
+  for await (const entry of directoryHandle.values()) {
+    if (entry.kind != "file") continue
+
+    const fileHandle = await directoryHandle.getFileHandle(entry.name)
+    const file = await fileHandle.getFile()
+
+    if (file.lastModifiedDate < mostRecentDate) continue
+
+    mostRecentDate = file.lastModifiedDate
+    mostRecentFile = file
+  }
+
+  return mostRecentFile
+}


### PR DESCRIPTION
This PR adds a new tab to the Wiki sidebar for live Inspector logs. Users can selector their Workshop inspector logs folder. The most recently edited file will be selected and it's text will be processed to show as log entries. This is useful for copying over data between the Workshop and the Editor. Take for example the position of a player, which requires a fair few clicks to copy over normally, where as now you can simply copy paste it. Log entries are created via the regular `Log To Inspector` function and requires no new syntax.

The directory picker uses `showDirectoryPicker` which is unfortunately not supported by all browsers. It is supported by Chrome, which of course is far and away our biggest users base. Unfortunately it does not work in Firefox :(

### Screenshots

#### Selecting the Workshop log file directory
![inspector-logs-select](https://github.com/Mitcheljager/workshop.codes/assets/12848235/9fbddc64-57ff-44e1-b0ab-4573d8ed99fa)

#### Moving around an environment and logging my position. At some point I restart my lobby and that is visible by the logs being cleared, indicating that the new file has been selected. Each server has their own log file.
![inspector-logs](https://github.com/Mitcheljager/workshop.codes/assets/12848235/066236ce-4ae1-49ec-a70a-c1f6f0f5e001)

#### When the browser does not support the API a message is shown.
![image](https://github.com/Mitcheljager/workshop.codes/assets/12848235/4ef71872-0e32-4b6a-a981-a170c2fc5b9f)
