### PR TITLE
fix(editor): Remove comments before extracting variables

### DIFF
--- a/app/javascript/src/utils/compiler/variables.ts
+++ b/app/javascript/src/utils/compiler/variables.ts
@@ -1,7 +1,7 @@
 import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "@utils/parse"
 import { evaluateParameterObjects } from "@utils/compiler/parameterObjects"
+import { removeComments } from "@utils/compiler/comments"
 import type { Range, Variables } from "@src/types/editor"
-import { removeComments } from "./comments"
 
 // NOTE: The fact variable names can start with a decimal is intentional.
 // We leave it to Overwatch to warn the user that this is not allowed.

--- a/app/javascript/src/utils/compiler/variables.ts
+++ b/app/javascript/src/utils/compiler/variables.ts
@@ -1,6 +1,7 @@
 import { findRangesOfStrings, getClosingBracket, matchAllOutsideRanges, splitArgumentsString } from "@utils/parse"
 import { evaluateParameterObjects } from "@utils/compiler/parameterObjects"
 import type { Range, Variables } from "@src/types/editor"
+import { removeComments } from "./comments"
 
 // NOTE: The fact variable names can start with a decimal is intentional.
 // We leave it to Overwatch to warn the user that this is not allowed.
@@ -137,7 +138,9 @@ function getLiteralPlayerVariables(source: string, stringRanges: Range[]): strin
 }
 
 export function getVariables(joinedItems: string): Variables {
+  joinedItems = removeComments(joinedItems)
   joinedItems = evaluateParameterObjects(joinedItems)
+
   const stringRanges = findRangesOfStrings(joinedItems)
 
   const playerVariablesFromActions = []

--- a/app/javascript/test/utils/compiler/variables.test.js
+++ b/app/javascript/test/utils/compiler/variables.test.js
@@ -326,6 +326,20 @@ describe("variables.js", () => {
 
       expect(getVariables(input)).toEqual(expectedOutput)
     })
+
+    it("Should ignore variables in comments", () => {
+      const input = `
+        // Global.someVariable
+        // somePlayer.somePlayerVariable
+        /* Event Player.someOtherPlayerVariable */
+      `
+      const expectedOutput = {
+        globalVariables: [],
+        playerVariables: []
+      }
+
+      expect(getVariables(input)).toEqual(expectedOutput)
+    })
   })
 
   describe("compileVariables", () => {


### PR DESCRIPTION
Variables would still be evaluated from comments. This commit fixes that by removing comments before extracting variables.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/d84648e1-8245-4544-ac9b-154477c9a44c) | ![image](https://github.com/user-attachments/assets/c8a3518c-2707-4794-ab80-b0e7551e2bb7)
