### PR TITLE
refactor(svelte5): Use ts and Svelte 5 syntax for Alerts

### DIFF
--- a/app/javascript/src/components/Alert.svelte
+++ b/app/javascript/src/components/Alert.svelte
@@ -1,27 +1,25 @@
-<script>
-  import { onMount, onDestroy, createEventDispatcher } from "svelte"
+<script lang="ts">
+  import { onMount } from "svelte"
 
-  export let text = ""
-  export let type = ""
-  export let key = ""
+  interface Props { text: string, type: string, onclose: () => void }
+
+  const { text = "", type = "", onclose = () => null }: Props = $props()
 
   const timer = 5000
-  const dispatch = createEventDispatcher()
 
   let timeout
 
-  onMount(() => setTimeout(close, timer))
-  onDestroy(() => { if (timeout) clearTimeout(timeout) })
+  onMount(() => {
+    setTimeout(onclose, timer)
 
-  function close() {
-    dispatch("close", key)
-  }
+    return () => { if (timeout) clearTimeout(timeout) }
+  })
 </script>
 
-<div class="alert {type} static">
+<div class="alert {type} static" aria-atomic="true" aria-live={type === "error" ? "assertive" : "polite"}>
   <p class="m-0">{text}</p>
 
-  <button class="button p-0 pl-1/16 pr-1/16 text-white" on:click={close}>✕</button>
+  <button class="button p-0 pl-1/16 pr-1/16 text-white" onclick={() => onclose()} aria-label="Close alert">✕</button>
 
   <div class="alert__timer" style="--timer: {timer}ms"></div>
 </div>

--- a/app/javascript/src/components/Alerts.svelte
+++ b/app/javascript/src/components/Alerts.svelte
@@ -1,30 +1,43 @@
-<script>
+<script lang="ts">
   import Alert from "@components/Alert.svelte"
   import { slide } from "svelte/transition"
+  import { onMount } from "svelte"
 
-  // When alerts are passed from rails they are passed as a string
-  // that is an array of arrays shaped like [[type, text], [type, text]]
-  export let initialAlerts = ""
+  interface Props { initialAlerts?: string }
+  interface AlertEntry { text: string, type: string, key?: string }
 
-  let alerts = []
+  const { initialAlerts = "" }: Props = $props()
 
-  $: if (initialAlerts) JSON.parse(initialAlerts)?.forEach(([type, text]) => add({ text, type: `alert--${type}` }))
+  let alerts: AlertEntry[] = $state([])
 
-  function add(alert) {
-    alerts = [...alerts, { ...alert, key: Math.random() }]
+  onMount(() => {
+    if (initialAlerts) parseInitialAlerts()
+  })
+
+  /** When alerts are passed from Rails they are passed as a string
+   * that is an array of arrays shaped like [[type, text], [type, text]] */
+  function parseInitialAlerts(): void {
+    JSON.parse(initialAlerts).forEach(([type, text]: [string, string]) => {
+      add({ text, type: `alert--${type}` })
+    })
   }
 
-  function close(key) {
+  function add(alert: AlertEntry) {
+    const key = Math.random().toString()
+    alerts = [...alerts, { ...alert, key }]
+  }
+
+  function close(key: string) {
     alerts = alerts.filter((a) => a.key !== key)
   }
 </script>
 
-<svelte:window on:alert={({ detail }) => add(detail)} />
+<svelte:window onalert={({ detail }) => add(detail)} />
 
 <div class="alerts">
   {#each alerts as { text, type, key } (key)}
     <div transition:slide={{ duration: 200 }}>
-      <Alert {text} {type} {key} on:close={({ detail }) => close(detail)} />
+      <Alert {text} {type}  onclose={() => close(key!)} />
     </div>
   {/each}
 </div>

--- a/app/javascript/src/types/global.d.ts
+++ b/app/javascript/src/types/global.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  declare namespace svelteHTML {
+    interface HTMLAttributes {
+      "onalert"?: (event: CustomEvent) => void
+    }
+  }
+}
+
+export {}


### PR DESCRIPTION
This merges into #504 

This converts the Alert and Alerts component this TS and Svelte 5. With this I refactored the components a little to be more readable, hopefully anyway.

Similar to https://github.com/Mitcheljager/workshop.codes/pull/506, I added `onalert` on the global object as the event can be fired from anyway on the window object.