### PR TITLE
 feat(translations): Add static modifier to @translate 

### DIFF
--- a/app/javascript/src/components/editor/TranslationKeys/TranslationKeysEditStrings.svelte
+++ b/app/javascript/src/components/editor/TranslationKeys/TranslationKeysEditStrings.svelte
@@ -79,6 +79,13 @@
   Some translation &#123;0&#125; with an icon in the middle
 </code>
 
+<p class="text-small mb-0">
+  Include this key as a static string replacement using
+  <code style="color: var(--color-punctuation)">
+    <span style="color: var(--color-custom-keyword)">@translate</span><span style="color: var(--color-variable)">.static</span>(<span style="color: var(--color-string)">"{selectedKey}"</span>)
+  </code>
+</p>
+
 <hr class="mt-1/4 mb-1/4">
 
 {#if $translationKeys[selectedKey]}

--- a/app/javascript/src/lib/OWLanguageLinter.ts
+++ b/app/javascript/src/lib/OWLanguageLinter.ts
@@ -317,6 +317,15 @@ function checkTranslations(content: string): void {
       })
       continue
     }
+    if (translateArguments.length > 1 && isStatic) {
+      diagnostics.push({
+        from: match.index + match[0].length + translateArguments[0].length,
+        to: translateEndParenthesisIndex,
+        severity: "warning",
+        message: "Additional arguments in static translations will have no effect."
+      })
+      continue
+    }
 
     // Provide option to create translation key via linter
     const translateKey = translateArguments[0].substring(1, translateArguments[0].length - 1)

