### PR TITLE
fix(editor linter): use forceLinting() instead of $currentItem.forceUpdate to rerun linter inside diagnostic action callback, patch lint plugin to support this

### DIFF
--- a/app/javascript/src/lib/OWLanguageLinter.ts
+++ b/app/javascript/src/lib/OWLanguageLinter.ts
@@ -1,9 +1,9 @@
 import { findRangesOfStrings, getClosingBracket, getPhraseFromPosition, matchAllOutsideRanges, splitArgumentsString } from "@utils/parse"
-import { completionsMap, currentItem, modal, subroutinesMap, workshopConstants } from "@stores/editor"
+import { completionsMap, modal, subroutinesMap, workshopConstants } from "@stores/editor"
 import { get } from "svelte/store"
 import { getFirstParameterObject } from "@utils/compiler/parameterObjects"
 import type { EditorView } from "codemirror"
-import type { Diagnostic } from "@codemirror/lint"
+import { forceLinting, type Diagnostic } from "@codemirror/lint"
 import type { Severity, TranslationKey } from "@src/types/editor"
 import type { Line } from "@codemirror/state"
 import { defaultLanguage, translationKeys } from "@src/stores/translationKeys"
@@ -337,7 +337,7 @@ function checkTranslations(content: string): void {
         message: "Unknown translate key.",
         actions: [{
           name: "Create translation key",
-          apply() {
+          apply(view) {
             const newTranslation: TranslationKey = {}
             const currentDefaultLanguage = get(defaultLanguage)
 
@@ -356,11 +356,7 @@ function checkTranslations(content: string): void {
               }
             })
 
-            // Run linter again
-            currentItem.update((currentItem) => currentItem && ({
-              ... currentItem,
-              forceUpdate: true
-            }))
+            forceLinting(view)
           }
         }]
       })

--- a/patches/@codemirror+lint+6.8.1.patch
+++ b/patches/@codemirror+lint+6.8.1.patch
@@ -1,0 +1,37 @@
+# Make forceLinting() actually force linting, even if within the period of
+# delay after linting (determined by `LintPlugin#set`)
+
+diff --git a/node_modules/@codemirror/lint/dist/index.cjs b/node_modules/@codemirror/lint/dist/index.cjs
+index 5af7008..d3dc0bc 100644
+--- a/node_modules/@codemirror/lint/dist/index.cjs
++++ b/node_modules/@codemirror/lint/dist/index.cjs
+@@ -255,10 +255,8 @@ const lintPlugin = view.ViewPlugin.fromClass(class {
+         }
+     }
+     force() {
+-        if (this.set) {
+-            this.lintTime = Date.now();
+-            this.run();
+-        }
++        this.lintTime = Date.now();
++        this.run();
+     }
+     destroy() {
+         clearTimeout(this.timeout);
+diff --git a/node_modules/@codemirror/lint/dist/index.js b/node_modules/@codemirror/lint/dist/index.js
+index 0321ca4..34992a5 100644
+--- a/node_modules/@codemirror/lint/dist/index.js
++++ b/node_modules/@codemirror/lint/dist/index.js
+@@ -253,10 +253,8 @@ const lintPlugin = /*@__PURE__*/ViewPlugin.fromClass(class {
+         }
+     }
+     force() {
+-        if (this.set) {
+-            this.lintTime = Date.now();
+-            this.run();
+-        }
++        this.lintTime = Date.now();
++        this.run();
+     }
+     destroy() {
+         clearTimeout(this.timeout);


### PR DESCRIPTION
`@codemirror/lint` has a (bug?)/annoying behavior where `forceLinting()` would do nothing if it is run ([by default](https://github.com/codemirror/lint/blame/2ffcff1ed78c13faedbe40e7845cc384c3ddd26e/src/lint.ts#L363)) within 750ms of linting being done (and also within 750ms of running diagnostic action too, it seems).

This made me consider setting `$currentItem.forceUpdate` to force a full update on the editor.
I thought it was overkill, but it fixed my issue.

Turns out calling setting `forceUpdate` is now causing other issues, like the editor's content going back to its initial text.

This PR switches that for the original plan of using `forceLinting()`, while also patching the issue there (thanks for having patch-package!)