### PR TITLE
refactor(svelte5): Use TS and Svelte 5 syntax for Notifications component

### DIFF
--- a/app/javascript/src/components/Notifications.svelte
+++ b/app/javascript/src/components/Notifications.svelte
@@ -1,5 +1,6 @@
-<script>
+<script lang="ts">
   import { onMount } from "svelte"
+  import { fly, scale } from "svelte/transition"
   import * as timeago from "timeago.js"
 
   import FetchRails from "@src/fetch-rails"
@@ -7,42 +8,52 @@
 
   import Bell from "@components/icon/Bell.svelte"
 
-  export let viewAllPath
+  interface Props { viewAllPath: string }
 
-  let active = false
-  let loading = true
+  const { viewAllPath = "" }: Props = $props()
+
+  let active = $state(false)
+  let animating = $state(false)
+  let loading = $state(true)
 
   onMount(() => {
     $notifications = []
     getUnreadCount()
   })
 
-  function getNotifications() {
-    active = true
+  async function getNotifications(): Promise<void> {
+    active = !active
+    if (active) animate()
 
-    setTimeout(() => { active = false }, 1000)
-
-    if (loading == false) return
+    if (!loading) return
 
     $notificationsCount = 0
 
-    new FetchRails("/unread-notifications").get()
-      .then(data => {
-        loading = false
-        $notifications = JSON.parse(data)
-      })
+    try {
+      const data = await new FetchRails("/unread-notifications").get()
+
+      $notifications = JSON.parse(data as string)
+    } finally {
+      loading = false
+    }
   }
 
-  function getUnreadCount() {
-    new FetchRails("/unread-notifications-count").get()
-      .then(data => $notificationsCount = parseInt(data))
+  async function getUnreadCount(): Promise<void> {
+    const data = await new FetchRails("/unread-notifications-count").get()
+
+    $notificationsCount = parseInt(data as string)
+  }
+
+  function animate(): void {
+    animating = true
+    setTimeout(() => { animating = false }, 1000)
   }
 </script>
 
-<div class="notifications dropdown lg-down:dropup mb-1/8 mbl:mb-0 mbl:mr-1/8" data-dropdown>
-  <button data-action="toggle-dropdown" aria-label="Notifications" on:click={getNotifications}>
+<div class="notifications dropdown lg-down:dropup mb-1/8 mbl:mb-0 mbl:mr-1/8">
+  <button data-action="toggle-dropdown" aria-label="Notifications" onclick={() => getNotifications()}>
     <div class="notifications__label">
-      <Bell animating={active} />
+      <Bell {animating} />
     </div>
 
     {#if $notificationsCount}
@@ -50,37 +61,39 @@
     {/if}
   </button>
 
-  <div class="dropdown__content dropdown__content--large pt-0" data-dropdown-content>
-    <div class="dropdown__header">
-      <h4 class="mt-0 mb-0">Notifications</h4>
+  {#if active}
+    <div class="dropdown__content dropdown__content--large active pt-0" transition:fly={{ y: 10, duration: 100 }}>
+      <div class="dropdown__header">
+        <h4 class="mt-0 mb-0">Notifications</h4>
 
-      <a href={viewAllPath} class="button button--link button--small" aria-label="View all notifications">View all</a>
-    </div>
-
-    {#if loading}
-      <span class="dropdown__item"><div class="spinner spinner--small mb-1/8" aria-live="polite" role="status"></div></span>
-    {/if}
-
-    {#each $notifications as notification}
-      <div class="notifications__item">
-        <small class="text-dark" title={notification.created_at}>
-          {timeago.format(notification.created_at)}
-        </small>
-
-        {@html notification.content}
-
-        {#if notification.go_to}
-          <a href={notification.go_to} class="button button--small button--thin button--dark mt-1/8">
-            View
-          </a>
-        {/if}
+        <a href={viewAllPath} class="button button--link button--small" aria-label="View all notifications">View all</a>
       </div>
-    {/each}
 
-    {#if !$notifications.length && !loading}
-      <small class="dropdown__item mt-1/8 text-base">
-        You have no unread notifications
-      </small>
-    {/if}
-  </div>
+      {#if loading}
+        <span class="dropdown__item"><div class="spinner spinner--small mt-1/8 mb-1/16" aria-live="polite" role="status"></div></span>
+      {/if}
+
+      {#each $notifications as notification}
+        <div class="notifications__item">
+          <small class="text-dark" title={notification.created_at}>
+            {timeago.format(notification.created_at)}
+          </small>
+
+          {@html notification.content}
+
+          {#if notification.go_to}
+            <a href={notification.go_to} class="button button--small button--thin button--dark mt-1/8">
+              View
+            </a>
+          {/if}
+        </div>
+      {/each}
+
+      {#if !$notifications.length && !loading}
+        <small class="dropdown__item mt-1/8 text-base">
+          You have no unread notifications
+        </small>
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/app/javascript/src/stores/notifications.ts
+++ b/app/javascript/src/stores/notifications.ts
@@ -1,3 +1,4 @@
+import type { Notification } from "@src/types/main"
 import { writable } from "svelte/store"
 
 export const notificationsCount = writable(0)

--- a/app/javascript/src/types/main.d.ts
+++ b/app/javascript/src/types/main.d.ts
@@ -4,5 +4,5 @@ export type Notification = {
   content: string,
   go_to: string,
   created_at: string,
-  updated_at: string,
+  updated_at: string
 }


### PR DESCRIPTION
This merges into #504 

This refactors the notifications component to use Svelte 5 and TS. With this also come some additional refactors. Previous the dropdown used the dropdown logic of the main site, showing and hiding with regular JS. This commit changes that by wrapping the content is an if statement, only rendering it when needed. This also allows us to add a little transition. Previous the `active` variable was used to animate the bell itself, and nothing but that. That variable is moved to the actual active state and a new variable `animating` is added to set the animating state.
Additionally I've changed the .then chains to more readable `async await`