### PR TITLE
feat(editor): fetch current not-owned projects, add project forking

### DIFF
--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -20,6 +20,7 @@
   import Bugsnag from "@components/Bugsnag.svelte"
   import EyeIcon from "@components/icon/Eye.svelte"
   import Logs from "@components/editor/Logs.svelte"
+  import { fetchProject } from "@src/utils/project"
 
   export let bugsnagApiKey = ""
   export let _isSignedIn = false
@@ -59,6 +60,12 @@
 
     loading = false
   })
+
+  $: if ($currentProjectUUID && $projects.some(({ uuid }) => uuid !== $currentProjectUUID)) {
+    fetchProject($currentProjectUUID).then((currentProject) => {
+      $projects.push(currentProject)
+    })
+  }
 
   function parseKeywords() {
     const { events, values, actions, constants, heroes, maps } = data

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -8,6 +8,7 @@
   import { onMount } from "svelte"
   import { fly } from "svelte/transition"
   import { flip } from "svelte/animate"
+  import { trimmed } from "@src/utils/text"
 
   let loading = false
   let active = false
@@ -71,7 +72,7 @@
     {#if loading}
       Loading...
     {:else}
-      {$currentProject?.title.substring(0, limit).trim() || "Select a project..."}{#if $currentProject?.title.length > limit}...{/if}
+      {trimmed($currentProject?.title, limit) || "Select a project..."}
     {/if}
   </button>
 

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -13,8 +13,10 @@
   let loading = false
   let active = false
   let showProjectSettings = false
-  let filteredProjects = $projects
+  let ownProjects = []
+  let filteredProjects = []
 
+  $: ownProjects = $projects.filter(({ is_owner }) => is_owner)
   $: limit = $isMobile ? 5 : 25
 
   onMount(() => {
@@ -22,7 +24,7 @@
     const uuid = urlParams.get("uuid")
 
     if (uuid) getProject(uuid)
-    else if ($projects.length) getProject($projects[0].uuid)
+    else if (ownProjects.length) getProject(ownProjects[0].uuid)
   })
 
   async function getProject(uuid) {
@@ -73,13 +75,16 @@
       Loading...
     {:else}
       {trimmed($currentProject?.title, limit) || "Select a project..."}
+      {#if $currentProject && !$currentProject.is_owner}
+        <small>(read-only)</small>
+      {/if}
     {/if}
   </button>
 
   {#if active}
     <div transition:fly={{ duration: 150, y: 20 }} use:escapeable on:escape={() => active = false} class="dropdown__content dropdown__content--left block w-100" style:min-width="200px">
       <div class="pl-1/8 pr-1/8">
-        <SearchObjects objects={$projects} bind:filteredObjects={filteredProjects} />
+        <SearchObjects objects={ownProjects} bind:filteredObjects={filteredProjects} />
       </div>
 
       <hr />
@@ -90,16 +95,16 @@
         </button>
       {/each}
 
-      {#if $projects?.length && !filteredProjects.length}
+      {#if ownProjects?.length && !filteredProjects.length}
         <em class="block text-dark text-small pl-1/8 pr-1/8">No projects match your search.</em>
       {/if}
 
-      {#if $projects?.length}
+      {#if ownProjects?.length}
         <hr />
       {/if}
 
       <div class="p-1/4">
-        {#if !$projects?.length}
+        {#if !ownProjects?.length}
           <em class="text-small block mb-1/4">Create a new project to get started.</em>
         {/if}
         <button class="button button--small w-100" on:click={() => {

--- a/app/javascript/src/utils/text.ts
+++ b/app/javascript/src/utils/text.ts
@@ -1,3 +1,8 @@
 export function toCapitalize(string: string): string {
   return string.toLowerCase().replace(/(^\w{1})|(\s+\w{1})/g, letter => letter.toUpperCase())
 }
+
+export function trimmed(string: string, limit: number, ellipsis = "..."): string {
+  if (!string || string.length <= limit) return string
+  return string.substring(limit - ellipsis.length) + ellipsis
+}


### PR DESCRIPTION
When viewing other people's projects, show a "Fork" button in place of the "Edit" button that would be present for owned projects.

![fork button next to an open project dropdown](https://github.com/user-attachments/assets/0d258feb-1c3c-4737-a21c-36e6323f05cc)

Also, ensure we have the name of the current project, even if not owned, by detecting when `$currentProjectUUID` is not present in `$projects`, then fetching and storing it.
