### PR TITLE
fix(editor compiler): correctly gen erate the arguments for the Custom String() replacing a @translate directive when compiling a singleLanguageOverride

### DIFF
--- a/app/javascript/src/utils/compiler/translations.ts
+++ b/app/javascript/src/utils/compiler/translations.ts
@@ -24,16 +24,15 @@ export function convertTranslations(joinedItems: string, singleLanguageOverride:
     const splitArguments = splitArgumentsString(argumentsString) || []
     const key = splitArguments[0].replaceAll("\"", "")
 
-    const eachLanguageStrings: string[] = []
-    get(selectedLanguages).forEach((language) => {
+    const genLanguageString = (language: Language): string => {
       const translation = getValueForLanguage(key, language)
-      eachLanguageStrings.push(`Custom String("${translation}"${splitArguments.length > 1 ? ", " : ""}${splitArguments.slice(1).join(", ")})`)
-    })
+      return `Custom String("${translation}"${splitArguments.length > 1 ? ", " : ""}${splitArguments.slice(1).join(", ")})`
+    }
 
     const replaceWith = singleLanguageOverride ?
-      `Custom String("${getValueForLanguage(key, singleLanguageOverride)}")` :
+      genLanguageString(singleLanguageOverride) :
       `Value In Array(
-      Array(${eachLanguageStrings.join(", ")}),
+      Array(${get(selectedLanguages).map((language) => genLanguageString(language)).join(", ")}),
       Max(False, Index Of Array Value(Global.WCDynamicLanguages, Custom String("{0}", Map(Practice Range), Null, Null)))
     )`
 

--- a/app/javascript/src/utils/compiler/translations.ts
+++ b/app/javascript/src/utils/compiler/translations.ts
@@ -24,15 +24,15 @@ export function convertTranslations(joinedItems: string, singleLanguageOverride:
     const splitArguments = splitArgumentsString(argumentsString) || []
     const key = splitArguments[0].replaceAll("\"", "")
 
-    const genLanguageString = (language: Language): string => {
+    const generateLanguageString = (language: Language): string => {
       const translation = getValueForLanguage(key, language)
       return `Custom String("${translation}"${splitArguments.length > 1 ? ", " : ""}${splitArguments.slice(1).join(", ")})`
     }
 
     const replaceWith = singleLanguageOverride ?
-      genLanguageString(singleLanguageOverride) :
+      generateLanguageString(singleLanguageOverride) :
       `Value In Array(
-      Array(${get(selectedLanguages).map((language) => genLanguageString(language)).join(", ")}),
+      Array(${get(selectedLanguages).map((language) => generateLanguageString(language)).join(", ")}),
       Max(False, Index Of Array Value(Global.WCDynamicLanguages, Custom String("{0}", Map(Practice Range), Null, Null)))
     )`
 


### PR DESCRIPTION
Very wordy title just to say `@translate("key", "a", "b", "c")` was being compiled to `Custom String("value of key")` without `"a"`, `"b"`, nor `"c"`.