--- a/app/javascript/src/lib/OWLanguageLinter.ts
+++ b/app/javascript/src/lib/OWLanguageLinter.ts
@@ -315,7 +315,7 @@ function checkTranslations(content: string): void {
     }
 
     if (translateArguments.length > 1 && isStatic) {
-      const secondArgumentStart = translateArgumentsString.indexOf(translateArguments[1])
+      const secondArgumentStart = translateArgumentsString.indexOf(translateArguments[1], translateArguments[0].length)
 
       diagnostics.push({
         from: translateStartParenthesisIndex + secondArgumentStart + 1,

--- a/app/javascript/src/lib/OWLanguageLinter.ts
+++ b/app/javascript/src/lib/OWLanguageLinter.ts
@@ -244,10 +244,11 @@ function checkMixins(content: string): void {
 }
 
 function checkTranslations(content: string): void {
-  const regex = /(@translate)(\.static)?\s*\(/g
+  const regex = /(@translate(?<isStatic>\.static)?)\s*\(/g
+
   let match
   while ((match = regex.exec(content)) != null) {
-    const isStatic = !!match[2] // If `.static` is given
+    const isStatic = !!match.groups?.isStatic // If `.static` is given
 
     let walk = match.index
     let parenthesisBeforeAtIndex = -1

--- a/app/javascript/src/lib/OWLanguageLinter.ts
+++ b/app/javascript/src/lib/OWLanguageLinter.ts
@@ -315,8 +315,10 @@ function checkTranslations(content: string): void {
     }
 
     if (translateArguments.length > 1 && isStatic) {
+      const secondArgumentStart = translateArgumentsString.indexOf(translateArguments[1])
+
       diagnostics.push({
-        from: match.index + match[0].length + translateArguments[0].length,
+        from: translateStartParenthesisIndex + secondArgumentStart + 1,
         to: translateEndParenthesisIndex,
         severity: "warning",
         message: "Additional arguments in static translations will have no effect."

--- a/app/javascript/src/utils/compiler/compile.ts
+++ b/app/javascript/src/utils/compiler/compile.ts
@@ -28,10 +28,9 @@ export function compile(overrideContent = "", singleLanguageOverride = null): st
   joinedItems = evaluateForLoops(joinedItems)
   joinedItems = evaluateEachLoops(joinedItems)
   joinedItems = evaluateConditionals(joinedItems)
-  joinedItems = convertTranslations(joinedItems, singleLanguageOverride)
 
   const variables = compileVariables(joinedItems)
   const subroutines = compileSubroutines(joinedItems)
 
-  return settings + variables + subroutines + joinedItems
+  return convertTranslations(settings + variables + subroutines + joinedItems, singleLanguageOverride)
 }

--- a/app/javascript/src/utils/compiler/translations.ts
+++ b/app/javascript/src/utils/compiler/translations.ts
@@ -8,9 +8,50 @@ export function convertTranslations(joinedItems: string, singleLanguageOverride:
   if (!get(selectedLanguages)?.length) return joinedItems
   if (!Object.keys(get(translationKeys) || {})?.length) return joinedItems
 
-  // Find @translate in content and replace with given translation key
+  joinedItems = replaceStaticTranslationKeys(joinedItems, singleLanguageOverride)
+  joinedItems = replaceDynamicTranslationKeys(joinedItems, singleLanguageOverride)
+
+  if (singleLanguageOverride) return joinedItems
+
+  // Array with custom string for Practice Range in each selected language
+  const customStringArrayForEachLanguage = get(selectedLanguages).map(language => `Custom String("${languageOptions[language].detect}")`)
+  const rule = `
+  rule("Workshop.codes Editor Dynamic Language - Set Languages") {
+    event { Ongoing - Global; }
+    actions { Global.WCDynamicLanguages = Array(${customStringArrayForEachLanguage.join(", ")}); }
+  }`
+
+  return joinedItems + rule
+}
+
+/**
+ * Replace @translate.static("Key") with "Value". Always compiles to a single language.
+ */
+function replaceStaticTranslationKeys(joinedItems: string, singleLanguageOverride: Language | null): string {
+  const staticRegex = /@translate\.static\(/g
+
   let match
+  while ((match = staticRegex.exec(joinedItems)) != null) {
+    const closing = getClosingBracket(joinedItems, "(", ")", match.index + 1)
+    if (closing < 0) continue
+
+    const full = joinedItems.slice(match.index, closing + 1)
+    const key = full.slice(full.indexOf("(") + 1, full.lastIndexOf(")")).replaceAll("\"", "")
+    const translation = getValueForLanguage(key, singleLanguageOverride || get(selectedLanguages)[0])
+
+    joinedItems = replaceBetween(joinedItems, `"${translation}"`, match.index, match.index + full.length)
+  }
+
+  return joinedItems
+}
+
+/**
+ * Replace @translate("Key") with Custom String("Value"), either compiled to a single language or a with dynamic languages.
+ */
+function replaceDynamicTranslationKeys(joinedItems: string, singleLanguageOverride: Language | null): string {
   const regex = /@translate/g
+
+  let match
   while ((match = regex.exec(joinedItems)) != null) {
     const closing = getClosingBracket(joinedItems, "(", ")", match.index + 1)
     if (closing < 0) continue
@@ -39,17 +80,7 @@ export function convertTranslations(joinedItems: string, singleLanguageOverride:
     joinedItems = replaceBetween(joinedItems, replaceWith, match.index, match.index + full.length)
   }
 
-  if (singleLanguageOverride) return joinedItems
-
-  // Array with custom string for Practice Range in each selected language
-  const customStringArrayForEachLanguage = get(selectedLanguages).map(language => `Custom String("${languageOptions[language].detect}")`)
-  const rule = `
-  rule("Workshop.codes Editor Dynamic Language - Set Languages") {
-    event { Ongoing - Global; }
-    actions { Global.WCDynamicLanguages = Array(${customStringArrayForEachLanguage.join(", ")}); }
-  }`
-
-  return joinedItems + rule
+  return joinedItems
 }
 
 function getValueForLanguage(key: string, language: Language): string {

--- a/app/javascript/test/utils/compiler/translations.test.js
+++ b/app/javascript/test/utils/compiler/translations.test.js
@@ -118,5 +118,15 @@ describe("translations.js", () => {
 
       expect(convertTranslations(input, "en-US")).toBe(expectedOutput)
     })
+
+    it("Should convert static marked translations to regular strings", () => {
+      selectedLanguages.set(["en-US"])
+      translationKeys.set({ "Some Key": { "en-US": "Some Value" } })
+
+      const input = "test @translate.static(\"Some Key\")"
+      const expectedOutput = "test \"Some Value\""
+
+      expect(convertTranslations(input, "en-US")).toBe(expectedOutput)
+    })
   })
 })


### PR DESCRIPTION
@netux 

This adds a modifier for the `@translate` feature, allowing you to output a string directly, rather than `Custom String`. This is handy when compiling to a single language and using `@translate` in places it normally wouldn't work. One example of that is the description in settings.

Static keys can not have arguments, as that makes no sense. A linter was added for this.

![image](https://github.com/user-attachments/assets/62ca6dfd-66a6-4854-99ec-a5e5e8ece7bf)
![image](https://github.com/user-attachments/assets/8e699d9a-ac25-4209-9609-1653d6ba5ce2)
![image](https://github.com/user-attachments/assets/5c988e60-3f5e-4506-9573-e1cb33bd05d8)
![image](https://github.com/user-attachments/assets/661c12c3-2c9c-4d19-bd80-615346686ba0)
