### PR TITLE
fix(editor linter): don't extract arguments from @translate() one character too short

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.ts
+++ b/app/javascript/src/lib/OWLanguageLinter.ts
@@ -292,7 +292,7 @@ function checkTranslations(content: string): void {
     const translateEndParenthesisIndex = getClosingBracket(content, "(", ")", translateStartParenthesisIndex - 1)
     if (translateEndParenthesisIndex === -1) continue
 
-    const translateArguments = splitArgumentsString(content.substring(translateStartParenthesisIndex + 1, translateEndParenthesisIndex - 1))
+    const translateArguments = splitArgumentsString(content.substring(translateStartParenthesisIndex + 1, translateEndParenthesisIndex))
     if (translateArguments.length === 0) continue
 
     if (!translateArguments[0].startsWith("\"") || !translateArguments[0].endsWith("\"")) {


### PR DESCRIPTION
Fixes erroneous diagnostics for the @translate()'s key argument type when @translate() takes no additional arguments