### PR TITLE
feat: remove elo hell references in copy

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -154,4 +154,4 @@
 
 <p>Please contact the third parties listed above individually if you would like to request that they delete any data, as deleting your account may not trigger a request or process resulting in the deletion of your data on third party platforms.</p>
 
-<p>If you cannot access your account, would like us to remove data not related to your account, or have further questions or comments, you may contact us via the #website-discussion channel in the <%= link_to "Elo Hell Workshops Discord", "https://discord.gg/DdxsQRD", target: "_blank", rel: "noreferrer noopener" %> or by any other means listed in the footer below.</p>
+<p>If you cannot access your account, would like us to remove data not related to your account, or have further questions or comments, you may contact us via the #wsc-discussion channel in the <%= link_to "Workshop.codes Discord", "https://discord.gg/DdxsQRD", target: "_blank", rel: "noreferrer noopener" %> or by any other means listed in the footer below.</p>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -16,7 +16,7 @@
           <%= tag.strong "You are not verified (?)", class: "cursor-pointer inline-block mt-1/2", data: { action: "toggle-content" } %>
           <div data-role="content-to-toggle snippet-container" style="display: none">
             <p>User names are not unique. A battletag can be the same for multiple users. Being verified helps users identify that you are indeed you. Furthermore if you are logged in with battle.net you will claim the url without the id. For example path/username#12345 will become path/username. The old url will also remain functional.</p>
-            <p>If you wish to be verified, please contact Mitsiee#9370 on Discord or @ me wherever you want on the Elo Hell Workshop Discord.</p>
+            <p>If you wish to be verified, please contact Mitsiee#9370 on Discord or @ me wherever you want on the Workshop.codes Discord.</p>
             <p>Please note: To be eligible for verification you need to have made a good number of contributions to the Workshop community. When contacting me please note why you wish to be verified.</p>
           </div>
         </small>


### PR DESCRIPTION
This PR removes outdated references to Elo Hell in the privacy policy and the verified user blurb