### PR TITLE
fix(editor compiler): do not try to parse operators in expressions wrapped in "/"s

### DIFF
--- a/app/javascript/src/utils/compiler/conditionals.ts
+++ b/app/javascript/src/utils/compiler/conditionals.ts
@@ -112,7 +112,7 @@ export function evaluateExpressionTree(node: ExpressionTree): boolean | string |
 }
 
 export function getExpressionTree(expression: string): ExpressionTree {
-  expression = removeSurroundingParenthesis(expression)
+  expression = removeSurroundingParenthesis(expression).trim()
 
   const result: ExpressionTree = {
     value: null,
@@ -122,6 +122,12 @@ export function getExpressionTree(expression: string): ExpressionTree {
   }
 
   if (expression.length === 0) return result
+
+  if (expression.at(0) === "/" && expression.at(-1) === "/") {
+    // Regular Expression
+    result.value = expression
+    return result
+  }
 
   for (let currentIndex = 0; currentIndex < expression.length; currentIndex++) {
     const char = expression[currentIndex]


### PR DESCRIPTION
Fixes an issue where in an @if condition, using a match operator with the righthand-side being a RegExp with an exclamation mark ("!"), the exclamation mark would be considered as an extra operator and cause issues in the evaluation.