### PR TITLE
fix(editor code actions): make transformParameterObjectsIntoPositionalParameters code action appear again

### DIFF
--- a/app/javascript/scss/editor/_codemirror-6.scss
+++ b/app/javascript/scss/editor/_codemirror-6.scss
@@ -386,6 +386,7 @@
     transform: translateX(-100%) translateY(-50%);
     opacity: 0.5;
     display: inline-block;
+    z-index: 201; // 1 more than .cm-gutter
   }
 
   .code-actions-lightbulb__dropdown {

--- a/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.ts
+++ b/app/javascript/src/lib/codeActionProviders/transformParameterObjectsIntoPositionalParameters.ts
@@ -17,7 +17,7 @@ export function transformParameterObjectsIntoPositionalParameters({ view, state 
   if (!line.text) return
 
   const phrase = getPhraseFromPosition(line, cursorFrom)
-  const completion = get(completionsMap).find(({ type, label }) => type === "function" && label === phrase.text)
+  const completion = get(completionsMap).find(({ type, label }) => type === "action" && label === phrase.text)
   if (!completion) return
 
   const fileWideActionNameStart = line.from + phrase.start


### PR DESCRIPTION
- Search for the correct completion type when calculating for which completion we should provide this code action
- Adjust z-index of lightbulb button to be +1 the z-index of the CodeMirror gutter